### PR TITLE
Fix read_line to properly clear old characters

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -14,7 +14,9 @@ for the time being.**
 
 **STILL UNDER DEVELOPMENT; NOT RELEASED YET.**
 
-*   No changes recorded.
+*   Issue #148: Fixed interactive line edits so that moving up and down through
+    history doesn't leave old characters behind when the cursor is in the middle
+    of a line (not at the end).
 
 ## Changes in version 0.8.0
 


### PR DESCRIPTION
The old logic to clear the previous line assumed that the cursor was at the
end of the line that had to be cleared, which means we left characters behind
when the cursor was not at the end.  Fix that now and add a test.

Fixes #148.