### PR TITLE
Support AS as an arg separator and use it in MOUNT

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -47,6 +47,10 @@ for the time being.**
 *   Issue #114: Added support for doubles in `FOR` iteration, both to specify
     the loop range and the step.
 
+*   Changed the syntax of the `MOUNT` command to take advantage of the `AS`
+    keyword as an argument separator and thus be of the form
+    `MOUNT target$ AS $drive_name$`.
+
 ## Changes in version 0.9.0
 
 **Released on 2022-06-05.**

--- a/cli/tests/repl/help.out
+++ b/cli/tests/repl/help.out
@@ -553,7 +553,7 @@ Output from HELP LOGOUT:
 
 Output from HELP MOUNT:
 
-    MOUNT [drive_name$, target$]
+    MOUNT [target$ AS drive_name$]
 
     Lists the mounted drives or mounts a new drive.
 

--- a/cli/tests/repl/storage.in
+++ b/cli/tests/repl/storage.in
@@ -24,8 +24,8 @@ DIR
 LOAD "demos:/hello.bas"
 
 ' Replace some default drives with two more.
-MOUNT "A", "memory://"
-MOUNT "B", "memory://"
+MOUNT "memory://" AS "A"
+MOUNT "memory://" AS "B"
 CD "A:/"
 UNMOUNT "DEMOS"
 UNMOUNT "MEMORY"

--- a/client/src/drive.rs
+++ b/client/src/drive.rs
@@ -369,7 +369,7 @@ mod tests {
             }),
         );
         t.run(format!(
-            r#"LOGIN "{}", "{}": MOUNT "x", "cloud://user2": DIR "cloud:/": DIR "x:/""#,
+            r#"LOGIN "{}", "{}": MOUNT "cloud://user2" AS "x": DIR "cloud:/": DIR "x:/""#,
             "mock-username", "mock-password",
         ))
         .expect_access_token("random token")

--- a/core/src/ast.rs
+++ b/core/src/ast.rs
@@ -374,6 +374,9 @@ pub enum ArgSep {
 
     /// Long separator (`,`).
     Long,
+
+    /// `AS` separator.
+    As,
 }
 
 /// Components of an array assignment statement.

--- a/core/src/testutils.rs
+++ b/core/src/testutils.rs
@@ -191,7 +191,7 @@ impl Command for OutCommand {
             match arg.sep {
                 ArgSep::End => break,
                 ArgSep::Short => text += " ",
-                ArgSep::Long => return Err(CallError::SyntaxError),
+                ArgSep::Long | ArgSep::As => return Err(CallError::SyntaxError),
             }
         }
         self.data.borrow_mut().push(text);

--- a/std/src/console/cmds.rs
+++ b/std/src/console/cmds.rs
@@ -449,6 +449,7 @@ impl Command for PrintCommand {
                         text += " ";
                     }
                 }
+                ArgSep::As => return Err(CallError::SyntaxError),
             }
         }
         self.console.borrow_mut().print(&text)?;
@@ -693,6 +694,11 @@ mod tests {
 
     #[test]
     fn test_print_errors() {
+        check_stmt_err("1:1: In call to PRINT: expected [expr1 [<;|,> .. exprN]]", "PRINT 3 AS b");
+        check_stmt_err(
+            "1:1: In call to PRINT: expected [expr1 [<;|,> .. exprN]]",
+            "PRINT 3, 4 AS b",
+        );
         // Ensure type errors from `Expr` and `Value` bubble up.
         check_stmt_err("1:9: Unexpected value in expression", "PRINT a b");
         check_stmt_err("1:9: Cannot add 3 and TRUE", "PRINT 3 + TRUE");


### PR DESCRIPTION
Looking through the QuickBASIC documentation, I found out that the command to rename a file is of the form "NAME old AS new".  Even though we don't have a rename command yet, we can start supporting AS as an argument separator and use it to make the MOUNT command more readable.