### PR TITLE
Fix UTF-8 handling in input methods

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -49,7 +49,8 @@ for the time being.**
     `endbasic-std` crate leaner dependencies-wise and facilitates configuring
     the client.
 
-*   Issue #161: Fixed line input in the REPL to properly accept UTF-8.
+*   Issue #161: Fixed input methods (line input in the REPL and the full-screen
+    text editor) to properly accept UTF-8.
 
 *   Issue #163: Fixed backspace handling in the the web and SDL consoles so
     that the previous character is not left behind the cursor.  The problem was

--- a/NEWS.md
+++ b/NEWS.md
@@ -49,6 +49,8 @@ for the time being.**
     `endbasic-std` crate leaner dependencies-wise and facilitates configuring
     the client.
 
+*   Issue #161: Fixed line input in the REPL to properly accept UTF-8.
+
 *   Issue #163: Fixed backspace handling in the the web and SDL consoles so
     that the previous character is not left behind the cursor.  The problem was
     visible in the web UI where the semi-transparent cursor would show the

--- a/client/src/cloud.rs
+++ b/client/src/cloud.rs
@@ -529,6 +529,18 @@ mod tests {
 
     #[test]
     #[ignore = "Requires environment configuration and is expensive"]
+    fn test_get_and_patch_file_utf8() {
+        #[tokio::main]
+        async fn run(context: &mut TestContext) {
+            let (filename, _content) = context.random_file();
+            let content = "안녕하세요";
+            do_get_and_patch_file_test(context, &filename, content.as_bytes()).await;
+        }
+        run(&mut TestContext::new_from_env());
+    }
+
+    #[test]
+    #[ignore = "Requires environment configuration and is expensive"]
     fn test_get_file_not_found() {
         #[tokio::main]
         async fn run(context: &mut TestContext) {

--- a/client/src/cmds.rs
+++ b/client/src/cmds.rs
@@ -658,9 +658,10 @@ mod tests {
         assert!(!storage.borrow().mounted().contains_key("CLOUD"));
 
         t.get_console().borrow_mut().set_interactive(true);
-        let mut exp_output = vec![CapturedOut::Write(b"Password: ".to_vec()), CapturedOut::SyncNow];
+        let mut exp_output =
+            vec![CapturedOut::Write("Password: ".to_string()), CapturedOut::SyncNow];
         for _ in 0.."the-password".len() {
-            exp_output.push(CapturedOut::Write(vec![b'*']));
+            exp_output.push(CapturedOut::Write("*".to_string()));
         }
         exp_output.push(CapturedOut::Print("".to_owned()));
 

--- a/repl/src/editor.rs
+++ b/repl/src/editor.rs
@@ -17,6 +17,7 @@
 
 use crate::console::{CharsXY, ClearType, Console, Key};
 use async_trait::async_trait;
+use endbasic_std::console::LineBuffer;
 use endbasic_std::program::Program;
 use std::cmp;
 use std::convert::TryFrom;
@@ -35,7 +36,7 @@ const INDENT_WIDTH: usize = 4;
 const KEYS_SUMMARY: &str = " ESC Exit ";
 
 /// Returns the indentation of a given string as a new string.
-fn copy_indent(line: &str) -> String {
+fn copy_indent(line: &LineBuffer) -> String {
     let mut indent = String::new();
     for ch in line.chars() {
         if !ch.is_whitespace() {
@@ -48,7 +49,7 @@ fn copy_indent(line: &str) -> String {
 
 /// Finds the first position within the line that is not an indentation character, or returns
 /// the line length if no such character is found.
-fn find_indent_end(line: &str) -> usize {
+fn find_indent_end(line: &LineBuffer) -> usize {
     let mut pos = 0;
     for ch in line.chars() {
         if ch != ' ' {
@@ -56,7 +57,7 @@ fn find_indent_end(line: &str) -> usize {
         }
         pos += 1;
     }
-    debug_assert!(pos <= line.chars().count());
+    debug_assert!(pos <= line.len());
     pos
 }
 
@@ -78,7 +79,7 @@ pub struct Editor {
     name: Option<String>,
 
     /// Owned contents of the file being edited.
-    content: Vec<String>,
+    content: Vec<LineBuffer>,
 
     /// Whether the `content` was modified since it was last retrieved.
     dirty: bool,
@@ -158,16 +159,12 @@ impl Editor {
         let mut printed_rows = 0;
         while row < self.content.len() && printed_rows < console_size.y - 1 {
             let line = &self.content[row];
-            let char_indices = line.char_indices().collect::<Vec<_>>();
-            let line_len = char_indices.len();
+            let line_len = line.len();
             if line_len > self.viewport_pos.col {
-                let last = if line_len <= self.viewport_pos.col + usize::from(console_size.x) {
-                    line.len()
-                } else {
-                    char_indices[self.viewport_pos.col + usize::from(console_size.x)].0
-                };
-                let view = &line[(char_indices[self.viewport_pos.col].0)..last];
-                console.print(view)?;
+                console.print(&line.range(
+                    self.viewport_pos.col,
+                    self.viewport_pos.col + usize::from(console_size.x),
+                ))?;
             } else {
                 console.print("")?;
             }
@@ -187,7 +184,7 @@ impl Editor {
         }
 
         let line = &self.content[self.file_pos.line];
-        self.file_pos.col = cmp::min(self.insert_col, line.chars().count());
+        self.file_pos.col = cmp::min(self.insert_col, line.len());
     }
 
     /// Moves the cursor up by the given number of lines in `nlines` or to the first line if there
@@ -200,7 +197,7 @@ impl Editor {
         }
 
         let line = &self.content[self.file_pos.line];
-        self.file_pos.col = cmp::min(self.insert_col, line.chars().count());
+        self.file_pos.col = cmp::min(self.insert_col, line.len());
     }
 
     /// Internal implementation of the interactive editor, which interacts with the `console`.
@@ -208,7 +205,7 @@ impl Editor {
         let console_size = console.size()?;
 
         if self.content.is_empty() {
-            self.content.push(String::new());
+            self.content.push(LineBuffer::default());
         }
 
         let mut need_refresh = true;
@@ -228,6 +225,7 @@ impl Editor {
                 }
                 need_refresh = true;
             }
+
             if self.file_pos.col < self.viewport_pos.col {
                 self.viewport_pos.col = self.file_pos.col;
                 need_refresh = true;
@@ -329,19 +327,12 @@ impl Editor {
                     let mut buf = [0; 4];
 
                     let line = &mut self.content[self.file_pos.line];
-                    let char_indices = line.char_indices().collect::<Vec<_>>();
-                    if self.file_pos.col < char_indices.len() {
+                    if self.file_pos.col < line.len() {
                         // TODO(jmmv): Refresh only the affected line.
                         need_refresh = true;
                     }
-                    let insert_pos = if self.file_pos.col < char_indices.len() {
-                        // insert at right position in the string
-                        char_indices[self.file_pos.col].0
-                    } else {
-                        // insert at end
-                        line.len()
-                    };
-                    line.insert(insert_pos, ch);
+
+                    line.insert(self.file_pos.col, ch);
                     self.file_pos.col += 1;
                     self.insert_col = self.file_pos.col;
 
@@ -372,10 +363,13 @@ impl Editor {
                     let indent_len = indent.len();
                     if self.file_pos.line < self.content.len() - 1 {
                         let new = self.content[self.file_pos.line].split_off(self.file_pos.col);
-                        self.content.insert(self.file_pos.line + 1, indent + &new);
+                        self.content.insert(
+                            self.file_pos.line + 1,
+                            LineBuffer::from(indent + &new.into_inner()),
+                        );
                         need_refresh = true;
                     } else {
-                        self.content.insert(self.file_pos.line + 1, indent);
+                        self.content.insert(self.file_pos.line + 1, indent.into());
                     }
                     self.file_pos.col = indent_len;
                     self.file_pos.line += 1;
@@ -389,8 +383,7 @@ impl Editor {
 
                 Key::Tab => {
                     let line = &mut self.content[self.file_pos.line];
-                    let char_indices = line.char_indices().collect::<Vec<_>>();
-                    if self.file_pos.col < char_indices.len() {
+                    if self.file_pos.col < line.len() {
                         // TODO(jmmv): Refresh only the affected line.
                         need_refresh = true;
                     }
@@ -400,14 +393,7 @@ impl Editor {
                     for _ in 0..new_text.capacity() {
                         new_text.push(' ');
                     }
-                    let insert_pos = if self.file_pos.col < char_indices.len() {
-                        // insert at right position in the string
-                        char_indices[self.file_pos.col].0
-                    } else {
-                        // insert at end
-                        line.len()
-                    };
-                    line.insert_str(insert_pos, &new_text);
+                    line.insert_str(self.file_pos.col, &new_text);
                     self.file_pos.col = new_pos;
                     self.insert_col = self.file_pos.col;
                     if !need_refresh {
@@ -440,7 +426,7 @@ impl Program for Editor {
 
     fn load(&mut self, name: Option<&str>, text: &str) {
         self.name = name.map(str::to_owned);
-        self.content = text.lines().map(|l| l.to_owned()).collect();
+        self.content = text.lines().map(LineBuffer::from).collect();
         self.dirty = false;
         self.viewport_pos = FilePos::default();
         self.file_pos = FilePos::default();
@@ -457,7 +443,9 @@ impl Program for Editor {
     }
 
     fn text(&self) -> String {
-        self.content.iter().fold(String::new(), |contents, line| contents + line + "\n")
+        self.content
+            .iter()
+            .fold(String::new(), |contents, line| contents + &line.to_string() + "\n")
     }
 }
 

--- a/sdl/src/console.rs
+++ b/sdl/src/console.rs
@@ -16,7 +16,9 @@
 //! Implementation of the EndBASIC console using SDL.
 
 use async_trait::async_trait;
-use endbasic_std::console::{ansi_color_to_rgb, CharsXY, ClearType, Console, Key, PixelsXY};
+use endbasic_std::console::{
+    ansi_color_to_rgb, CharsXY, ClearType, Console, Key, LineBuffer, PixelsXY,
+};
 use once_cell::sync::Lazy;
 use sdl2::event::Event;
 use sdl2::keyboard::{Keycode, Mod};

--- a/sdl/src/console.rs
+++ b/sdl/src/console.rs
@@ -29,7 +29,6 @@ use sdl2::surface::{Surface, SurfaceContext};
 use sdl2::ttf::{Font, FontError, InitError, Sdl2TtfContext};
 use sdl2::video::{Window, WindowBuildError};
 use sdl2::{EventPump, Sdl};
-use std::cmp;
 use std::convert::TryFrom;
 use std::io;
 use std::path::Path;
@@ -666,13 +665,13 @@ impl SdlConsole {
         Ok(())
     }
 
-    /// Renders the given `bytes` of text at the `start` position.
+    /// Renders the given text at the `start` position.
     ///
     /// Does not handle overflow nor scrolling, and also does not present the canvas.
-    fn raw_write(&mut self, bytes: &[u8], start: PixelsXY) -> io::Result<()> {
-        debug_assert!(!bytes.is_empty(), "SDL does not like empty strings");
+    fn raw_write(&mut self, text: &str, start: PixelsXY) -> io::Result<()> {
+        debug_assert!(!text.is_empty(), "SDL does not like empty strings");
 
-        let len = match u16::try_from(bytes.len()) {
+        let len = match u16::try_from(text.chars().count()) {
             Ok(v) => v,
             Err(_) => return Err(io::Error::new(io::ErrorKind::InvalidInput, "String too long")),
         };
@@ -680,7 +679,7 @@ impl SdlConsole {
         let surface = self
             .font
             .font
-            .render_latin1(bytes)
+            .render(text)
             .shaded(self.fg_color, self.bg_color)
             .map_err(font_error_to_io_error)?;
         let texture = self
@@ -699,22 +698,29 @@ impl SdlConsole {
         Ok(())
     }
 
-    /// Renders the given `bytes` of text at the current cursor position, with wrapping and
+    /// Renders the given text at the current cursor position, with wrapping and
     /// scrolling if necessary.
     ///
     /// Does not present the canvas.
-    fn raw_write_wrapped(&mut self, mut bytes: &[u8]) -> io::Result<()> {
-        debug_assert!(!bytes.is_empty(), "SDL does not like empty strings");
+    fn raw_write_wrapped(&mut self, text: &str) -> io::Result<()> {
+        debug_assert!(!text.is_empty(), "SDL does not like empty strings");
+
+        let mut line_buffer = LineBuffer::from(text);
 
         loop {
             let fit_chars = self.size_chars.x - self.cursor_pos.x;
-            let partial = &bytes[0..cmp::min(bytes.len(), usize::from(fit_chars))];
-            self.raw_write(partial, self.cursor_pos.clamped_mul(self.font.glyph_size))?;
-            self.cursor_pos.x += u16::try_from(partial.len())
-                .expect("Partial length was computed to fit on the screen");
 
-            bytes = &bytes[partial.len()..];
-            if bytes.is_empty() {
+            let remaining = line_buffer.split_off(usize::from(fit_chars));
+            let len = line_buffer.len();
+            self.raw_write(
+                &line_buffer.into_inner(),
+                self.cursor_pos.clamped_mul(self.font.glyph_size),
+            )?;
+            self.cursor_pos.x +=
+                u16::try_from(len).expect("Partial length was computed to fit on the screen");
+
+            line_buffer = remaining;
+            if line_buffer.is_empty() {
                 break;
             } else {
                 self.open_line()?;
@@ -902,7 +908,7 @@ impl Console for SdlConsole {
 
         self.clear_cursor()?;
         if !text.is_empty() {
-            self.raw_write_wrapped(text.as_bytes())?;
+            self.raw_write_wrapped(text)?;
         }
         self.open_line()?;
         self.draw_cursor()?;
@@ -949,15 +955,15 @@ impl Console for SdlConsole {
         Ok(self.size_chars)
     }
 
-    fn write(&mut self, bytes: &[u8]) -> io::Result<()> {
-        debug_assert!(!endbasic_std::console::has_control_chars_u8(bytes));
+    fn write(&mut self, text: &str) -> io::Result<()> {
+        debug_assert!(!endbasic_std::console::has_control_chars_u8(text.as_bytes()));
 
-        if bytes.is_empty() {
+        if text.is_empty() {
             return Ok(());
         }
 
         self.clear_cursor()?;
-        self.raw_write_wrapped(bytes)?;
+        self.raw_write_wrapped(text)?;
         self.draw_cursor()?;
         self.present_canvas()
     }
@@ -1297,22 +1303,22 @@ mod tests {
         test.console().clear(ClearType::All).unwrap();
         test.console().print("After clearing the console in blue").unwrap();
 
-        test.console().write(b"A line that will be erased").unwrap();
+        test.console().write("A line that will be erased").unwrap();
         test.console().clear(ClearType::CurrentLine).unwrap();
 
-        test.console().write(b"A line with corrections1.").unwrap();
+        test.console().write("A line with corrections1.").unwrap();
         test.console().clear(ClearType::PreviousChar).unwrap();
         test.console().clear(ClearType::PreviousChar).unwrap();
         test.console().print(&"!".to_owned()).unwrap();
 
-        test.console().write(b"Remove part of this").unwrap();
+        test.console().write("Remove part of this").unwrap();
         test.console().move_within_line(-8).unwrap();
         test.console().clear(ClearType::UntilNewLine).unwrap();
-        test.console().write(b" -- done").unwrap();
+        test.console().write(" -- done").unwrap();
 
         test.console().locate(CharsXY { x: 0, y: 5 }).unwrap();
         test.console().hide_cursor().unwrap();
-        test.console().write(b"Trailing period should be gone.").unwrap();
+        test.console().write("Trailing period should be gone.").unwrap();
         test.console().clear(ClearType::PreviousChar).unwrap();
         test.console().move_within_line(-2).unwrap();
         test.console().show_cursor().unwrap();
@@ -1325,7 +1331,7 @@ mod tests {
     fn test_sdl_console_move_cursor() {
         let mut test = SdlTest::new();
 
-        test.console().write(b"Move cursor over parts of this text").unwrap();
+        test.console().write("Move cursor over parts of this text").unwrap();
         for _ in 0..15 {
             test.console().move_within_line(-1).unwrap();
         }
@@ -1343,7 +1349,7 @@ mod tests {
 
         test.console().hide_cursor().unwrap();
         test.console().hide_cursor().unwrap();
-        test.console().write(b"Cursor hidden").unwrap();
+        test.console().write("Cursor hidden").unwrap();
 
         test.verify("sdl-hide-cursor");
     }
@@ -1535,7 +1541,7 @@ mod tests {
 
         console.color(None, None).unwrap();
         console.locate(CharsXY { x: 4, y: 22 }).unwrap();
-        console.write(b"Done!").unwrap();
+        console.write("Done!").unwrap();
 
         test.verify("sdl-draw");
     }
@@ -1573,13 +1579,16 @@ mod tests {
         let mut test = SdlTest::new();
 
         let len = usize::from(u16::MAX) + 1;
-        let bytes = vec![b'x'; len];
+        let very_long_string = "x".repeat(len);
         // We have to reach into raw_write here because the public write() wraps text and would
         // never trigger this problem (until we expose unwrapped writes at a later stage and forget
         // about this corner case).
         assert_eq!(
             io::ErrorKind::InvalidInput,
-            test.console().raw_write(&bytes, PixelsXY { x: 0, y: 0 }).unwrap_err().kind()
+            test.console()
+                .raw_write(&very_long_string, PixelsXY { x: 0, y: 0 })
+                .unwrap_err()
+                .kind()
         );
 
         test.verify("sdl-empty");

--- a/std/src/console/linebuffer.rs
+++ b/std/src/console/linebuffer.rs
@@ -1,0 +1,255 @@
+// EndBASIC
+// Copyright 2022 Philippe GASSMANN
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not
+// use this file except in compliance with the License.  You may obtain a copy
+// of the License at:
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+// License for the specific language governing permissions and limitations
+// under the License.
+
+//! String buffer used to manipulate strings at the UTF-8 code point level instead of at the byte
+//! level.
+
+use std::fmt::Display;
+use std::iter;
+use std::str::Chars;
+
+#[derive(Default, Debug)]
+/// Abstraction over a string to handle manipulation operations at char boundaries.
+///
+/// This exists because Rust strings are indexed by bytes and manipulating string bytes is
+/// complicated.
+///
+/// TODO(zenria): The current implementation of the buffer is using `String::chars`.  Should be
+/// converted to using graphemes instead.
+pub struct LineBuffer {
+    line: String,
+}
+
+impl LineBuffer {
+    /// Creates an empty `LineBuffer` with an allocated `capacity`.
+    pub fn with_capacity(capacity: usize) -> Self {
+        Self { line: String::with_capacity(capacity) }
+    }
+
+    /// Returns the logical `LineBuffer` length (in UTF-8 code point count and not in bytes).
+    pub fn len(&self) -> usize {
+        self.line.chars().count()
+    }
+
+    /// Gets and iterator over buffer chars.
+    pub fn chars(&self) -> Chars {
+        self.line.chars()
+    }
+
+    /// Returns the end of the string starting at `start_pos`, or an empty string if `start_pos` is
+    /// after the string's end.
+    pub fn end(&self, start_pos: usize) -> String {
+        self.chars().skip(start_pos).collect()
+    }
+
+    /// Returns the characters from the start of the string to `end_pos`, excluding `end_pos`.
+    ///
+    /// Calling this with `end_pos` set to 0 will return an empty string, and a 1-char string if
+    /// `end_pos` is 1 (if the string contains at least 1 character).
+    pub fn start(&self, end_pos: usize) -> String {
+        self.chars().take(end_pos).collect()
+    }
+
+    /// Extracts a range of characters from this buffer.
+    pub fn range(&self, start_pos: usize, end_pos: usize) -> String {
+        let count = if start_pos > end_pos { 0 } else { end_pos - start_pos };
+        self.chars().skip(start_pos).take(count).collect()
+    }
+
+    /// Checks if this buffer is empty or not.
+    pub fn is_empty(&self) -> bool {
+        self.line.is_empty()
+    }
+
+    /// Gets a view on the underlying bytes held by this buffer.
+    ///
+    /// Warning: direct bytes manipulation may lead to undefined behavior.
+    pub fn as_bytes(&self) -> &[u8] {
+        self.line.as_bytes()
+    }
+
+    /// Removes a character from this buffer.
+    ///
+    /// If the given position if greater than the length of the buffer, this function does nothing.
+    pub fn remove(&mut self, pos: usize) {
+        self.line = self.line.chars().take(pos).chain(self.line.chars().skip(pos + 1)).collect();
+    }
+
+    /// Inserts a char at the given position.
+    ///
+    /// If the position is greater than the buffer length, the character will be appended at the
+    /// end ot it.
+    pub fn insert(&mut self, pos: usize, ch: char) {
+        self.line = self
+            .line
+            .chars()
+            .take(pos)
+            .chain(iter::once(ch))
+            .chain(self.line.chars().skip(pos))
+            .collect();
+    }
+
+    /// Returns the underlying string.
+    pub fn into_inner(self) -> String {
+        self.line
+    }
+
+    /// Inserts the given string `s` into the buffer at `pos`.
+    ///
+    /// If `pos` is greater than the length of the buffer, `s` will be appended at the end of it.
+    pub fn insert_str(&mut self, pos: usize, s: &str) {
+        self.line = self
+            .line
+            .chars()
+            .take(pos)
+            .chain(s.chars())
+            .chain(self.line.chars().skip(pos))
+            .collect();
+    }
+
+    /// Appends the given string `s` to the buffer.
+    pub fn push_str(&mut self, s: &LineBuffer) {
+        self.line.push_str(&s.line);
+    }
+
+    /// Splits the buffer in two parts at the position `at`.
+    ///
+    /// Returns the remaining part of the buffer (same behavior as `String::split_off`).
+    pub fn split_off(&mut self, at: usize) -> LineBuffer {
+        let ret = LineBuffer::from(self.line.chars().skip(at).collect::<String>());
+        self.line = self.line.chars().take(at).collect();
+        ret
+    }
+}
+
+impl From<&str> for LineBuffer {
+    fn from(s: &str) -> Self {
+        Self { line: String::from(s) }
+    }
+}
+
+impl From<&String> for LineBuffer {
+    fn from(s: &String) -> Self {
+        Self::from(s.as_str())
+    }
+}
+impl From<String> for LineBuffer {
+    fn from(line: String) -> Self {
+        Self { line }
+    }
+}
+
+impl Display for LineBuffer {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.line.fmt(f)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::LineBuffer;
+
+    #[test]
+    fn test_end() {
+        let empty = LineBuffer::default();
+        assert_eq!(empty.end(0), "");
+        assert_eq!(empty.end(1), ""); // Should not panic even if the given position is invalid.
+        let hw = LineBuffer::from("Hello, World");
+
+        assert_eq!(hw.end(0), "Hello, World");
+        assert_eq!(hw.end(7), "World");
+        assert_eq!(hw.end(100), "");
+    }
+
+    #[test]
+    fn test_start() {
+        let empty = LineBuffer::default();
+        assert_eq!(empty.start(0), "");
+        assert_eq!(empty.start(1), ""); // Should not panic even if the given position is invalid.
+        let hw = LineBuffer::from("Hello, World");
+
+        assert_eq!(hw.start(0), "");
+        assert_eq!(hw.start(7), "Hello, ");
+        assert_eq!(hw.start(100), "Hello, World");
+    }
+
+    #[test]
+    fn test_insert() {
+        let mut buffer = LineBuffer::default();
+        buffer.insert(0, 'c'); // c
+        buffer.insert(0, 'é'); // éc
+
+        // Insertion must happen after the 2-byte UTF-8 code point and not at byte 1.
+        buffer.insert(1, 'à'); // éàc
+        buffer.insert(100, 'd'); // Should not panic even if the given position is invalid.
+
+        assert_eq!(buffer.into_inner(), "éàcd");
+    }
+
+    #[test]
+    fn test_remove() {
+        let mut empty = LineBuffer::default();
+        empty.remove(0);
+        empty.remove(5);
+        assert_eq!(empty.into_inner(), "");
+
+        let mut hello = LineBuffer::from("Hello");
+        hello.remove(100); // Do nothing.
+        hello.remove(1); // Remove the 'e'
+        assert_eq!(hello.into_inner(), "Hllo");
+    }
+
+    #[test]
+    fn test_insert_str() {
+        let mut buffer = LineBuffer::default();
+        buffer.insert_str(0, "Hello");
+        assert_eq!(buffer.end(0), "Hello");
+        buffer.insert_str(100, "World"); // pos > len will insert at the end.
+        assert_eq!(buffer.end(0), "HelloWorld");
+        buffer.insert_str(5, ", ");
+        assert_eq!(buffer.end(0), "Hello, World");
+    }
+
+    #[test]
+    fn test_range() {
+        let mut buffer = LineBuffer::default();
+
+        assert_eq!(buffer.range(0, 0), "");
+        assert_eq!(buffer.range(0, 10), "");
+        assert_eq!(buffer.range(0, 10), "");
+        assert_eq!(buffer.range(10, 0), ""); // Should not panic even with bad indexes.
+
+        buffer.insert_str(0, "Hello, World");
+        assert_eq!(buffer.range(0, 5), "Hello");
+        assert_eq!(buffer.range(7, 10), "Wor");
+        assert_eq!(buffer.range(7, 100), "World");
+        assert_eq!(buffer.range(10, 0), ""); // Should not panic even with bad indexes.
+    }
+
+    #[test]
+    fn test_is_empty() {
+        assert!(LineBuffer::default().is_empty());
+        assert!(LineBuffer::from("").is_empty());
+        assert!(!LineBuffer::from("This is not empty").is_empty());
+    }
+
+    #[test]
+    fn test_split_off() {
+        let mut buffer = LineBuffer::from("Hello, World");
+        let world = buffer.split_off(7);
+        assert_eq!(buffer.into_inner(), "Hello, ");
+        assert_eq!(world.into_inner(), "World");
+    }
+}

--- a/std/src/console/mod.rs
+++ b/std/src/console/mod.rs
@@ -35,6 +35,8 @@ mod readline;
 pub use readline::{read_line, read_line_secure};
 mod trivial;
 pub use trivial::TrivialConsole;
+mod linebuffer;
+pub use linebuffer::LineBuffer;
 
 /// Decoded key presses as returned by the console.
 #[derive(Clone, Debug, PartialEq)]

--- a/std/src/console/mod.rs
+++ b/std/src/console/mod.rs
@@ -202,10 +202,9 @@ pub trait Console {
     /// The returned position represents the first row and column that lay *outside* of the console.
     fn size(&self) -> io::Result<CharsXY>;
 
-    /// Writes the raw `bytes` into the console.
+    /// Writes the text into the console at the position of the cursor.
     ///
-    /// The input `bytes` are not supposed to contain any control characters, such as CR or LF.
-    fn write(&mut self, bytes: &[u8]) -> io::Result<()>;
+    fn write(&mut self, text: &str) -> io::Result<()>;
 
     /// Draws a line from `_x1y1` to `_x2y2` using the current drawing color.
     fn draw_line(&mut self, _x1y1: PixelsXY, _x2y2: PixelsXY) -> io::Result<()> {

--- a/std/src/console/trivial.rs
+++ b/std/src/console/trivial.rs
@@ -109,12 +109,12 @@ impl Console for TrivialConsole {
         Ok(CharsXY::new(columns, lines))
     }
 
-    fn write(&mut self, bytes: &[u8]) -> io::Result<()> {
-        debug_assert!(!crate::console::has_control_chars_u8(bytes));
+    fn write(&mut self, text: &str) -> io::Result<()> {
+        debug_assert!(!crate::console::has_control_chars_u8(text.as_bytes()));
 
         let stdout = io::stdout();
         let mut stdout = stdout.lock();
-        stdout.write_all(bytes)?;
+        stdout.write_all(text.as_bytes())?;
         self.maybe_flush(stdout)
     }
 

--- a/std/src/testutils.rs
+++ b/std/src/testutils.rs
@@ -62,7 +62,7 @@ pub enum CapturedOut {
     ShowCursor,
 
     /// Represents a call to `Console::write`.
-    Write(Vec<u8>),
+    Write(String),
 
     /// Represents a call to `Console::draw_line`.
     DrawLine(PixelsXY, PixelsXY),
@@ -233,10 +233,10 @@ impl Console for MockConsole {
         Ok(self.size)
     }
 
-    fn write(&mut self, bytes: &[u8]) -> io::Result<()> {
-        debug_assert!(!console::has_control_chars_u8(bytes));
+    fn write(&mut self, text: &str) -> io::Result<()> {
+        debug_assert!(!console::has_control_chars_u8(text.as_bytes()));
 
-        self.captured_out.push(CapturedOut::Write(bytes.to_owned()));
+        self.captured_out.push(CapturedOut::Write(text.to_owned()));
         Ok(())
     }
 
@@ -277,7 +277,7 @@ pub fn flatten_output(captured_out: Vec<CapturedOut>) -> String {
     let mut flattened = String::new();
     for out in captured_out {
         match out {
-            CapturedOut::Write(bs) => flattened.push_str(str::from_utf8(&bs).unwrap()),
+            CapturedOut::Write(bs) => flattened.push_str(&bs),
             CapturedOut::Print(s) => flattened.push_str(&s),
             _ => (),
         }

--- a/terminal/src/lib.rs
+++ b/terminal/src/lib.rs
@@ -326,12 +326,12 @@ impl Console for TerminalConsole {
         Ok(size)
     }
 
-    fn write(&mut self, bytes: &[u8]) -> io::Result<()> {
-        debug_assert!(!endbasic_std::console::has_control_chars_u8(bytes));
+    fn write(&mut self, text: &str) -> io::Result<()> {
+        debug_assert!(!endbasic_std::console::has_control_chars_u8(text.as_bytes()));
 
         let stdout = io::stdout();
         let mut stdout = stdout.lock();
-        stdout.write_all(bytes)?;
+        stdout.write_all(text.as_bytes())?;
         self.maybe_flush(stdout)
     }
 

--- a/web/src/canvas.rs
+++ b/web/src/canvas.rs
@@ -23,7 +23,9 @@
 use crate::input::WebInput;
 use crate::log_and_panic;
 use async_trait::async_trait;
-use endbasic_std::console::{ansi_color_to_rgb, CharsXY, ClearType, Console, Key, PixelsXY, RGB};
+use endbasic_std::console::{
+    ansi_color_to_rgb, CharsXY, ClearType, Console, Key, LineBuffer, PixelsXY, RGB,
+};
 use js_sys::Map;
 use std::cmp;
 use std::convert::TryFrom;


### PR DESCRIPTION
This is a the same as #162 from @zenria after resolving conflicts, reordering and squashing some commits, and ensuring the web interface works. I've tried to keep the original sequence of commits as much as possible. The original PR description reads:

Here is a summary of what has been done:

* Use a dedicated struct to manipulate string (LineBuffer) to avoid splitting inside UTF-8 code points.
* Console::write does not take bytes anymore but a string slice to ensure proper UTF-8 data is sent to the console.
* sdl & web implementation of write_wrapped do not manipulate bytes anymore but are using LineBuffer instead. This ensures correct line length & line splitting while wrapping.
* sdl console rendering use the render method instead of the render_latin1 method to properly render UTF-8 strings.

Fixes #161.