### PR TITLE
Fix PRINT to support avoiding newline characters

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -51,6 +51,10 @@ for the time being.**
     keyword as an argument separator and thus be of the form
     `MOUNT target$ AS $drive_name$`.
 
+*   Fixed `PRINT` so that, if the statement ends in a comma or in a semicolon,
+    no newline character is printed.  Useful to construct output lines in
+    multiple steps and matches the behavior of other BASIC implementations.
+
 ## Changes in version 0.9.0
 
 **Released on 2022-06-05.**

--- a/cli/tests/repl/help.out
+++ b/cli/tests/repl/help.out
@@ -590,7 +590,7 @@ Output from HELP PWD:
 
 Output from HELP PRINT:
 
-    PRINT [expr1 [<;|,> .. exprN]]
+    PRINT [expr1 [<;|,> [.. exprN]]]
 
     Prints a message to the console.
 
@@ -598,6 +598,10 @@ Output from HELP PRINT:
     strings.  Arguments separated by the short `;` separator are
     concatenated with a single space, while arguments separated by the long
     `,` separator are concatenated with a tab character.
+
+    If the last expression is empty (i.e. if the statement ends in a
+    semicolon or a comma), then the cursor position remains on the same
+    line of the message right after what was printed.
 
 Output from HELP RAD:
 


### PR DESCRIPTION
If the PRINT statement ends in a comma or semicolon, do not print a newline character -- just like other BASICs do.