### PR TITLE
Proper handling of UTF-8

### DIFF
--- a/sdl/src/console.rs
+++ b/sdl/src/console.rs
@@ -664,13 +664,13 @@ impl SdlConsole {
         Ok(())
     }
 
-    /// Renders the given `bytes` of text at the `start` position.
+    /// Renders the given text at the `start` position.
     ///
     /// Does not handle overflow nor scrolling, and also does not present the canvas.
-    fn raw_write(&mut self, bytes: &str, start: PixelsXY) -> io::Result<()> {
-        debug_assert!(!bytes.is_empty(), "SDL does not like empty strings");
+    fn raw_write(&mut self, text: &str, start: PixelsXY) -> io::Result<()> {
+        debug_assert!(!text.is_empty(), "SDL does not like empty strings");
 
-        let len = match u16::try_from(bytes.chars().count()) {
+        let len = match u16::try_from(text.chars().count()) {
             Ok(v) => v,
             Err(_) => return Err(io::Error::new(io::ErrorKind::InvalidInput, "String too long")),
         };
@@ -678,7 +678,7 @@ impl SdlConsole {
         let surface = self
             .font
             .font
-            .render(bytes)
+            .render(text)
             .shaded(self.fg_color, self.bg_color)
             .map_err(font_error_to_io_error)?;
         let texture = self

--- a/std/src/console/line_buffer.rs
+++ b/std/src/console/line_buffer.rs
@@ -1,0 +1,96 @@
+//! Handle string manipulation like inserting a char at a specified char position.
+//!
+//! This exists because Rust String is indexed by bytes and manipulating string bytes is
+//! complicated!
+//!
+//! The current implementation of the line buffer is using String::chars && String::char_indices.
+//!
+//! TODO: use graphemes instead.
+
+use std::{fmt::Display, str::Chars};
+
+#[derive(Default, Debug)]
+pub struct LineBuffer {
+    line: String,
+}
+
+impl LineBuffer {
+    pub fn new() -> Self {
+        Default::default()
+    }
+
+    pub fn with_capacity(capacity: usize) -> Self {
+        Self { line: String::with_capacity(capacity) }
+    }
+
+    pub fn len(&self) -> usize {
+        self.line.chars().count()
+    }
+
+    pub fn chars(&self) -> Chars {
+        self.line.chars()
+    }
+
+    /// return the end of the string starting at the given position ; an empty string is
+    /// returned if start_pos > self.len()
+    pub fn end(&self, start_pos: usize) -> String {
+        self.chars().skip(start_pos).collect()
+    }
+
+    /// Return the characters from the start if the string to the given position, excluding the position
+    ///
+    /// Calling it with 0 will return an empty string, 1, will return a 1-char String (is the string
+    /// contains at least 1 char)
+    pub fn start(&self, end_pos: usize) -> String {
+        self.chars().take(end_pos).collect()
+    }
+
+    pub fn range(&self, start_pos: usize, end_pos: usize) -> String {
+        let count = if start_pos > end_pos { 0 } else { end_pos - start_pos };
+        self.chars().skip(start_pos).take(count).collect()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.line.is_empty()
+    }
+
+    pub fn as_bytes(&self) -> &[u8] {
+        self.line.as_bytes()
+    }
+
+    pub fn remove(&mut self, pos: usize) {
+        self.line = self.line.chars().take(pos).chain(self.line.chars().skip(pos + 1)).collect();
+    }
+
+    pub fn insert(&mut self, pos: usize, ch: char) {
+        self.line = self
+            .line
+            .chars()
+            .take(pos)
+            .chain(std::iter::once(ch))
+            .chain(self.line.chars().skip(pos))
+            .collect();
+    }
+
+    pub fn into_inner(self) -> String {
+        self.line
+    }
+}
+
+impl From<&str> for LineBuffer {
+    fn from(s: &str) -> Self {
+        Self { line: String::from(s) }
+    }
+}
+
+impl From<&String> for LineBuffer {
+    fn from(s: &String) -> Self {
+        Self::from(s.as_str())
+    }
+}
+
+impl Display for LineBuffer {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.line.fmt(f)
+    }
+}

--- a/std/src/console/mod.rs
+++ b/std/src/console/mod.rs
@@ -36,6 +36,7 @@ pub use readline::read_line;
 pub(crate) use readline::read_line_secure;
 mod trivial;
 pub use trivial::TrivialConsole;
+pub mod line_buffer;
 
 /// Decoded key presses as returned by the console.
 #[derive(Clone, Debug, PartialEq)]

--- a/std/src/console/mod.rs
+++ b/std/src/console/mod.rs
@@ -202,10 +202,9 @@ pub trait Console {
     /// The returned position represents the first row and column that lay *outside* of the console.
     fn size(&self) -> io::Result<CharsXY>;
 
-    /// Writes the raw `bytes` into the console.
+    /// Writes the text into the console at the position of the cursor.
     ///
-    /// The input `bytes` are not supposed to contain any control characters, such as CR or LF.
-    fn write(&mut self, bytes: &[u8]) -> io::Result<()>;
+    fn write(&mut self, text: &str) -> io::Result<()>;
 
     /// Draws a line from `_x1y1` to `_x2y2` using the current drawing color.
     fn draw_line(&mut self, _x1y1: PixelsXY, _x2y2: PixelsXY) -> io::Result<()> {

--- a/std/src/console/readline.rs
+++ b/std/src/console/readline.rs
@@ -545,6 +545,63 @@ mod tests {
     }
 
     #[test]
+    fn test_read_line_interactive_utf8() {
+        // most basic
+        ReadLineInteractiveTest::default()
+            .add_key_chars("é")
+            .add_output(CapturedOut::Write("é".as_bytes().to_vec()))
+            .set_line("é")
+            .accept();
+        // remove single 2-bytes char
+        ReadLineInteractiveTest::default()
+            .add_key_chars("é")
+            .add_output(CapturedOut::Write("é".as_bytes().to_vec()))
+            .add_key(Key::Backspace)
+            .add_output(CapturedOut::HideCursor)
+            .add_output(CapturedOut::MoveWithinLine(-1))
+            .add_output_bytes(b" ")
+            .add_output(CapturedOut::MoveWithinLine(-1))
+            .add_output(CapturedOut::ShowCursor)
+            .set_line("")
+            .accept();
+        // 2 2-bytes char, remove the last
+        ReadLineInteractiveTest::default()
+            .add_key_chars("àé")
+            .add_output(CapturedOut::Write("à".as_bytes().to_vec()))
+            .add_output(CapturedOut::Write("é".as_bytes().to_vec()))
+            .add_key(Key::Backspace)
+            .add_output(CapturedOut::HideCursor)
+            .add_output(CapturedOut::MoveWithinLine(-1))
+            .add_output_bytes(b" ")
+            .add_output(CapturedOut::MoveWithinLine(-1))
+            .add_output(CapturedOut::ShowCursor)
+            .set_line("à")
+            .accept();
+
+        // "à" "é" left left left right backspace (correct 2-bytes chars jumps and string manipulation)
+        ReadLineInteractiveTest::default()
+            .add_key_chars("àé")
+            .add_output(CapturedOut::Write("à".as_bytes().to_vec()))
+            .add_output(CapturedOut::Write("é".as_bytes().to_vec()))
+            .add_key(Key::ArrowLeft)
+            .add_output(CapturedOut::MoveWithinLine(-1))
+            .add_key(Key::ArrowLeft)
+            .add_output(CapturedOut::MoveWithinLine(-1))
+            .add_key(Key::ArrowLeft) // this one does nothing we are already at the bebinning
+            .add_key(Key::ArrowRight)
+            .add_output(CapturedOut::MoveWithinLine(1))
+            .add_key(Key::Backspace)
+            .add_output(CapturedOut::HideCursor)
+            .add_output(CapturedOut::MoveWithinLine(-1))
+            .add_output(CapturedOut::Write("é".as_bytes().to_vec()))
+            .add_output_bytes(b" ")
+            .add_output(CapturedOut::MoveWithinLine(-2))
+            .add_output(CapturedOut::ShowCursor)
+            .set_line("é")
+            .accept();
+    }
+
+    #[test]
     fn test_read_line_interactive_trailing_backspace() {
         ReadLineInteractiveTest::default()
             .add_key_chars("bar")

--- a/std/src/console/readline.rs
+++ b/std/src/console/readline.rs
@@ -18,6 +18,8 @@
 use crate::console::{Console, Key};
 use std::io;
 
+use super::line_buffer::LineBuffer;
+
 /// Character to print when typing a secure string.
 const SECURE_CHAR: u8 = b'*';
 
@@ -28,7 +30,7 @@ fn update_line(
     console: &mut dyn Console,
     pos: usize,
     clear_len: usize,
-    line: &str,
+    line: &LineBuffer,
 ) -> io::Result<()> {
     console.hide_cursor()?;
     if pos > 0 {
@@ -37,7 +39,7 @@ fn update_line(
     if !line.is_empty() {
         console.write(line.as_bytes())?;
     }
-    let line_len = line.char_indices().count();
+    let line_len = line.len();
     if line_len < clear_len {
         let diff = clear_len - line_len;
         console.write(&vec![b' '; diff])?;
@@ -56,7 +58,7 @@ async fn read_line_interactive(
     mut history: Option<&mut Vec<String>>,
     echo: bool,
 ) -> io::Result<String> {
-    let mut line = String::from(previous);
+    let mut line = LineBuffer::from(previous);
     if !prompt.is_empty() || !line.is_empty() {
         if echo {
             console.write(format!("{}{}", prompt, line).as_bytes())?;
@@ -75,12 +77,12 @@ async fn read_line_interactive(
 
     // Insertion position *within* the line, without accounting for the prompt.
     // TODO handle UTF-8 graphemes.
-    let mut pos = line.char_indices().count();
+    let mut pos = line.len();
 
     let mut history_pos;
     match history.as_mut() {
         Some(history) => {
-            history.push(line.clone());
+            history.push(line.to_string());
             history_pos = history.len() - 1;
         }
         None => history_pos = 0,
@@ -94,15 +96,15 @@ async fn read_line_interactive(
                         continue;
                     }
 
-                    let clear_len = line.char_indices().count();
+                    let clear_len = line.len();
 
-                    history[history_pos] = line;
+                    history[history_pos] = line.into_inner();
                     history_pos -= 1;
-                    line = history[history_pos].clone();
+                    line = LineBuffer::from(&history[history_pos]);
 
                     update_line(console, pos, clear_len, &line)?;
 
-                    pos = line.char_indices().count();
+                    pos = line.len();
                 }
             }
 
@@ -112,15 +114,15 @@ async fn read_line_interactive(
                         continue;
                     }
 
-                    let clear_len = line.char_indices().count();
+                    let clear_len = line.len();
 
-                    history[history_pos] = line;
+                    history[history_pos] = line.to_string();
                     history_pos += 1;
-                    line = history[history_pos].clone();
+                    line = LineBuffer::from(&history[history_pos]);
 
                     update_line(console, pos, clear_len, &line)?;
 
-                    pos = line.char_indices().count();
+                    pos = line.len();
                 }
             }
 
@@ -132,7 +134,7 @@ async fn read_line_interactive(
             }
 
             Key::ArrowRight => {
-                if pos < line.char_indices().count() {
+                if pos < line.len() {
                     console.move_within_line(1)?;
                     pos += 1;
                 }
@@ -140,22 +142,17 @@ async fn read_line_interactive(
 
             Key::Backspace => {
                 if pos > 0 {
-                    let char_indices = line.char_indices().collect::<Vec<_>>();
                     console.hide_cursor()?;
                     console.move_within_line(-1)?;
                     if echo {
-                        if pos < char_indices.len() {
-                            console.write(line[(char_indices[pos].0)..].as_bytes())?;
-                        } else {
-                            // we are at the end of the line, so there is nothing to write
-                        }
+                        console.write(line.end(pos).as_bytes())?;
                     } else {
-                        console.write(&vec![SECURE_CHAR; char_indices.len() - pos])?;
+                        console.write(&vec![SECURE_CHAR; line.len() - pos])?;
                     }
                     console.write(&[b' '])?;
-                    console.move_within_line(-((char_indices.len() - pos) as i16 + 1))?;
+                    console.move_within_line(-((line.len() - pos) as i16 + 1))?;
                     console.show_cursor()?;
-                    line.remove(char_indices[pos - 1].0);
+                    line.remove(pos - 1);
                     pos -= 1;
                 }
             }
@@ -172,26 +169,26 @@ async fn read_line_interactive(
             }
 
             Key::Char(ch) => {
-                let char_indices = line.char_indices().collect::<Vec<_>>();
-                debug_assert!(char_indices.len() < width);
-                if char_indices.len() == width - 1 {
+                let line_len = line.len();
+                debug_assert!(line_len < width);
+                if line_len == width - 1 {
                     // TODO(jmmv): Implement support for lines that exceed the width of the input
                     // field (the width of the screen).
                     continue;
                 }
 
-                if pos < char_indices.len() {
+                if pos < line_len {
                     console.hide_cursor()?;
                     if echo {
                         let mut buf = [0u8; 4];
                         console.write(ch.encode_utf8(&mut buf).as_bytes())?;
-                        console.write(line[(char_indices[pos].0)..].as_bytes())?;
+                        console.write(line.end(pos).as_bytes())?;
                     } else {
-                        console.write(&vec![SECURE_CHAR; char_indices.len() - pos + 1])?;
+                        console.write(&vec![SECURE_CHAR; line_len - pos + 1])?;
                     }
-                    console.move_within_line(-((char_indices.len() - pos) as i16))?;
+                    console.move_within_line(-((line_len - pos) as i16))?;
                     console.show_cursor()?;
-                    line.insert(char_indices[pos].0, ch);
+                    line.insert(pos, ch);
                 } else {
                     if echo {
                         let mut buf = [0u8; 4];
@@ -199,13 +196,13 @@ async fn read_line_interactive(
                     } else {
                         console.write(&[SECURE_CHAR])?;
                     }
-                    line.insert(line.len(), ch);
+                    line.insert(line_len, ch);
                 }
                 pos += 1;
             }
 
             Key::End => {
-                let offset = line.char_indices().count() - pos;
+                let offset = line.len() - pos;
                 if offset > 0 {
                     console.move_within_line(offset as i16)?;
                     pos += offset;
@@ -250,10 +247,10 @@ async fn read_line_interactive(
             history.pop();
         } else {
             let last = history.len() - 1;
-            history[last] = line.clone();
+            history[last] = line.to_string();
         }
     }
-    Ok(line)
+    Ok(line.into_inner())
 }
 
 /// Reads a line of text interactively from the console, which is not expected to be a TTY.
@@ -559,6 +556,7 @@ mod tests {
             .add_key(Key::Backspace)
             .add_output(CapturedOut::HideCursor)
             .add_output(CapturedOut::MoveWithinLine(-1))
+            .add_output_bytes(b"")
             .add_output_bytes(b" ")
             .add_output(CapturedOut::MoveWithinLine(-1))
             .add_output(CapturedOut::ShowCursor)
@@ -572,6 +570,7 @@ mod tests {
             .add_key(Key::Backspace)
             .add_output(CapturedOut::HideCursor)
             .add_output(CapturedOut::MoveWithinLine(-1))
+            .add_output_bytes(b"")
             .add_output_bytes(b" ")
             .add_output(CapturedOut::MoveWithinLine(-1))
             .add_output(CapturedOut::ShowCursor)

--- a/std/src/console/readline.rs
+++ b/std/src/console/readline.rs
@@ -37,8 +37,9 @@ fn update_line(
     if !line.is_empty() {
         console.write(line.as_bytes())?;
     }
-    if line.len() < clear_len {
-        let diff = clear_len - line.len();
+    let line_len = line.char_indices().count();
+    if line_len < clear_len {
+        let diff = clear_len - line_len;
         console.write(&vec![b' '; diff])?;
         console.move_within_line(-(diff as i16))?;
     }
@@ -73,7 +74,8 @@ async fn read_line_interactive(
     };
 
     // Insertion position *within* the line, without accounting for the prompt.
-    let mut pos = line.len();
+    // TODO handle UTF-8 graphemes.
+    let mut pos = line.char_indices().count();
 
     let mut history_pos;
     match history.as_mut() {
@@ -92,7 +94,7 @@ async fn read_line_interactive(
                         continue;
                     }
 
-                    let clear_len = line.len();
+                    let clear_len = line.char_indices().count();
 
                     history[history_pos] = line;
                     history_pos -= 1;
@@ -100,7 +102,7 @@ async fn read_line_interactive(
 
                     update_line(console, pos, clear_len, &line)?;
 
-                    pos = line.len();
+                    pos = line.char_indices().count();
                 }
             }
 
@@ -110,7 +112,7 @@ async fn read_line_interactive(
                         continue;
                     }
 
-                    let clear_len = line.len();
+                    let clear_len = line.char_indices().count();
 
                     history[history_pos] = line;
                     history_pos += 1;
@@ -118,7 +120,7 @@ async fn read_line_interactive(
 
                     update_line(console, pos, clear_len, &line)?;
 
-                    pos = line.len();
+                    pos = line.char_indices().count();
                 }
             }
 
@@ -130,7 +132,7 @@ async fn read_line_interactive(
             }
 
             Key::ArrowRight => {
-                if pos < line.len() {
+                if pos < line.char_indices().count() {
                     console.move_within_line(1)?;
                     pos += 1;
                 }
@@ -138,17 +140,22 @@ async fn read_line_interactive(
 
             Key::Backspace => {
                 if pos > 0 {
+                    let char_indices = line.char_indices().collect::<Vec<_>>();
                     console.hide_cursor()?;
                     console.move_within_line(-1)?;
                     if echo {
-                        console.write(line[pos..].as_bytes())?;
+                        if pos < char_indices.len() {
+                            console.write(line[(char_indices[pos].0)..].as_bytes())?;
+                        } else {
+                            // we are at the end of the line, so there is nothing to write
+                        }
                     } else {
-                        console.write(&vec![SECURE_CHAR; line.len() - pos])?;
+                        console.write(&vec![SECURE_CHAR; char_indices.len() - pos])?;
                     }
                     console.write(&[b' '])?;
-                    console.move_within_line(-((line.len() - pos) as i16 + 1))?;
+                    console.move_within_line(-((char_indices.len() - pos) as i16 + 1))?;
                     console.show_cursor()?;
-                    line.remove(pos - 1);
+                    line.remove(char_indices[pos - 1].0);
                     pos -= 1;
                 }
             }
@@ -165,36 +172,40 @@ async fn read_line_interactive(
             }
 
             Key::Char(ch) => {
-                debug_assert!(line.len() < width);
-                if line.len() == width - 1 {
+                let char_indices = line.char_indices().collect::<Vec<_>>();
+                debug_assert!(char_indices.len() < width);
+                if char_indices.len() == width - 1 {
                     // TODO(jmmv): Implement support for lines that exceed the width of the input
                     // field (the width of the screen).
                     continue;
                 }
 
-                if pos < line.len() {
+                if pos < char_indices.len() {
                     console.hide_cursor()?;
                     if echo {
-                        console.write(&[ch as u8])?;
-                        console.write(line[pos..].as_bytes())?;
+                        let mut buf = [0u8; 4];
+                        console.write(ch.encode_utf8(&mut buf).as_bytes())?;
+                        console.write(line[(char_indices[pos].0)..].as_bytes())?;
                     } else {
-                        console.write(&vec![SECURE_CHAR; line.len() - pos + 1])?;
+                        console.write(&vec![SECURE_CHAR; char_indices.len() - pos + 1])?;
                     }
-                    console.move_within_line(-((line.len() - pos) as i16))?;
+                    console.move_within_line(-((char_indices.len() - pos) as i16))?;
                     console.show_cursor()?;
+                    line.insert(char_indices[pos].0, ch);
                 } else {
                     if echo {
-                        console.write(&[ch as u8])?;
+                        let mut buf = [0u8; 4];
+                        console.write(ch.encode_utf8(&mut buf).as_bytes())?;
                     } else {
                         console.write(&[SECURE_CHAR])?;
                     }
+                    line.insert(line.len(), ch);
                 }
-                line.insert(pos, ch);
                 pos += 1;
             }
 
             Key::End => {
-                let offset = line.len() - pos;
+                let offset = line.char_indices().count() - pos;
                 if offset > 0 {
                     console.move_within_line(offset as i16)?;
                     pos += offset;

--- a/std/src/console/trivial.rs
+++ b/std/src/console/trivial.rs
@@ -109,12 +109,12 @@ impl Console for TrivialConsole {
         Ok(CharsXY::new(columns, lines))
     }
 
-    fn write(&mut self, bytes: &[u8]) -> io::Result<()> {
-        debug_assert!(!crate::console::has_control_chars_u8(bytes));
+    fn write(&mut self, text: &str) -> io::Result<()> {
+        debug_assert!(!crate::console::has_control_chars_u8(text.as_bytes()));
 
         let stdout = io::stdout();
         let mut stdout = stdout.lock();
-        stdout.write_all(bytes)?;
+        stdout.write_all(text.as_bytes())?;
         self.maybe_flush(stdout)
     }
 

--- a/std/src/service/cmds.rs
+++ b/std/src/service/cmds.rs
@@ -424,9 +424,10 @@ mod tests {
         assert!(!storage.borrow().mounted().contains_key("CLOUD"));
 
         t.get_console().borrow_mut().set_interactive(true);
-        let mut exp_output = vec![CapturedOut::Write(b"Password: ".to_vec()), CapturedOut::SyncNow];
+        let mut exp_output =
+            vec![CapturedOut::Write("Password: ".to_string()), CapturedOut::SyncNow];
         for _ in 0..MockService::PASSWORD.len() {
-            exp_output.push(CapturedOut::Write(vec![b'*']));
+            exp_output.push(CapturedOut::Write("*".to_string()));
         }
         exp_output.push(CapturedOut::Print("".to_owned()));
 

--- a/std/src/testutils.rs
+++ b/std/src/testutils.rs
@@ -65,7 +65,7 @@ pub enum CapturedOut {
     ShowCursor,
 
     /// Represents a call to `Console::write`.
-    Write(Vec<u8>),
+    Write(String),
 
     /// Represents a call to `Console::draw_line`.
     DrawLine(PixelsXY, PixelsXY),
@@ -228,10 +228,10 @@ impl Console for MockConsole {
         Ok(self.size)
     }
 
-    fn write(&mut self, bytes: &[u8]) -> io::Result<()> {
-        debug_assert!(!console::has_control_chars_u8(bytes));
+    fn write(&mut self, text: &str) -> io::Result<()> {
+        debug_assert!(!console::has_control_chars_u8(text.as_bytes()));
 
-        self.captured_out.push(CapturedOut::Write(bytes.to_owned()));
+        self.captured_out.push(CapturedOut::Write(text.to_owned()));
         Ok(())
     }
 

--- a/terminal/src/lib.rs
+++ b/terminal/src/lib.rs
@@ -326,12 +326,12 @@ impl Console for TerminalConsole {
         Ok(size)
     }
 
-    fn write(&mut self, bytes: &[u8]) -> io::Result<()> {
-        debug_assert!(!endbasic_std::console::has_control_chars_u8(bytes));
+    fn write(&mut self, text: &str) -> io::Result<()> {
+        debug_assert!(!endbasic_std::console::has_control_chars_u8(text.as_bytes()));
 
         let stdout = io::stdout();
         let mut stdout = stdout.lock();
-        stdout.write_all(bytes)?;
+        stdout.write_all(text.as_bytes())?;
         self.maybe_flush(stdout)
     }
 

--- a/web/src/canvas.rs
+++ b/web/src/canvas.rs
@@ -23,6 +23,7 @@
 use crate::input::WebInput;
 use crate::log_and_panic;
 use async_trait::async_trait;
+use endbasic_std::console::line_buffer::LineBuffer;
 use endbasic_std::console::{ansi_color_to_rgb, CharsXY, ClearType, Console, Key, PixelsXY, RGB};
 use js_sys::Map;
 use std::cmp;
@@ -356,13 +357,13 @@ impl CanvasConsole {
         Ok(())
     }
 
-    /// Renders the given `bytes` of text at the `start` position.
+    /// Renders the given text at the `start` position.
     ///
     /// Does not handle overflow nor scrolling.
-    fn raw_write(&mut self, bytes: &[u8], start: PixelsXY) -> io::Result<()> {
-        debug_assert!(!bytes.is_empty(), "It doesn't make sense to render an empty string");
+    fn raw_write(&mut self, text: &str, start: PixelsXY) -> io::Result<()> {
+        debug_assert!(!text.is_empty(), "It doesn't make sense to render an empty string");
 
-        let len = match u16::try_from(bytes.len()) {
+        let len = match u16::try_from(text.chars().count()) {
             Ok(v) => v,
             Err(_) => return Err(io::Error::new(io::ErrorKind::InvalidInput, "Text too long")),
         };
@@ -387,17 +388,10 @@ impl CanvasConsole {
             Ok(height) => height / 2,
             Err(e) => log_and_panic!("Glyph height is too big: {}", e),
         };
-        for b in bytes {
-            let bs = &[*b];
-            let sb = match std::str::from_utf8(bs) {
-                Ok(s) => s,
-                Err(_) => {
-                    return Err(io::Error::new(
-                        io::ErrorKind::InvalidInput,
-                        "Text contains invalid characters",
-                    ))
-                }
-            };
+        for ch in text.chars() {
+            let mut buf = [0u8; 4];
+            let sb = ch.encode_utf8(&mut buf);
+
             self.context
                 .fill_text(sb, f64::from(x), f64::from(start.y + y_offset))
                 .map_err(js_value_to_io_error)?;
@@ -408,22 +402,29 @@ impl CanvasConsole {
         Ok(())
     }
 
-    /// Renders the given `bytes` of text at the current cursor position, with wrapping and
+    /// Renders the given text at the current cursor position, with wrapping and
     /// scrolling if necessary.
-    fn raw_write_wrapped(&mut self, mut bytes: &[u8]) -> io::Result<()> {
-        debug_assert!(!bytes.is_empty(), "It doesn't make sense to render an empty string");
+    fn raw_write_wrapped(&mut self, mut text: &str) -> io::Result<()> {
+        debug_assert!(!text.is_empty(), "It doesn't make sense to render an empty string");
+
+        let mut line_buffer = LineBuffer::from(text);
 
         loop {
             let fit_chars = self.size_chars.x - self.cursor_pos.x;
-            let partial = &bytes[0..cmp::min(bytes.len(), usize::from(fit_chars))];
-            self.raw_write(partial, self.cursor_pos.clamped_mul(self.glyph_size))?;
-            self.cursor_pos.x += match u16::try_from(partial.len()) {
+
+            let remaining = line_buffer.split_off(usize::from(fit_chars));
+            let len = line_buffer.len();
+            self.raw_write(
+                &line_buffer.into_inner(),
+                self.cursor_pos.clamped_mul(self.glyph_size),
+            )?;
+            self.cursor_pos.x += match u16::try_from(len) {
                 Ok(len) => len,
                 Err(e) => log_and_panic!("Partial length was computed to fit on the screen: {}", e),
             };
 
-            bytes = &bytes[partial.len()..];
-            if bytes.is_empty() {
+            line_buffer = remaining;
+            if line_buffer.is_empty() {
                 break;
             } else {
                 self.open_line()?;
@@ -588,7 +589,7 @@ impl Console for CanvasConsole {
 
         self.clear_cursor()?;
         if !text.is_empty() {
-            self.raw_write_wrapped(text.as_bytes())?;
+            self.raw_write_wrapped(text)?;
         }
         self.open_line()?;
         self.draw_cursor()
@@ -617,15 +618,15 @@ impl Console for CanvasConsole {
         Ok(self.size_chars)
     }
 
-    fn write(&mut self, bytes: &[u8]) -> io::Result<()> {
-        debug_assert!(!endbasic_std::console::has_control_chars_u8(bytes));
+    fn write(&mut self, text: &str) -> io::Result<()> {
+        debug_assert!(!endbasic_std::console::has_control_chars_u8(text.as_bytes()));
 
-        if bytes.is_empty() {
+        if text.is_empty() {
             return Ok(());
         }
 
         self.clear_cursor()?;
-        self.raw_write_wrapped(bytes)?;
+        self.raw_write_wrapped(text)?;
         self.draw_cursor()
     }
 

--- a/web/src/canvas.rs
+++ b/web/src/canvas.rs
@@ -26,7 +26,6 @@ use async_trait::async_trait;
 use endbasic_std::console::line_buffer::LineBuffer;
 use endbasic_std::console::{ansi_color_to_rgb, CharsXY, ClearType, Console, Key, PixelsXY, RGB};
 use js_sys::Map;
-use std::cmp;
 use std::convert::TryFrom;
 use std::io;
 use wasm_bindgen::prelude::*;
@@ -404,7 +403,7 @@ impl CanvasConsole {
 
     /// Renders the given text at the current cursor position, with wrapping and
     /// scrolling if necessary.
-    fn raw_write_wrapped(&mut self, mut text: &str) -> io::Result<()> {
+    fn raw_write_wrapped(&mut self, text: &str) -> io::Result<()> {
         debug_assert!(!text.is_empty(), "It doesn't make sense to render an empty string");
 
         let mut line_buffer = LineBuffer::from(text);


### PR DESCRIPTION
This PR has a bunch of modification in it, in short, it fixes UTF-8 issues #161.

Here a a summary of what has been done: 
- use a dedicated struct to manipulate string (`LineBuffer`) to avoid splitting inside UTF-8 code points
- `Console::write` does not take bytes anymore but a string slice to ensure proper UTF-8 data is sent to the console
- sdl & web implementation of `write_wrapped` do not manipulate bytes anymore but are using `LineBuffer` instead. This  ensures correct line length & line splitting while wrapping
- sdl console rendering use the `render` method instead of the `render_latin1` method to properly render UTF-8 strings.

I did not test the web version as I do not know how to run it ;)

Fix #161 