### PR TITLE
Parameterize the exec URL of the REPL

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -135,7 +135,7 @@ fn finish_interactive_build(
     let mut machine = builder.build()?;
 
     let service = Rc::from(RefCell::from(endbasic_client::CloudService::new(service_url)?));
-    endbasic_client::add_all(&mut machine, service, console, storage);
+    endbasic_client::add_all(&mut machine, service, console, storage, "https://repl.endbasic.dev/");
 
     Ok(machine)
 }

--- a/client/src/testutils.rs
+++ b/client/src/testutils.rs
@@ -234,7 +234,13 @@ impl Default for ClientTester {
         let console = tester.get_console();
         let storage = tester.get_storage();
         let service = Rc::from(RefCell::from(MockService::default()));
-        add_all(tester.get_machine(), service.clone(), console, storage);
+        add_all(
+            tester.get_machine(),
+            service.clone(),
+            console,
+            storage,
+            "https://repl.example.com/",
+        );
         ClientTester { tester, service }
     }
 }

--- a/web/Cargo.toml
+++ b/web/Cargo.toml
@@ -27,6 +27,7 @@ js-sys = "0.3"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 time = { version = "0.2", features = ["serde", "std"] }
+url = "2.2"
 wasm-bindgen = "^0.2.78"
 wasm-bindgen-futures = "0.4"
 
@@ -55,6 +56,7 @@ features = [
     "ImageData",
     "InputEvent",
     "KeyboardEvent",
+    "Location",
     "Storage",
     "TextMetrics",
     "Window",

--- a/web/src/index.js
+++ b/web/src/index.js
@@ -137,6 +137,4 @@ if (isMobile) {
 var sizeInChars = wt.size_description();
 $('#terminal-size').text(sizeInChars);
 
-const params = new URLSearchParams(window.location.search.substring(1));
-const autoRun = params.get("run");
-wt.run_repl_loop(autoRun);
+wt.run_repl_loop();


### PR DESCRIPTION
This modifies the SHARE command so that the exec URL for public scripts
is configurable.  The cli always passes a fixed value, but this allows
the web UI to properly display its own origin.