### PR TITLE
Fix insertion of newlines in the editor

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -25,6 +25,8 @@ for the time being.**
     interpreted program to not run at all, as opposed to before where the
     program would make progress until it hit the error.
 
+*   Fixed erratic insertion of newlines in existing text in the editor.
+
 ## Changes in version 0.9.0
 
 **Released on 2022-06-05.**


### PR DESCRIPTION
Attempting to split the last line immediately after insertion did not work correctly due to an off-by-one problem, and inserting a newline at the end of an existing line did not work for similar reasons.  Add tests and then fix the problem.