### PR TITLE
Homogenize arguments compilation

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -55,6 +55,11 @@ for the time being.**
 
 *   Fixed the `MID` function so that the `length%` parameter is actually optional
     as the documentation claimed.
+    
+*   Homogenized the handling of command and function arguments into a single
+    parser.  The user-visible effects of this change are that all syntax
+    definitions that `HELP` prints now follow a consistent pattern and that such
+    help strings truly match what the commands and functions expect.
 
 ## Changes in version 0.10.0
 

--- a/cli/tests/lang/types.in
+++ b/cli/tests/lang/types.in
@@ -51,3 +51,6 @@ PRINT PRINT
 PRINT ">>> Argless function calls"
 PRINT PI
 PRINT PI()
+
+PRINT ">>> Function references"
+INPUT PI

--- a/cli/tests/lang/types.out
+++ b/cli/tests/lang/types.out
@@ -29,4 +29,6 @@ ERROR: 1:7: PRINT is not an array nor a function
 >>> Argless function calls
  3.141592653589793
 ERROR: 1:7: In call to PI: expected no arguments nor parenthesis
+>>> Function references
+ERROR: 1:7: PI is not an array nor a function
 End of input by CTRL-D

--- a/cli/tests/lang/types.out
+++ b/cli/tests/lang/types.out
@@ -30,5 +30,5 @@ ERROR: 1:7: PRINT is not an array nor a function
  3.141592653589793
 ERROR: 1:7: In call to PI: expected no arguments nor parenthesis
 >>> Function references
-ERROR: 1:7: PI is not an array nor a function
+ERROR: 1:1: In call to INPUT: 1:7: PI is not an array nor a function
 End of input by CTRL-D

--- a/cli/tests/repl/help.out
+++ b/cli/tests/repl/help.out
@@ -721,7 +721,7 @@ Output from HELP "GFX_SYNC":
 
 Output from HELP "GPIO_CLEAR":
 
-[38;5;11m    GPIO_CLEAR [pin%]
+[38;5;11m    GPIO_CLEAR <> | <pin%>
 [39m
     Resets the GPIO chip or a specific pin.
 

--- a/cli/tests/repl/help.out
+++ b/cli/tests/repl/help.out
@@ -1161,7 +1161,7 @@ Output from HELP "INT%":
 
 Output from HELP "LBOUND":
 
-[38;5;11m    LBOUND%(array[, dimension%])
+[38;5;11m    LBOUND%(<array> | <array, dimension%>)
 [39m
     Returns the lower bound for the given dimension of the array.
 
@@ -1317,7 +1317,7 @@ Output from HELP "TAN":
 
 Output from HELP "UBOUND":
 
-[38;5;11m    UBOUND%(array[, dimension%])
+[38;5;11m    UBOUND%(<array> | <array, dimension%>)
 [39m
     Returns the upper bound for the given dimension of the array.
 

--- a/cli/tests/repl/help.out
+++ b/cli/tests/repl/help.out
@@ -828,7 +828,7 @@ Output from HELP "LOCATE":
 
 Output from HELP "LOGIN":
 
-[38;5;11m    LOGIN username$[, password$]
+[38;5;11m    LOGIN <username$> | <username$, password$>
 [39m
     Logs into the user's account.
 

--- a/cli/tests/repl/help.out
+++ b/cli/tests/repl/help.out
@@ -932,7 +932,7 @@ Output from HELP "RANDOMIZE":
 
 Output from HELP "READ":
 
-[38;5;11m    READ vref1 [, .., vrefN]
+[38;5;11m    READ vref1[, .., vrefN]
 [39m
     Extracts data values from DATA statements.
 

--- a/cli/tests/repl/help.out
+++ b/cli/tests/repl/help.out
@@ -760,7 +760,7 @@ Output from HELP "GPIO_WRITE":
 
 Output from HELP "HELP":
 
-[38;5;11m    HELP [topic$]
+[38;5;11m    HELP <> | <topic$>
 [39m
     Prints interactive help.
 

--- a/cli/tests/repl/help.out
+++ b/cli/tests/repl/help.out
@@ -693,7 +693,7 @@ Output from HELP "GFX_RECTF":
 
 Output from HELP "GFX_SYNC":
 
-[38;5;11m    GFX_SYNC [enabled?]
+[38;5;11m    GFX_SYNC <> | <enabled?>
 [39m
     Controls the video syncing flag and/or forces a sync.
 

--- a/cli/tests/repl/help.out
+++ b/cli/tests/repl/help.out
@@ -629,7 +629,7 @@ Output from HELP "DEG":
 
 Output from HELP "DIR":
 
-[38;5;11m    DIR [path$]
+[38;5;11m    DIR <> | <path$>
 [39m
     Displays the list of files on the current or given path.
 
@@ -851,7 +851,7 @@ Output from HELP "LOGOUT":
 
 Output from HELP "MOUNT":
 
-[38;5;11m    MOUNT [target$ AS drive_name$]
+[38;5;11m    MOUNT <> | <target$ AS drive_name$>
 [39m
     Lists the mounted drives or mounts a new drive.
 

--- a/cli/tests/repl/help.out
+++ b/cli/tests/repl/help.out
@@ -607,7 +607,7 @@ Output from HELP "CLS":
 
 Output from HELP "COLOR":
 
-[38;5;11m    COLOR [fg%][, [bg%]]
+[38;5;11m    COLOR <> | <fg%> | <[fg%], [bg%]>
 [39m
     Sets the foreground and background colors.
 
@@ -777,7 +777,7 @@ Output from HELP "HELP":
 
 Output from HELP "INPUT":
 
-[38;5;11m    INPUT ["prompt" <;|,>] variableref
+[38;5;11m    INPUT <vref> | <[prompt$] <,|;> vref>
 [39m
     Obtains user input from the console.
 
@@ -878,7 +878,7 @@ Output from HELP "NEW":
 
 Output from HELP "PRINT":
 
-[38;5;11m    PRINT [expr1 [<;|,> [.. exprN]]]
+[38;5;11m    PRINT [expr1 <,|;> ..  <,|;> exprN]
 [39m
     Prints one or more values to the console.
 

--- a/cli/tests/repl/help.out
+++ b/cli/tests/repl/help.out
@@ -921,7 +921,7 @@ Output from HELP "RAD":
 
 Output from HELP "RANDOMIZE":
 
-[38;5;11m    RANDOMIZE [seed%]
+[38;5;11m    RANDOMIZE <> | <seed%>
 [39m
     Reinitializes the pseudo-random number generator.
 
@@ -1052,7 +1052,7 @@ Output from HELP "ASC":
 
 Output from HELP "ATN":
 
-[38;5;11m    ATN#(n<%|#>)
+[38;5;11m    ATN#(n#)
 [39m
     Computes the arc-tangent of a number.
 
@@ -1069,7 +1069,7 @@ Output from HELP "CHR":
 
 Output from HELP "CINT":
 
-[38;5;11m    CINT%(expr<%|#>)
+[38;5;11m    CINT%(expr#)
 [39m
     Casts the given numeric expression to an integer (with rounding).
 
@@ -1079,7 +1079,7 @@ Output from HELP "CINT":
 
 Output from HELP "COS":
 
-[38;5;11m    COS#(angle<%|#>)
+[38;5;11m    COS#(angle#)
 [39m
     Computes the cosine of an angle.
 
@@ -1149,7 +1149,7 @@ Output from HELP "INKEY":
 
 Output from HELP "INT%":
 
-[38;5;11m    INT%(expr<%|#>)
+[38;5;11m    INT%(expr#)
 [39m
     Casts the given numeric expression to an integer (with truncation).
 
@@ -1196,7 +1196,7 @@ Output from HELP "LTRIM":
 
 Output from HELP "MAX":
 
-[38;5;11m    MAX#(expr<%|#>[, .., expr<%|#>])
+[38;5;11m    MAX#(expr1#[, .., exprN#])
 [39m
     Returns the maximum number out of a set of numbers.
 
@@ -1216,7 +1216,7 @@ Output from HELP "MID":
 
 Output from HELP "MIN":
 
-[38;5;11m    MIN#(expr<%|#>[, .., expr<%|#>])
+[38;5;11m    MIN#(expr1#[, .., exprN#])
 [39m
     Returns the minimum number out of a set of numbers.
 
@@ -1239,7 +1239,7 @@ Output from HELP "RIGHT":
 
 Output from HELP "RND":
 
-[38;5;11m    RND#([n%])
+[38;5;11m    RND#(<> | <n%>)
 [39m
     Returns a random number in the [0..1] range.
 
@@ -1276,7 +1276,7 @@ Output from HELP "SCRROWS":
 
 Output from HELP "SIN":
 
-[38;5;11m    SIN#(angle<%|#>)
+[38;5;11m    SIN#(angle#)
 [39m
     Computes the sine of an angle.
 
@@ -1285,7 +1285,7 @@ Output from HELP "SIN":
 
 Output from HELP "SQR":
 
-[38;5;11m    SQR#(num<%|#>)
+[38;5;11m    SQR#(num#)
 [39m
     Computes the square root of the given number.
 
@@ -1308,7 +1308,7 @@ Output from HELP "STR$":
 
 Output from HELP "TAN":
 
-[38;5;11m    TAN#(angle<%|#>)
+[38;5;11m    TAN#(angle#)
 [39m
     Computes the tangent of an angle.
 

--- a/cli/tests/repl/help.out
+++ b/cli/tests/repl/help.out
@@ -1202,7 +1202,7 @@ Output from HELP "MAX":
 
 Output from HELP "MID":
 
-[38;5;11m    MID$(expr$, start%[, length%])
+[38;5;11m    MID$(<expr$, start%> | <expr$, start%, length%>)
 [39m
     Returns a portion of a string.
 

--- a/cli/tests/repl/help.out
+++ b/cli/tests/repl/help.out
@@ -975,7 +975,7 @@ Output from HELP "RUN":
 
 Output from HELP "SAVE":
 
-[38;5;11m    SAVE [filename$]
+[38;5;11m    SAVE <> | <filename$>
 [39m
     Saves the current program in memory to the given filename.
 

--- a/cli/tests/repl/help.out
+++ b/cli/tests/repl/help.out
@@ -1021,7 +1021,7 @@ Output from HELP "SIGNUP":
 
 Output from HELP "SLEEP":
 
-[38;5;11m    SLEEP seconds<%|#>
+[38;5;11m    SLEEP seconds#
 [39m
     Suspends program execution.
 

--- a/client/src/cmds.rs
+++ b/client/src/cmds.rs
@@ -65,7 +65,7 @@ impl LoginCommand {
     ) -> Rc<Self> {
         Rc::from(Self {
             metadata: CallableMetadataBuilder::new("LOGIN", VarType::Void)
-                .with_typed_syntax(&[
+                .with_syntax(&[
                     (
                         &[SingularArgSyntax::RequiredValue(
                             RequiredValueSyntax { name: "username", vtype: ExprType::Text },
@@ -170,7 +170,7 @@ impl LogoutCommand {
     ) -> Rc<Self> {
         Rc::from(Self {
             metadata: CallableMetadataBuilder::new("LOGOUT", VarType::Void)
-                .with_typed_syntax(&[(&[], None)])
+                .with_syntax(&[(&[], None)])
                 .with_category(CATEGORY)
                 .with_description(
                     "Logs the user out of their account.
@@ -256,7 +256,7 @@ impl ShareCommand {
     ) -> Rc<Self> {
         Rc::from(Self {
             metadata: CallableMetadataBuilder::new("SHARE", VarType::Void)
-                .with_typed_syntax(&[(
+                .with_syntax(&[(
                     &[SingularArgSyntax::RequiredValue(
                         RequiredValueSyntax { name: "filename", vtype: ExprType::Text },
                         ArgSepSyntax::Exactly(ArgSep::Long),
@@ -439,7 +439,7 @@ impl SignupCommand {
     pub fn new(service: Rc<RefCell<dyn Service>>, console: Rc<RefCell<dyn Console>>) -> Rc<Self> {
         Rc::from(Self {
             metadata: CallableMetadataBuilder::new("SIGNUP", VarType::Void)
-                .with_typed_syntax(&[(&[], None)])
+                .with_syntax(&[(&[], None)])
                 .with_category(CATEGORY)
                 .with_description(
                     "Creates a new user account interactively.

--- a/core/examples/dsl.rs
+++ b/core/examples/dsl.rs
@@ -60,7 +60,7 @@ impl NumLightsFunction {
     pub fn new(lights: Rc<RefCell<Lights>>) -> Rc<Self> {
         Rc::from(Self {
             metadata: CallableMetadataBuilder::new("NUM_LIGHTS", VarType::Integer)
-                .with_typed_syntax(&[(&[], None)])
+                .with_syntax(&[(&[], None)])
                 .with_category("Demonstration")
                 .with_description("Returns the number of available lights.")
                 .build(),
@@ -94,7 +94,7 @@ impl SwitchLightCommand {
     pub fn new(lights: Rc<RefCell<Lights>>) -> Rc<Self> {
         Rc::from(Self {
             metadata: CallableMetadataBuilder::new("SWITCH_LIGHT", VarType::Void)
-                .with_typed_syntax(&[(
+                .with_syntax(&[(
                     &[SingularArgSyntax::RequiredValue(
                         RequiredValueSyntax { name: "id", vtype: ExprType::Integer },
                         ArgSepSyntax::End,

--- a/core/examples/dsl.rs
+++ b/core/examples/dsl.rs
@@ -23,7 +23,7 @@
 
 use async_trait::async_trait;
 use endbasic_core::ast::{Value, VarType};
-use endbasic_core::compiler::{ExprType, NoArgsCompiler, SameTypeArgsCompiler};
+use endbasic_core::compiler::{ArgSepSyntax, ExprType, RequiredValueSyntax, SingularArgSyntax};
 use endbasic_core::exec::{Machine, Scope, StopReason};
 use endbasic_core::syms::{
     CallError, CallResult, Callable, CallableMetadata, CallableMetadataBuilder,
@@ -60,8 +60,7 @@ impl NumLightsFunction {
     pub fn new(lights: Rc<RefCell<Lights>>) -> Rc<Self> {
         Rc::from(Self {
             metadata: CallableMetadataBuilder::new("NUM_LIGHTS", VarType::Integer)
-                .with_syntax("")
-                .with_args_compiler(NoArgsCompiler::default())
+                .with_typed_syntax(&[(&[], None)])
                 .with_category("Demonstration")
                 .with_description("Returns the number of available lights.")
                 .build(),
@@ -95,8 +94,13 @@ impl SwitchLightCommand {
     pub fn new(lights: Rc<RefCell<Lights>>) -> Rc<Self> {
         Rc::from(Self {
             metadata: CallableMetadataBuilder::new("SWITCH_LIGHT", VarType::Void)
-                .with_syntax("id")
-                .with_args_compiler(SameTypeArgsCompiler::new(1, 1, ExprType::Integer))
+                .with_typed_syntax(&[(
+                    &[SingularArgSyntax::RequiredValue(
+                        RequiredValueSyntax { name: "id", vtype: ExprType::Integer },
+                        ArgSepSyntax::End,
+                    )],
+                    None,
+                )])
                 .with_category("Demonstration")
                 .with_description("Turns the light identified by 'id' on or off.")
                 .build(),

--- a/core/src/ast.rs
+++ b/core/src/ast.rs
@@ -336,14 +336,6 @@ pub enum Value {
     /// An integer value.
     Integer(i32),
 
-    /// An empty argument in a command call.  This is not strictly necessary but makes argument
-    /// parsing much simpler in the commands because we can assume each argument is followed by
-    /// a separator.
-    Missing,
-
-    /// A separator for built-in command arguments.
-    Separator(ArgSep),
-
     /// A string value.
     Text(String), // Should be `String` but would get confusing with the built-in Rust type.
 
@@ -372,12 +364,6 @@ impl From<i32> for Value {
     }
 }
 
-impl From<ArgSep> for Value {
-    fn from(s: ArgSep) -> Self {
-        Value::Separator(s)
-    }
-}
-
 impl From<&str> for Value {
     fn from(s: &str) -> Self {
         Value::Text(s.to_owned())
@@ -397,8 +383,6 @@ impl fmt::Display for Value {
                 write!(f, "{}", s)
             }
             Value::Integer(i) => write!(f, "{}", i),
-            Value::Missing => Ok(()),
-            Value::Separator(s) => write!(f, "{}", s),
             Value::Text(s) => write!(f, "\"{}\"", s),
             Value::VarRef(v) => write!(f, "{}", v),
             Value::Void => write!(f, "()"),
@@ -413,8 +397,6 @@ impl Value {
             Value::Boolean(_) => VarType::Boolean,
             Value::Double(_) => VarType::Double,
             Value::Integer(_) => VarType::Integer,
-            Value::Missing => panic!("Should have never asked for the type of a missing argument"),
-            Value::Separator(_) => VarType::Integer,
             Value::Text(_) => VarType::Text,
             Value::VarRef(vref) => vref.ref_type,
             Value::Void => VarType::Void,
@@ -437,8 +419,6 @@ impl Value {
             Value::Double(d) => format!(" {}", d),
             Value::Integer(i) if i.is_negative() => format!("{}", i),
             Value::Integer(i) => format!(" {}", i),
-            Value::Missing => "".to_owned(),
-            Value::Separator(_s) => panic!("Separators should not be printed"),
             Value::Text(s) => s,
             Value::VarRef(v) => format!("{}", v),
             Value::Void => panic!("Void should not be printed"),

--- a/core/src/ast.rs
+++ b/core/src/ast.rs
@@ -405,29 +405,44 @@ impl Value {
 }
 
 /// Types of separators between arguments to a `BuiltinCall`.
-#[repr(i32)]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum ArgSep {
     /// Filler for the separator in the last argument.
-    End,
+    End = 0,
 
     /// Short separator (`;`).
-    Short,
+    Short = 1,
 
     /// Long separator (`,`).
-    Long,
+    Long = 2,
 
     /// `AS` separator.
-    As,
+    As = 3,
 }
 
 impl fmt::Display for ArgSep {
+    // TODO(jmmv): Can this be removed in favor of describe()?
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
             ArgSep::End => write!(f, "<END OF STATEMENT>"),
             ArgSep::Short => write!(f, ";"),
             ArgSep::Long => write!(f, ","),
             ArgSep::As => write!(f, "AS"),
+        }
+    }
+}
+
+impl ArgSep {
+    /// Formats the separator for a syntax specification.
+    ///
+    /// The return value contains the textual representation of the separator and a boolean that
+    /// indicates whether the separator requires a leading space.
+    pub(crate) fn describe(&self) -> (&str, bool) {
+        match self {
+            ArgSep::End => ("", false),
+            ArgSep::Short => (";", false),
+            ArgSep::Long => (",", false),
+            ArgSep::As => ("AS", true),
         }
     }
 }

--- a/core/src/ast.rs
+++ b/core/src/ast.rs
@@ -402,28 +402,6 @@ impl Value {
             Value::Void => VarType::Void,
         }
     }
-
-    /// Consumes the value and converts it to a string value.  This is slightly different from the
-    /// `Display` implementation because strings aren't double-quoted.
-    ///
-    /// The output of this function is used anywhere a value is converted to a string, say as the
-    /// output of `PRINT`.
-    ///
-    /// This is *not* named `to_string` to prevent confusion with the behavior of a traditional
-    /// method named like that, and to avoid conflicts with the `Display` implementation.
-    pub fn to_text(self) -> String {
-        match self {
-            Value::Boolean(true) => "TRUE".to_owned(),
-            Value::Boolean(false) => "FALSE".to_owned(),
-            Value::Double(d) if !d.is_nan() && d.is_sign_negative() => format!("{}", d),
-            Value::Double(d) => format!(" {}", d),
-            Value::Integer(i) if i.is_negative() => format!("{}", i),
-            Value::Integer(i) => format!(" {}", i),
-            Value::Text(s) => s,
-            Value::VarRef(v) => format!("{}", v),
-            Value::Void => panic!("Void should not be printed"),
-        }
-    }
 }
 
 /// Types of separators between arguments to a `BuiltinCall`.
@@ -883,20 +861,5 @@ mod tests {
         assert_eq!("NaN", format!("{}", Value::Double(-f64::NAN)));
         assert_eq!("-56", format!("{}", Value::Integer(-56)));
         assert_eq!("\"some words\"", format!("{}", Value::Text("some words".to_owned())));
-    }
-
-    #[test]
-    fn test_value_to_text() {
-        assert_eq!("TRUE", Value::Boolean(true).to_text());
-        assert_eq!("FALSE", Value::Boolean(false).to_text());
-        assert_eq!(" 3", Value::Double(3.0).to_text());
-        assert_eq!(" 3.1", Value::Double(3.1).to_text());
-        assert_eq!(" 0.51", Value::Double(0.51).to_text());
-        assert_eq!(" inf", Value::Double(f64::INFINITY).to_text());
-        assert_eq!("-inf", Value::Double(f64::NEG_INFINITY).to_text());
-        assert_eq!(" NaN", Value::Double(f64::NAN).to_text());
-        assert_eq!(" NaN", Value::Double(-f64::NAN).to_text());
-        assert_eq!("-56", Value::Integer(-56).to_text());
-        assert_eq!("some words", Value::Text("some words".to_owned()).to_text());
     }
 }

--- a/core/src/compiler/args.rs
+++ b/core/src/compiler/args.rs
@@ -15,12 +15,14 @@
 
 //! Common compilers for callable arguments.
 
-use super::ExprType;
 use super::{compile_expr, CallableArgsCompiler, SymbolsTable};
+use super::{ExprType, SymbolPrototype};
 use crate::ast::*;
 use crate::bytecode::*;
+use crate::exec::ValueTag;
 use crate::reader::LineCol;
-use crate::syms::CallError;
+use crate::syms::{CallError, SymbolKey};
+use std::ops::RangeInclusive;
 
 /// Result for argument compilation return values.
 pub type Result<T> = std::result::Result<T, CallError>;
@@ -190,5 +192,2433 @@ impl CallableArgsCompiler for SameTypeArgsCompiler {
         }
         debug_assert!(i >= self.min);
         Ok(i)
+    }
+}
+
+/// Details to compile a required scalar parameter.
+#[derive(Debug)]
+pub struct RequiredValueSyntax {
+    /// The name of the parameter for help purposes.
+    pub name: &'static str,
+
+    /// The type of the expected parameter.
+    pub vtype: ExprType,
+}
+
+/// Details to compile a required reference parameter.
+#[derive(Debug)]
+pub struct RequiredRefSyntax {
+    /// The name of the parameter for help purposes.
+    pub name: &'static str,
+
+    /// If true, require an array reference; if false, a variable reference.
+    pub require_array: bool,
+
+    /// If true, allow references to undefined variables because the command will define them when
+    /// missing.  Can only be set to true for commands, not functions, and `require_array` must be
+    /// false.
+    pub define_undefined: bool,
+}
+
+/// Details to compile an optional scalar parameter.
+///
+/// Optional parameters are only supported in commands.
+#[derive(Debug)]
+pub struct OptionalValueSyntax {
+    /// The name of the parameter for help purposes.
+    pub name: &'static str,
+
+    /// The type of the expected parameter.
+    pub vtype: ExprType,
+
+    /// Value to push onto the stack when the parameter is missing.
+    pub missing_value: i32,
+
+    /// Value to push onto the stack when the parameter is present, after which the stack contains
+    /// the parameter value.
+    pub present_value: i32,
+}
+
+/// Details to describe the type of a repeated parameter.
+#[derive(Debug)]
+pub enum RepeatedTypeSyntax {
+    /// Allows any value type, including empty arguments.  The values pushed onto the stack have
+    /// the same semantics as those pushed by `AnyValueSyntax`.
+    AnyValue,
+
+    /// Expects a value of the given type.
+    TypedValue(ExprType),
+
+    /// Expects a reference to a variable (not an array) and allows the variables to not be defined.
+    VariableRef,
+}
+
+/// Details to compile a repeated parameter.
+///
+/// The repeated parameter must appear after all singular positional parameters.
+#[derive(Debug)]
+pub struct RepeatedSyntax {
+    /// The name of the parameter for help purposes.
+    pub name: &'static str,
+
+    /// The type of the expected parameters.
+    pub type_syn: RepeatedTypeSyntax,
+
+    /// The separator to expect between the repeated parameters.  For functions, this must be the
+    /// long separator (the comma).
+    pub sep: ArgSepSyntax,
+
+    /// Whether the repeated parameter must at least have one element or not.
+    pub require_one: bool,
+
+    /// Whether to allow any parameter to not be present or not.  Can only be true for commands.
+    pub allow_missing: bool,
+}
+
+impl RepeatedSyntax {
+    /// Formats the repeated argument syntax for help purposes into `output`.
+    ///
+    /// `last_singular_sep` contains the separator of the last singular argument syntax, if any,
+    /// which we need to place inside of the optional group.
+    fn describe(&self, output: &mut String, last_singular_sep: Option<&ArgSepSyntax>) {
+        if !self.require_one {
+            output.push('[');
+        }
+
+        if let Some(sep) = last_singular_sep {
+            sep.describe(output);
+        }
+
+        output.push_str(self.name);
+        output.push('1');
+        if let RepeatedTypeSyntax::TypedValue(vtype) = self.type_syn {
+            output.push(vtype.annotation());
+        }
+
+        if self.require_one {
+            output.push('[');
+        }
+
+        self.sep.describe(output);
+        output.push_str("..");
+        self.sep.describe(output);
+
+        output.push_str(self.name);
+        output.push('N');
+        if let RepeatedTypeSyntax::TypedValue(vtype) = self.type_syn {
+            output.push(vtype.annotation());
+        }
+
+        output.push(']');
+    }
+}
+
+/// Details to compile a parameter of any scalar type.
+#[derive(Debug)]
+pub struct AnyValueSyntax {
+    /// The name of the parameter for help purposes.
+    pub name: &'static str,
+
+    /// Whether to allow the parameter to not be present or not.  Can only be true for commands.
+    pub allow_missing: bool,
+}
+
+/// Details to process an argument separator.
+#[derive(Copy, Clone, Debug, PartialEq)]
+pub enum ArgSepSyntax {
+    /// The argument separator must exactly be the one give.
+    Exactly(ArgSep),
+
+    /// The argument separator may be any of the ones given.
+    OneOf(ArgSep, ArgSep),
+
+    /// The argument separator is the end of the call.
+    End,
+}
+
+impl ArgSepSyntax {
+    /// Formats the argument separator for help purposes into `output`.
+    fn describe(&self, output: &mut String) {
+        match self {
+            ArgSepSyntax::Exactly(sep) => {
+                let (text, needs_space) = sep.describe();
+
+                if !text.is_empty() && needs_space {
+                    output.push(' ');
+                }
+                output.push_str(text);
+                if !text.is_empty() {
+                    output.push(' ');
+                }
+            }
+
+            ArgSepSyntax::OneOf(sep1, sep2) => {
+                let (text1, _needs_space1) = sep1.describe();
+                let (text2, _needs_space2) = sep2.describe();
+
+                output.push(' ');
+                output.push_str(&format!("<{}|{}>", text1, text2));
+                output.push(' ');
+            }
+
+            ArgSepSyntax::End => (),
+        };
+    }
+}
+
+/// Details to process a non-repeated argument.
+///
+/// Every item in this enum is composed of a struct that provides the details on the parameter and
+/// a struct that provides the details on how this parameter is separated from the next.
+#[derive(Debug)]
+pub enum SingularArgSyntax {
+    /// A required scalar value.
+    RequiredValue(RequiredValueSyntax, ArgSepSyntax),
+
+    /// A required reference.
+    RequiredRef(RequiredRefSyntax, ArgSepSyntax),
+
+    /// An optional scalar value.
+    OptionalValue(OptionalValueSyntax, ArgSepSyntax),
+
+    /// A required scalar value of any type.
+    AnyValue(AnyValueSyntax, ArgSepSyntax),
+}
+
+/// Details to process the arguments of a callable.
+///
+/// Note that the description of function arguments is more restricted than that of commands.
+/// The arguments compiler panics when these preconditions aren't met with the rationale that
+/// builtin functions must never be ill-defined.
+// TODO(jmmv): It might be nice to try to express these restrictions in the type system, but
+// things are already too verbose as they are...
+#[derive(Debug)]
+pub(crate) struct CallableSyntax {
+    /// Ordered list of singular arguments that appear before repeated arguments.
+    singular: &'static [SingularArgSyntax],
+
+    /// Details on the repeated argument allowed after singular arguments.
+    repeated: Option<&'static RepeatedSyntax>,
+}
+
+impl CallableSyntax {
+    /// Creates a new callable arguments definition from its parts.
+    pub(crate) fn new(
+        singular: &'static [SingularArgSyntax],
+        repeated: Option<&'static RepeatedSyntax>,
+    ) -> Self {
+        Self { singular, repeated }
+    }
+
+    /// Computes the range of the expected number of parameters for this syntax.
+    fn expected_nargs(&self) -> RangeInclusive<usize> {
+        let mut min = self.singular.len();
+        let mut max = self.singular.len();
+        if let Some(syn) = self.repeated.as_ref() {
+            if syn.require_one {
+                min += 1;
+            }
+            max = usize::MAX;
+        }
+        min..=max
+    }
+
+    /// Produces a user-friendly description of this callable syntax.
+    pub(crate) fn describe(&self) -> String {
+        let mut description = String::new();
+        let mut last_singular_sep = None;
+        for (i, s) in self.singular.iter().enumerate() {
+            let sep = match s {
+                SingularArgSyntax::RequiredValue(details, sep) => {
+                    description.push_str(details.name);
+                    description.push(details.vtype.annotation());
+                    sep
+                }
+
+                SingularArgSyntax::RequiredRef(details, sep) => {
+                    description.push_str(details.name);
+                    sep
+                }
+
+                SingularArgSyntax::OptionalValue(details, sep) => {
+                    description.push('[');
+                    description.push_str(details.name);
+                    description.push(details.vtype.annotation());
+                    description.push(']');
+                    sep
+                }
+
+                SingularArgSyntax::AnyValue(details, sep) => {
+                    if details.allow_missing {
+                        description.push('[');
+                    }
+                    description.push_str(details.name);
+                    if details.allow_missing {
+                        description.push(']');
+                    }
+                    sep
+                }
+            };
+
+            if self.repeated.is_none() || i < self.singular.len() - 1 {
+                sep.describe(&mut description);
+            }
+            if i == self.singular.len() - 1 {
+                last_singular_sep = Some(sep);
+            }
+        }
+
+        if let Some(syn) = self.repeated {
+            syn.describe(&mut description, last_singular_sep);
+        }
+
+        description
+    }
+}
+
+/// Compiles an argument that requires a reference.
+///
+/// If the reference does not exist and the syntax allowed undefined symbols, returns the details
+/// for the symbol to insert into the symbols table, which the caller must handle because we do
+/// not have mutable access to the `symtable` here.
+fn compile_required_ref(
+    instrs: &mut Vec<Instruction>,
+    symtable: &SymbolsTable,
+    require_array: bool,
+    define_undefined: bool,
+    expr: Option<Expr>,
+) -> std::result::Result<Option<(SymbolKey, SymbolPrototype)>, CallError> {
+    match expr {
+        Some(Expr::Symbol(span)) => {
+            let key = SymbolKey::from(span.vref.name());
+            match symtable.get(&key) {
+                None => {
+                    if !define_undefined {
+                        let message = if require_array {
+                            format!("Undefined array {}", span.vref.name())
+                        } else {
+                            format!("Undefined variable {}", span.vref.name())
+                        };
+                        return Err(CallError::ArgumentError(span.pos, message));
+                    }
+                    debug_assert!(!require_array);
+
+                    let vtype = if span.vref.ref_type() == VarType::Auto {
+                        ExprType::Integer
+                    } else {
+                        span.vref.ref_type().into()
+                    };
+
+                    if !span.vref.accepts(vtype.into()) {
+                        return Err(CallError::ArgumentError(
+                            span.pos,
+                            format!("Incompatible type annotation in {} reference", span.vref),
+                        ));
+                    }
+
+                    instrs.push(Instruction::LoadRef(span.vref, span.pos));
+                    Ok(Some((key, SymbolPrototype::Variable(vtype))))
+                }
+
+                Some(SymbolPrototype::Array(vtype, _)) => {
+                    let vtype = *vtype;
+
+                    if !span.vref.accepts(vtype.into()) {
+                        return Err(CallError::ArgumentError(
+                            span.pos,
+                            format!("Incompatible type annotation in {} reference", span.vref),
+                        ));
+                    }
+
+                    if !require_array {
+                        return Err(CallError::ArgumentError(
+                            span.pos,
+                            format!("{} is not a variable reference", span.vref),
+                        ));
+                    }
+
+                    instrs.push(Instruction::LoadRef(span.vref, span.pos));
+                    Ok(None)
+                }
+
+                Some(SymbolPrototype::Variable(vtype)) => {
+                    let vtype = *vtype;
+
+                    if !span.vref.accepts(vtype.into()) {
+                        return Err(CallError::ArgumentError(
+                            span.pos,
+                            format!("Incompatible type annotation in {} reference", span.vref),
+                        ));
+                    }
+
+                    if require_array {
+                        return Err(CallError::ArgumentError(
+                            span.pos,
+                            format!("{} is not an array reference", span.vref),
+                        ));
+                    }
+
+                    instrs.push(Instruction::LoadRef(span.vref, span.pos));
+                    Ok(None)
+                }
+
+                Some(SymbolPrototype::Callable(md)) => {
+                    if !span.vref.accepts(md.return_type()) {
+                        return Err(CallError::ArgumentError(
+                            span.pos,
+                            format!("Incompatible type annotation in {} reference", span.vref),
+                        ));
+                    }
+
+                    Err(CallError::ArgumentError(
+                        span.pos,
+                        format!("{} is not an array nor a function", span.vref.name()),
+                    ))
+                }
+            }
+        }
+
+        Some(expr) => {
+            let message = if require_array {
+                "Requires an array reference, not a value"
+            } else {
+                "Requires a variable reference, not a value"
+            };
+            Err(CallError::ArgumentError(expr.start_pos(), message.to_owned()))
+        }
+
+        None => Err(CallError::SyntaxError),
+    }
+}
+
+/// A generic compiler for arguments to callables.
+///
+/// Callables can have more than one syntax definition as a simplistic form of function
+/// overloading.  This makes it easier to process certain commands (like `INPUT`, which wants
+/// to have an optional parameter and separator at the beginning).
+#[derive(Debug, Default)]
+pub(crate) struct ArgsCompiler {
+    /// Collection of syntaxes to compile against.
+    syntaxes: Vec<CallableSyntax>,
+}
+
+impl ArgsCompiler {
+    /// Creates an arguments compiler from a collection of syntaxes.
+    pub(crate) fn new(syntaxes: Vec<CallableSyntax>) -> Self {
+        Self { syntaxes }
+    }
+
+    /// Locates the syntax definition that can parse the given number of arguments.
+    ///
+    /// Panics if more than one syntax definition applies.
+    fn find_syntax(&self, nargs: usize) -> std::result::Result<&CallableSyntax, CallError> {
+        let mut matches = self.syntaxes.iter().filter(|s| s.expected_nargs().contains(&nargs));
+        let syntax = matches.next();
+        debug_assert!(matches.next().is_none(), "Ambiguous syntax definitions");
+        match syntax {
+            Some(syntax) => Ok(syntax),
+            None => Err(CallError::SyntaxError),
+        }
+    }
+
+    /// Compiles an argument separator with any necessary tagging.
+    ///
+    /// `instrs` is the list of instructions into which insert the separator tag at `sep_tag_pc`
+    /// when it is needed to disambiguate separators at runtime.
+    ///
+    /// `syn` contains the details about the separator syntax that is accepted.
+    ///
+    /// `sep` and `sep_pos` are the details about the separator being compiled.
+    ///
+    /// `is_last` indicates whether this is the last separator in the command call and is used
+    /// only for diagnostics purposes.
+    fn compile_syn_argsep(
+        instrs: &mut Vec<Instruction>,
+        syn: &ArgSepSyntax,
+        is_last: bool,
+        sep: ArgSep,
+        sep_pos: LineCol,
+        sep_tag_pc: Address,
+    ) -> std::result::Result<usize, CallError> {
+        debug_assert!(
+            (!is_last || sep == ArgSep::End) && (is_last || sep != ArgSep::End),
+            "Parser can only supply an End separator in the last argument"
+        );
+
+        match syn {
+            ArgSepSyntax::Exactly(exp_sep) => {
+                debug_assert!(*exp_sep != ArgSep::End, "Use ArgSepSyntax::End");
+                if sep != ArgSep::End && sep != *exp_sep {
+                    return Err(CallError::SyntaxError);
+                }
+                Ok(0)
+            }
+
+            ArgSepSyntax::OneOf(exp_sep1, exp_sep2) => {
+                debug_assert!(*exp_sep1 != ArgSep::End, "Use ArgSepSyntax::End");
+                debug_assert!(*exp_sep2 != ArgSep::End, "Use ArgSepSyntax::End");
+                if sep == ArgSep::End {
+                    Ok(0)
+                } else {
+                    if sep != *exp_sep1 && sep != *exp_sep2 {
+                        return Err(CallError::SyntaxError);
+                    }
+                    instrs
+                        .insert(sep_tag_pc, Instruction::Push(Value::Integer(sep as i32), sep_pos));
+                    Ok(1)
+                }
+            }
+
+            ArgSepSyntax::End => {
+                debug_assert!(is_last);
+                Ok(0)
+            }
+        }
+    }
+}
+
+impl CallableArgsCompiler for ArgsCompiler {
+    fn compile_complex(
+        &self,
+        instrs: &mut Vec<Instruction>,
+        symtable: &mut SymbolsTable,
+        _pos: LineCol,
+        args: Vec<ArgSpan>,
+    ) -> std::result::Result<usize, CallError> {
+        let syntax = self.find_syntax(args.len())?;
+
+        let input_nargs = args.len();
+        let mut aiter = args.into_iter().rev();
+        let mut nargs = 0;
+
+        let mut remaining;
+        if let Some(syn) = syntax.repeated.as_ref() {
+            let mut min_nargs = syntax.singular.len();
+            if syn.require_one {
+                min_nargs += 1;
+            }
+            if input_nargs < min_nargs {
+                return Err(CallError::SyntaxError);
+            }
+
+            let need_tags =
+                syn.allow_missing || matches!(syn.type_syn, RepeatedTypeSyntax::AnyValue);
+
+            remaining = input_nargs;
+            while remaining > syntax.singular.len() {
+                let span = aiter.next().expect("Args and their syntax must advance in unison");
+
+                let sep_tag_pc = instrs.len();
+
+                match span.expr {
+                    Some(expr) => {
+                        let pos = expr.start_pos();
+                        match syn.type_syn {
+                            RepeatedTypeSyntax::AnyValue => {
+                                debug_assert!(need_tags);
+                                let etype = compile_expr(instrs, symtable, expr, false)?;
+                                instrs.push(Instruction::Push(
+                                    Value::Integer(ValueTag::from(etype) as i32),
+                                    pos,
+                                ));
+                                nargs += 2;
+                            }
+
+                            RepeatedTypeSyntax::VariableRef => {
+                                let to_insert = compile_required_ref(
+                                    instrs,
+                                    symtable,
+                                    false,
+                                    true,
+                                    Some(expr),
+                                )?;
+                                if let Some((key, proto)) = to_insert {
+                                    symtable.insert(key, proto);
+                                }
+                                nargs += 1;
+                            }
+
+                            RepeatedTypeSyntax::TypedValue(vtype) => {
+                                compile_arg_expr(instrs, symtable, expr, vtype)?;
+                                if need_tags {
+                                    instrs.push(Instruction::Push(
+                                        Value::Integer(ValueTag::from(vtype) as i32),
+                                        pos,
+                                    ));
+                                    nargs += 2;
+                                } else {
+                                    nargs += 1;
+                                }
+                            }
+                        }
+                    }
+                    None => {
+                        if !syn.allow_missing {
+                            return Err(CallError::SyntaxError);
+                        }
+                        instrs.push(Instruction::Push(
+                            Value::Integer(ValueTag::Missing as i32),
+                            span.sep_pos,
+                        ));
+                        nargs += 1;
+                    }
+                }
+
+                nargs += Self::compile_syn_argsep(
+                    instrs,
+                    &syn.sep,
+                    input_nargs == remaining,
+                    span.sep,
+                    span.sep_pos,
+                    sep_tag_pc,
+                )?;
+
+                remaining -= 1;
+            }
+        } else {
+            remaining = syntax.singular.len();
+        }
+
+        for syn in syntax.singular.iter().rev() {
+            let span = aiter.next().expect("Args and their syntax must advance in unison");
+
+            let sep_tag_pc = instrs.len();
+
+            let exp_sep = match syn {
+                SingularArgSyntax::RequiredValue(details, sep) => {
+                    match span.expr {
+                        Some(expr) => {
+                            compile_arg_expr(instrs, symtable, expr, details.vtype)?;
+                            nargs += 1;
+                        }
+                        None => return Err(CallError::SyntaxError),
+                    }
+                    sep
+                }
+
+                SingularArgSyntax::RequiredRef(details, sep) => {
+                    let to_insert = compile_required_ref(
+                        instrs,
+                        symtable,
+                        details.require_array,
+                        details.define_undefined,
+                        span.expr,
+                    )?;
+                    if let Some((key, proto)) = to_insert {
+                        symtable.insert(key, proto);
+                    }
+                    nargs += 1;
+                    sep
+                }
+
+                SingularArgSyntax::OptionalValue(details, sep) => {
+                    let (tag, pos) = match span.expr {
+                        Some(expr) => {
+                            let pos = expr.start_pos();
+                            compile_arg_expr(instrs, symtable, expr, details.vtype)?;
+                            nargs += 1;
+                            (details.present_value, pos)
+                        }
+                        None => (details.missing_value, span.sep_pos),
+                    };
+                    instrs.push(Instruction::Push(Value::Integer(tag), pos));
+                    nargs += 1;
+                    sep
+                }
+
+                SingularArgSyntax::AnyValue(details, sep) => {
+                    let (tag, pos) = match span.expr {
+                        Some(expr) => {
+                            let pos = expr.start_pos();
+                            let etype = compile_expr(instrs, symtable, expr, false)?;
+                            nargs += 2;
+                            (ValueTag::from(etype), pos)
+                        }
+                        None => {
+                            if !details.allow_missing {
+                                return Err(CallError::ArgumentError(
+                                    span.sep_pos,
+                                    "Missing expression before separator".to_owned(),
+                                ));
+                            }
+                            nargs += 1;
+                            (ValueTag::Missing, span.sep_pos)
+                        }
+                    };
+                    instrs.push(Instruction::Push(Value::Integer(tag as i32), pos));
+                    sep
+                }
+            };
+
+            nargs += Self::compile_syn_argsep(
+                instrs,
+                exp_sep,
+                input_nargs == remaining,
+                span.sep,
+                span.sep_pos,
+                sep_tag_pc,
+            )?;
+
+            remaining -= 1;
+        }
+
+        Ok(nargs)
+    }
+
+    fn compile_simple(
+        &self,
+        instrs: &mut Vec<Instruction>,
+        symtable: &SymbolsTable,
+        _pos: LineCol,
+        args: Vec<Expr>,
+    ) -> std::result::Result<usize, CallError> {
+        let syntax = self.find_syntax(args.len())?;
+
+        let input_nargs = args.len();
+        let mut aiter = args.into_iter().rev();
+        let mut nargs = 0;
+
+        if let Some(syn) = syntax.repeated.as_ref() {
+            debug_assert_eq!(
+                ArgSepSyntax::Exactly(ArgSep::Long),
+                syn.sep,
+                "Function argument separators must be commas"
+            );
+            debug_assert!(!syn.allow_missing, "Functions don't support missing values");
+
+            let mut min_nargs = syntax.singular.len();
+            if syn.require_one {
+                min_nargs += 1;
+            }
+            if input_nargs < min_nargs {
+                return Err(CallError::SyntaxError);
+            }
+
+            let mut remaining = input_nargs;
+            while remaining > syntax.singular.len() {
+                let arg = aiter.next().expect("Args and their syntax must advance in unison");
+
+                match syn.type_syn {
+                    RepeatedTypeSyntax::AnyValue => {
+                        let pos = arg.start_pos();
+                        let etype = compile_expr(instrs, symtable, arg, false)?;
+                        let tag = ValueTag::from(etype);
+                        instrs.push(Instruction::Push(Value::Integer(tag as i32), pos));
+                        nargs += 2;
+                    }
+
+                    RepeatedTypeSyntax::TypedValue(vtype) => {
+                        compile_arg_expr(instrs, symtable, arg, vtype)?;
+                        nargs += 1;
+                    }
+
+                    RepeatedTypeSyntax::VariableRef => {
+                        unreachable!("Repeated variable references not supported for functions")
+                    }
+                }
+                remaining -= 1;
+            }
+        }
+
+        for (i, syn) in syntax.singular.iter().rev().enumerate() {
+            let arg = aiter.next().expect("Args and their syntax must advance in unison");
+
+            let sep = match syn {
+                SingularArgSyntax::RequiredValue(details, sep) => {
+                    compile_arg_expr(instrs, symtable, arg, details.vtype)?;
+                    nargs += 1;
+                    sep
+                }
+
+                SingularArgSyntax::RequiredRef(details, sep) => {
+                    debug_assert!(!details.define_undefined);
+                    let to_insert = compile_required_ref(
+                        instrs,
+                        symtable,
+                        details.require_array,
+                        details.define_undefined,
+                        Some(arg),
+                    )?;
+                    debug_assert!(to_insert.is_none());
+                    nargs += 1;
+                    sep
+                }
+
+                SingularArgSyntax::OptionalValue(_details, _sep) => {
+                    unreachable!("Functions don't support optional arguments")
+                }
+
+                SingularArgSyntax::AnyValue(details, sep) => {
+                    debug_assert!(!details.allow_missing);
+                    let pos = arg.start_pos();
+                    let etype = compile_expr(instrs, symtable, arg, false)?;
+                    let tag = ValueTag::from(etype);
+                    instrs.push(Instruction::Push(Value::Integer(tag as i32), pos));
+                    nargs += 2;
+                    sep
+                }
+            };
+            debug_assert!(
+                (i == syntax.singular.len() - 1 || *sep == ArgSepSyntax::Exactly(ArgSep::Long))
+                    || (i < syntax.singular.len() - 1
+                        || *sep == ArgSepSyntax::Exactly(ArgSep::End))
+            );
+        }
+
+        Ok(nargs)
+    }
+}
+
+#[cfg(test)]
+mod testutils {
+    use super::*;
+    use std::collections::HashMap;
+
+    /// Syntactic sugar to instantiate a `LineCol` for tests.
+    pub(super) fn lc(line: usize, col: usize) -> LineCol {
+        LineCol { line, col }
+    }
+
+    /// Builder pattern to instantiate a test scenario.
+    #[derive(Default)]
+    #[must_use]
+    pub(super) struct Tester {
+        syntaxes: Vec<CallableSyntax>,
+        symtable: SymbolsTable,
+    }
+
+    impl Tester {
+        /// Registers a syntax definition in the arguments compiler.
+        pub(super) fn syntax(
+            mut self,
+            singular: &'static [SingularArgSyntax],
+            repeated: Option<&'static RepeatedSyntax>,
+        ) -> Self {
+            self.syntaxes.push(CallableSyntax::new(singular, repeated));
+            self
+        }
+
+        /// Registers a pre-existing symbol in the symbols table.
+        pub(super) fn symbol(mut self, key: &str, proto: SymbolPrototype) -> Self {
+            self.symtable.insert(SymbolKey::from(key), proto);
+            self
+        }
+
+        /// Feeds function `args` into the arguments compiler and returns a checker to validate
+        /// expectations.
+        pub(super) fn compile_function<A: Into<Vec<Expr>>>(self, args: A) -> Checker {
+            let args_compiler = ArgsCompiler::new(self.syntaxes);
+            let mut instrs = vec![
+                // Start with one instruction to validate that the args compiler doesn't touch it.
+                Instruction::Nop,
+            ];
+            let result = args_compiler.compile_simple(
+                &mut instrs,
+                &self.symtable,
+                lc(1000, 2000),
+                args.into(),
+            );
+            Checker {
+                result,
+                instrs,
+                symtable: self.symtable,
+                exp_result: Ok(0),
+                exp_instrs: vec![Instruction::Nop],
+                exp_vars: HashMap::default(),
+            }
+        }
+
+        /// Feeds command `args` into the arguments compiler and returns a checker to validate
+        /// expectations.
+        pub(super) fn compile_command<A: Into<Vec<ArgSpan>>>(mut self, args: A) -> Checker {
+            let args = args.into();
+            let args_compiler = ArgsCompiler::new(self.syntaxes);
+            let mut instrs = vec![
+                // Start with one instruction to validate that the args compiler doesn't touch it.
+                Instruction::Nop,
+            ];
+            let result = args_compiler.compile_complex(
+                &mut instrs,
+                &mut self.symtable,
+                lc(1000, 2000),
+                args,
+            );
+            Checker {
+                result,
+                instrs,
+                symtable: self.symtable,
+                exp_result: Ok(0),
+                exp_instrs: vec![Instruction::Nop],
+                exp_vars: HashMap::default(),
+            }
+        }
+    }
+
+    /// Builder pattern to validate expectations in a test scenario.
+    #[must_use]
+    pub(super) struct Checker {
+        result: std::result::Result<usize, CallError>,
+        instrs: Vec<Instruction>,
+        symtable: SymbolsTable,
+        exp_result: std::result::Result<usize, CallError>,
+        exp_instrs: Vec<Instruction>,
+        exp_vars: HashMap<SymbolKey, ExprType>,
+    }
+
+    impl Checker {
+        /// Expects the compilation to succeeded and produce `nargs` arguments.
+        pub(super) fn exp_nargs(mut self, nargs: usize) -> Self {
+            self.exp_result = Ok(nargs);
+            self
+        }
+
+        /// Expects the compilation to fail with the given `error`.
+        pub(super) fn exp_error(mut self, error: CallError) -> Self {
+            self.exp_result = Err(error);
+            self
+        }
+
+        /// Adds the given instruction to the expected instructions on success.
+        pub(super) fn exp_instr(mut self, instr: Instruction) -> Self {
+            self.exp_instrs.push(instr);
+            self
+        }
+
+        /// Expects the compilation to define a new variable `key` of type `etype`.
+        pub(super) fn exp_symbol<K: AsRef<str>>(mut self, key: K, etype: ExprType) -> Self {
+            self.exp_vars.insert(SymbolKey::from(key), etype);
+            self
+        }
+
+        /// Formats a `CallError` as a string to simplify comparisons.
+        fn format_call_error(e: CallError) -> String {
+            match e {
+                CallError::ArgumentError(pos, e) => format!("{}:{}: {}", pos.line, pos.col, e),
+                CallError::EvalError(pos, e) => format!("{}:{}: {}", pos.line, pos.col, e),
+                CallError::InternalError(_pos, e) => panic!("Must not happen here: {}", e),
+                CallError::IoError(e) => panic!("Must not happen here: {}", e),
+                CallError::NestedError(e) => panic!("Must not happen here: {}", e),
+                CallError::SyntaxError => "Syntax error".to_owned(),
+            }
+        }
+
+        /// Checks that the compilation ended with the configured expectations.
+        pub(super) fn check(self) {
+            let is_ok = self.result.is_ok();
+            assert_eq!(
+                self.exp_result.map_err(Self::format_call_error),
+                self.result.map_err(Self::format_call_error),
+            );
+
+            if !is_ok {
+                return;
+            }
+
+            assert_eq!(self.exp_instrs, self.instrs);
+
+            let mut exp_keys = self.symtable.keys();
+            for (key, exp_etype) in &self.exp_vars {
+                match self.symtable.get(key) {
+                    Some(SymbolPrototype::Variable(etype)) => {
+                        assert_eq!(
+                            exp_etype, etype,
+                            "Variable {} was defined with the wrong type",
+                            key
+                        );
+                    }
+                    Some(_) => panic!("Symbol {} was defined but not as a variable", key),
+                    None => panic!("Symbol {} was not defined", key),
+                }
+                exp_keys.insert(key);
+            }
+
+            assert_eq!(exp_keys, self.symtable.keys(), "Unexpected variables defined");
+        }
+    }
+}
+
+#[cfg(test)]
+mod description_tests {
+    use super::*;
+
+    #[test]
+    fn test_no_args() {
+        assert_eq!("", CallableSyntax::new(&[], None).describe());
+    }
+
+    #[test]
+    fn test_singular_required_value() {
+        assert_eq!(
+            "the-arg%",
+            CallableSyntax::new(
+                &[SingularArgSyntax::RequiredValue(
+                    RequiredValueSyntax { name: "the-arg", vtype: ExprType::Integer },
+                    ArgSepSyntax::End,
+                )],
+                None,
+            )
+            .describe(),
+        );
+    }
+
+    #[test]
+    fn test_singular_required_ref() {
+        assert_eq!(
+            "the-arg",
+            CallableSyntax::new(
+                &[SingularArgSyntax::RequiredRef(
+                    RequiredRefSyntax {
+                        name: "the-arg",
+                        require_array: false,
+                        define_undefined: false
+                    },
+                    ArgSepSyntax::End,
+                )],
+                None,
+            )
+            .describe()
+        );
+    }
+
+    #[test]
+    fn test_singular_optional_value() {
+        assert_eq!(
+            "[the-arg%]",
+            CallableSyntax::new(
+                &[SingularArgSyntax::OptionalValue(
+                    OptionalValueSyntax {
+                        name: "the-arg",
+                        vtype: ExprType::Integer,
+                        missing_value: 0,
+                        present_value: 1,
+                    },
+                    ArgSepSyntax::End,
+                )],
+                None,
+            )
+            .describe()
+        );
+    }
+
+    #[test]
+    fn test_singular_any_value_required() {
+        assert_eq!(
+            "the-arg",
+            CallableSyntax::new(
+                &[SingularArgSyntax::AnyValue(
+                    AnyValueSyntax { name: "the-arg", allow_missing: false },
+                    ArgSepSyntax::End,
+                )],
+                None,
+            )
+            .describe()
+        );
+    }
+
+    #[test]
+    fn test_singular_any_value_optional() {
+        assert_eq!(
+            "[the-arg]",
+            CallableSyntax::new(
+                &[SingularArgSyntax::AnyValue(
+                    AnyValueSyntax { name: "the-arg", allow_missing: true },
+                    ArgSepSyntax::End,
+                )],
+                None,
+            )
+            .describe()
+        );
+    }
+
+    #[test]
+    fn test_singular_exactly_separators() {
+        assert_eq!(
+            "a; b AS c, d",
+            CallableSyntax::new(
+                &[
+                    SingularArgSyntax::AnyValue(
+                        AnyValueSyntax { name: "a", allow_missing: false },
+                        ArgSepSyntax::Exactly(ArgSep::Short),
+                    ),
+                    SingularArgSyntax::AnyValue(
+                        AnyValueSyntax { name: "b", allow_missing: false },
+                        ArgSepSyntax::Exactly(ArgSep::As),
+                    ),
+                    SingularArgSyntax::AnyValue(
+                        AnyValueSyntax { name: "c", allow_missing: false },
+                        ArgSepSyntax::Exactly(ArgSep::Long),
+                    ),
+                    SingularArgSyntax::AnyValue(
+                        AnyValueSyntax { name: "d", allow_missing: false },
+                        ArgSepSyntax::Exactly(ArgSep::End),
+                    ),
+                ],
+                None,
+            )
+            .describe()
+        );
+    }
+
+    #[test]
+    fn test_singular_oneof_separators() {
+        assert_eq!(
+            "a <;|,> b <AS|,> c",
+            CallableSyntax::new(
+                &[
+                    SingularArgSyntax::AnyValue(
+                        AnyValueSyntax { name: "a", allow_missing: false },
+                        ArgSepSyntax::OneOf(ArgSep::Short, ArgSep::Long),
+                    ),
+                    SingularArgSyntax::AnyValue(
+                        AnyValueSyntax { name: "b", allow_missing: false },
+                        ArgSepSyntax::OneOf(ArgSep::As, ArgSep::Long),
+                    ),
+                    SingularArgSyntax::AnyValue(
+                        AnyValueSyntax { name: "c", allow_missing: false },
+                        ArgSepSyntax::Exactly(ArgSep::End),
+                    ),
+                ],
+                None,
+            )
+            .describe()
+        );
+    }
+
+    #[test]
+    fn test_repeated_require_one() {
+        assert_eq!(
+            "rep1[; ..; repN]",
+            CallableSyntax::new(
+                &[],
+                Some(&RepeatedSyntax {
+                    name: "rep",
+                    type_syn: RepeatedTypeSyntax::AnyValue,
+                    sep: ArgSepSyntax::Exactly(ArgSep::Short),
+                    require_one: true,
+                    allow_missing: false,
+                }),
+            )
+            .describe()
+        );
+    }
+
+    #[test]
+    fn test_repeated_allow_missing() {
+        assert_eq!(
+            "[rep1, .., repN]",
+            CallableSyntax::new(
+                &[],
+                Some(&RepeatedSyntax {
+                    name: "rep",
+                    type_syn: RepeatedTypeSyntax::AnyValue,
+                    sep: ArgSepSyntax::Exactly(ArgSep::Long),
+                    require_one: false,
+                    allow_missing: true,
+                }),
+            )
+            .describe()
+        );
+    }
+
+    #[test]
+    fn test_repeated_value() {
+        assert_eq!(
+            "rep1$[ AS .. AS repN$]",
+            CallableSyntax::new(
+                &[],
+                Some(&RepeatedSyntax {
+                    name: "rep",
+                    type_syn: RepeatedTypeSyntax::TypedValue(ExprType::Text),
+                    sep: ArgSepSyntax::Exactly(ArgSep::As),
+                    require_one: true,
+                    allow_missing: false,
+                }),
+            )
+            .describe()
+        );
+    }
+
+    #[test]
+    fn test_repeated_ref() {
+        assert_eq!(
+            "rep1[ AS .. AS repN]",
+            CallableSyntax::new(
+                &[],
+                Some(&RepeatedSyntax {
+                    name: "rep",
+                    type_syn: RepeatedTypeSyntax::VariableRef,
+                    sep: ArgSepSyntax::Exactly(ArgSep::As),
+                    require_one: true,
+                    allow_missing: false,
+                }),
+            )
+            .describe()
+        );
+    }
+
+    #[test]
+    fn test_singular_and_repeated() {
+        assert_eq!(
+            "arg%[, rep1 <;|,> .. <;|,> repN]",
+            CallableSyntax::new(
+                &[SingularArgSyntax::RequiredValue(
+                    RequiredValueSyntax { name: "arg", vtype: ExprType::Integer },
+                    ArgSepSyntax::Exactly(ArgSep::Long),
+                )],
+                Some(&RepeatedSyntax {
+                    name: "rep",
+                    type_syn: RepeatedTypeSyntax::AnyValue,
+                    sep: ArgSepSyntax::OneOf(ArgSep::Short, ArgSep::Long),
+                    require_one: false,
+                    allow_missing: false,
+                }),
+            )
+            .describe()
+        );
+    }
+}
+
+#[cfg(test)]
+mod function_tests {
+    use super::testutils::*;
+    use super::*;
+
+    #[test]
+    fn test_no_syntaxes_yields_error() {
+        Tester::default().compile_function([]).exp_error(CallError::SyntaxError).check();
+    }
+
+    #[test]
+    fn test_no_args_ok() {
+        Tester::default().syntax(&[], None).compile_function([]).check();
+    }
+
+    #[test]
+    fn test_no_args_mismatch() {
+        Tester::default()
+            .syntax(&[], None)
+            .compile_function([Expr::Integer(IntegerSpan { value: 3, pos: lc(1, 2) })])
+            .exp_error(CallError::SyntaxError)
+            .check();
+    }
+
+    #[test]
+    fn test_one_required_value_ok() {
+        Tester::default()
+            .syntax(
+                &[SingularArgSyntax::RequiredValue(
+                    RequiredValueSyntax { name: "arg1", vtype: ExprType::Integer },
+                    ArgSepSyntax::End,
+                )],
+                None,
+            )
+            .compile_function([Expr::Integer(IntegerSpan { value: 3, pos: lc(1, 2) })])
+            .exp_instr(Instruction::Push(Value::Integer(3), lc(1, 2)))
+            .exp_nargs(1)
+            .check();
+    }
+
+    #[test]
+    fn test_one_required_value_type_promotion() {
+        Tester::default()
+            .syntax(
+                &[SingularArgSyntax::RequiredValue(
+                    RequiredValueSyntax { name: "arg1", vtype: ExprType::Integer },
+                    ArgSepSyntax::End,
+                )],
+                None,
+            )
+            .compile_function([Expr::Double(DoubleSpan { value: 3.0, pos: lc(1, 2) })])
+            .exp_instr(Instruction::Push(Value::Double(3.0), lc(1, 2)))
+            .exp_instr(Instruction::DoubleToInteger)
+            .exp_nargs(1)
+            .check();
+    }
+
+    #[test]
+    fn test_one_required_ref_variable_ok() {
+        Tester::default()
+            .symbol("foo", SymbolPrototype::Variable(ExprType::Text))
+            .syntax(
+                &[SingularArgSyntax::RequiredRef(
+                    RequiredRefSyntax {
+                        name: "ref",
+                        require_array: false,
+                        define_undefined: false,
+                    },
+                    ArgSepSyntax::End,
+                )],
+                None,
+            )
+            .compile_function([Expr::Symbol(SymbolSpan {
+                vref: VarRef::new("foo", VarType::Auto),
+                pos: lc(1, 2),
+            })])
+            .exp_instr(Instruction::LoadRef(VarRef::new("foo", VarType::Auto), lc(1, 2)))
+            .exp_nargs(1)
+            .check();
+    }
+
+    #[test]
+    fn test_one_required_ref_variable_not_defined() {
+        Tester::default()
+            .syntax(
+                &[SingularArgSyntax::RequiredRef(
+                    RequiredRefSyntax {
+                        name: "ref",
+                        require_array: false,
+                        define_undefined: false,
+                    },
+                    ArgSepSyntax::End,
+                )],
+                None,
+            )
+            .compile_function([Expr::Symbol(SymbolSpan {
+                vref: VarRef::new("foo", VarType::Auto),
+                pos: lc(1, 2),
+            })])
+            .exp_error(CallError::ArgumentError(lc(1, 2), "Undefined variable foo".to_owned()))
+            .check();
+    }
+
+    #[test]
+    fn test_one_required_ref_variable_disallow_value() {
+        Tester::default()
+            .syntax(
+                &[SingularArgSyntax::RequiredRef(
+                    RequiredRefSyntax {
+                        name: "ref",
+                        require_array: false,
+                        define_undefined: false,
+                    },
+                    ArgSepSyntax::End,
+                )],
+                None,
+            )
+            .compile_function([Expr::Integer(IntegerSpan { value: 5, pos: lc(1, 2) })])
+            .exp_error(CallError::ArgumentError(
+                lc(1, 2),
+                "Requires a variable reference, not a value".to_owned(),
+            ))
+            .check();
+    }
+
+    #[test]
+    fn test_one_required_ref_variable_wrong_type() {
+        Tester::default()
+            .symbol("foo", SymbolPrototype::Array(ExprType::Text, 1))
+            .syntax(
+                &[SingularArgSyntax::RequiredRef(
+                    RequiredRefSyntax {
+                        name: "ref",
+                        require_array: false,
+                        define_undefined: false,
+                    },
+                    ArgSepSyntax::End,
+                )],
+                None,
+            )
+            .compile_function([Expr::Symbol(SymbolSpan {
+                vref: VarRef::new("foo", VarType::Auto),
+                pos: lc(1, 2),
+            })])
+            .exp_error(CallError::ArgumentError(
+                lc(1, 2),
+                "foo is not a variable reference".to_owned(),
+            ))
+            .check();
+    }
+
+    #[test]
+    fn test_one_required_ref_variable_wrong_annotation() {
+        Tester::default()
+            .symbol("foo", SymbolPrototype::Variable(ExprType::Text))
+            .syntax(
+                &[SingularArgSyntax::RequiredRef(
+                    RequiredRefSyntax {
+                        name: "ref",
+                        require_array: false,
+                        define_undefined: false,
+                    },
+                    ArgSepSyntax::End,
+                )],
+                None,
+            )
+            .compile_function([Expr::Symbol(SymbolSpan {
+                vref: VarRef::new("foo", VarType::Integer),
+                pos: lc(1, 2),
+            })])
+            .exp_error(CallError::ArgumentError(
+                lc(1, 2),
+                "Incompatible type annotation in foo% reference".to_owned(),
+            ))
+            .check();
+    }
+
+    #[test]
+    fn test_one_required_ref_array_ok() {
+        Tester::default()
+            .symbol("foo", SymbolPrototype::Array(ExprType::Text, 0))
+            .syntax(
+                &[SingularArgSyntax::RequiredRef(
+                    RequiredRefSyntax { name: "ref", require_array: true, define_undefined: false },
+                    ArgSepSyntax::End,
+                )],
+                None,
+            )
+            .compile_function([Expr::Symbol(SymbolSpan {
+                vref: VarRef::new("foo", VarType::Auto),
+                pos: lc(1, 2),
+            })])
+            .exp_instr(Instruction::LoadRef(VarRef::new("foo", VarType::Auto), lc(1, 2)))
+            .exp_nargs(1)
+            .check();
+    }
+
+    #[test]
+    fn test_one_required_ref_array_not_defined() {
+        Tester::default()
+            .syntax(
+                &[SingularArgSyntax::RequiredRef(
+                    RequiredRefSyntax { name: "ref", require_array: true, define_undefined: false },
+                    ArgSepSyntax::End,
+                )],
+                None,
+            )
+            .compile_function([Expr::Symbol(SymbolSpan {
+                vref: VarRef::new("foo", VarType::Auto),
+                pos: lc(1, 2),
+            })])
+            .exp_error(CallError::ArgumentError(lc(1, 2), "Undefined array foo".to_owned()))
+            .check();
+    }
+
+    #[test]
+    fn test_one_required_ref_array_disallow_value() {
+        Tester::default()
+            .syntax(
+                &[SingularArgSyntax::RequiredRef(
+                    RequiredRefSyntax { name: "ref", require_array: true, define_undefined: false },
+                    ArgSepSyntax::End,
+                )],
+                None,
+            )
+            .compile_function([Expr::Integer(IntegerSpan { value: 5, pos: lc(1, 2) })])
+            .exp_error(CallError::ArgumentError(
+                lc(1, 2),
+                "Requires an array reference, not a value".to_owned(),
+            ))
+            .check();
+    }
+
+    #[test]
+    fn test_one_required_ref_array_wrong_type() {
+        Tester::default()
+            .symbol("foo", SymbolPrototype::Variable(ExprType::Text))
+            .syntax(
+                &[SingularArgSyntax::RequiredRef(
+                    RequiredRefSyntax { name: "ref", require_array: true, define_undefined: false },
+                    ArgSepSyntax::End,
+                )],
+                None,
+            )
+            .compile_function([Expr::Symbol(SymbolSpan {
+                vref: VarRef::new("foo", VarType::Auto),
+                pos: lc(1, 2),
+            })])
+            .exp_error(CallError::ArgumentError(
+                lc(1, 2),
+                "foo is not an array reference".to_owned(),
+            ))
+            .check();
+    }
+
+    #[test]
+    fn test_one_required_ref_array_wrong_annotation() {
+        Tester::default()
+            .symbol("foo", SymbolPrototype::Array(ExprType::Text, 0))
+            .syntax(
+                &[SingularArgSyntax::RequiredRef(
+                    RequiredRefSyntax { name: "ref", require_array: true, define_undefined: false },
+                    ArgSepSyntax::End,
+                )],
+                None,
+            )
+            .compile_function([Expr::Symbol(SymbolSpan {
+                vref: VarRef::new("foo", VarType::Integer),
+                pos: lc(1, 2),
+            })])
+            .exp_error(CallError::ArgumentError(
+                lc(1, 2),
+                "Incompatible type annotation in foo% reference".to_owned(),
+            ))
+            .check();
+    }
+
+    #[test]
+    fn test_multiple_any_value_ok() {
+        Tester::default()
+            .syntax(
+                &[
+                    SingularArgSyntax::AnyValue(
+                        AnyValueSyntax { name: "arg1", allow_missing: false },
+                        ArgSepSyntax::Exactly(ArgSep::Long),
+                    ),
+                    SingularArgSyntax::AnyValue(
+                        AnyValueSyntax { name: "arg2", allow_missing: false },
+                        ArgSepSyntax::Exactly(ArgSep::Long),
+                    ),
+                    SingularArgSyntax::AnyValue(
+                        AnyValueSyntax { name: "arg3", allow_missing: false },
+                        ArgSepSyntax::Exactly(ArgSep::Long),
+                    ),
+                    SingularArgSyntax::AnyValue(
+                        AnyValueSyntax { name: "arg4", allow_missing: false },
+                        ArgSepSyntax::End,
+                    ),
+                ],
+                None,
+            )
+            .compile_function([
+                Expr::Boolean(BooleanSpan { value: false, pos: lc(1, 2) }),
+                Expr::Double(DoubleSpan { value: 2.0, pos: lc(1, 3) }),
+                Expr::Integer(IntegerSpan { value: 3, pos: lc(1, 4) }),
+                Expr::Text(TextSpan { value: "foo".to_owned(), pos: lc(1, 5) }),
+            ])
+            .exp_instr(Instruction::Push(Value::Text("foo".to_owned()), lc(1, 5)))
+            .exp_instr(Instruction::Push(Value::Integer(ValueTag::Text as i32), lc(1, 5)))
+            .exp_instr(Instruction::Push(Value::Integer(3), lc(1, 4)))
+            .exp_instr(Instruction::Push(Value::Integer(ValueTag::Integer as i32), lc(1, 4)))
+            .exp_instr(Instruction::Push(Value::Double(2.0), lc(1, 3)))
+            .exp_instr(Instruction::Push(Value::Integer(ValueTag::Double as i32), lc(1, 3)))
+            .exp_instr(Instruction::Push(Value::Boolean(false), lc(1, 2)))
+            .exp_instr(Instruction::Push(Value::Integer(ValueTag::Boolean as i32), lc(1, 2)))
+            .exp_nargs(8)
+            .check();
+    }
+
+    #[test]
+    fn test_one_any_value_expr_error() {
+        Tester::default()
+            .symbol("foo", SymbolPrototype::Variable(ExprType::Double))
+            .syntax(
+                &[SingularArgSyntax::AnyValue(
+                    AnyValueSyntax { name: "arg1", allow_missing: false },
+                    ArgSepSyntax::End,
+                )],
+                None,
+            )
+            .compile_function([Expr::Symbol(SymbolSpan {
+                vref: VarRef::new("foo", VarType::Boolean),
+                pos: lc(1, 2),
+            })])
+            .exp_error(CallError::ArgumentError(
+                lc(1, 2),
+                "Incompatible type annotation in foo? reference".to_owned(),
+            ))
+            .check();
+    }
+
+    #[test]
+    fn test_repeated_none() {
+        Tester::default()
+            .syntax(
+                &[],
+                Some(&RepeatedSyntax {
+                    name: "arg",
+                    type_syn: RepeatedTypeSyntax::TypedValue(ExprType::Integer),
+                    sep: ArgSepSyntax::Exactly(ArgSep::Long),
+                    allow_missing: false,
+                    require_one: false,
+                }),
+            )
+            .compile_function([])
+            .exp_nargs(0)
+            .check();
+    }
+
+    #[test]
+    fn test_repeated_multiple_and_cast() {
+        Tester::default()
+            .syntax(
+                &[],
+                Some(&RepeatedSyntax {
+                    name: "arg",
+                    type_syn: RepeatedTypeSyntax::TypedValue(ExprType::Integer),
+                    sep: ArgSepSyntax::Exactly(ArgSep::Long),
+                    allow_missing: false,
+                    require_one: false,
+                }),
+            )
+            .compile_function([
+                Expr::Double(DoubleSpan { value: 3.0, pos: lc(1, 2) }),
+                Expr::Integer(IntegerSpan { value: 5, pos: lc(1, 4) }),
+            ])
+            .exp_instr(Instruction::Push(Value::Integer(5), lc(1, 4)))
+            .exp_instr(Instruction::Push(Value::Double(3.0), lc(1, 2)))
+            .exp_instr(Instruction::DoubleToInteger)
+            .exp_nargs(2)
+            .check();
+    }
+
+    #[test]
+    fn test_repeated_require_one_just_one() {
+        Tester::default()
+            .syntax(
+                &[],
+                Some(&RepeatedSyntax {
+                    name: "arg",
+                    type_syn: RepeatedTypeSyntax::TypedValue(ExprType::Integer),
+                    sep: ArgSepSyntax::Exactly(ArgSep::Long),
+                    allow_missing: false,
+                    require_one: true,
+                }),
+            )
+            .compile_function([Expr::Integer(IntegerSpan { value: 5, pos: lc(1, 2) })])
+            .exp_instr(Instruction::Push(Value::Integer(5), lc(1, 2)))
+            .exp_nargs(1)
+            .check();
+    }
+
+    #[test]
+    fn test_repeated_require_one_missing() {
+        Tester::default()
+            .syntax(
+                &[],
+                Some(&RepeatedSyntax {
+                    name: "arg",
+                    type_syn: RepeatedTypeSyntax::TypedValue(ExprType::Integer),
+                    sep: ArgSepSyntax::Exactly(ArgSep::Long),
+                    allow_missing: false,
+                    require_one: true,
+                }),
+            )
+            .compile_function([])
+            .exp_error(CallError::SyntaxError)
+            .check();
+    }
+
+    #[test]
+    fn test_repeated_any_value() {
+        Tester::default()
+            .syntax(
+                &[],
+                Some(&RepeatedSyntax {
+                    name: "arg",
+                    type_syn: RepeatedTypeSyntax::AnyValue,
+                    sep: ArgSepSyntax::Exactly(ArgSep::Long),
+                    allow_missing: false,
+                    require_one: false,
+                }),
+            )
+            .compile_function([
+                Expr::Boolean(BooleanSpan { value: false, pos: lc(1, 2) }),
+                Expr::Double(DoubleSpan { value: 2.0, pos: lc(1, 4) }),
+                Expr::Integer(IntegerSpan { value: 3, pos: lc(1, 6) }),
+                Expr::Text(TextSpan { value: "foo".to_owned(), pos: lc(1, 8) }),
+            ])
+            .exp_instr(Instruction::Push(Value::Text("foo".to_owned()), lc(1, 8)))
+            .exp_instr(Instruction::Push(Value::Integer(ValueTag::Text as i32), lc(1, 8)))
+            .exp_instr(Instruction::Push(Value::Integer(3), lc(1, 6)))
+            .exp_instr(Instruction::Push(Value::Integer(ValueTag::Integer as i32), lc(1, 6)))
+            .exp_instr(Instruction::Push(Value::Double(2.0), lc(1, 4)))
+            .exp_instr(Instruction::Push(Value::Integer(ValueTag::Double as i32), lc(1, 4)))
+            .exp_instr(Instruction::Push(Value::Boolean(false), lc(1, 2)))
+            .exp_instr(Instruction::Push(Value::Integer(ValueTag::Boolean as i32), lc(1, 2)))
+            .exp_nargs(8)
+            .check();
+    }
+
+    #[test]
+    fn test_singular_and_repeated() {
+        Tester::default()
+            .syntax(
+                &[SingularArgSyntax::RequiredValue(
+                    RequiredValueSyntax { name: "arg", vtype: ExprType::Double },
+                    ArgSepSyntax::End,
+                )],
+                Some(&RepeatedSyntax {
+                    name: "rep",
+                    type_syn: RepeatedTypeSyntax::TypedValue(ExprType::Integer),
+                    sep: ArgSepSyntax::Exactly(ArgSep::Long),
+                    allow_missing: false,
+                    require_one: false,
+                }),
+            )
+            .compile_function([
+                Expr::Double(DoubleSpan { value: 4.0, pos: lc(1, 2) }),
+                Expr::Integer(IntegerSpan { value: 5, pos: lc(1, 5) }),
+                Expr::Integer(IntegerSpan { value: 6, pos: lc(1, 7) }),
+            ])
+            .exp_nargs(3)
+            .exp_instr(Instruction::Push(Value::Integer(6), lc(1, 7)))
+            .exp_instr(Instruction::Push(Value::Integer(5), lc(1, 5)))
+            .exp_instr(Instruction::Push(Value::Double(4.0), lc(1, 2)))
+            .check();
+    }
+}
+
+#[cfg(test)]
+mod command_tests {
+    use super::testutils::*;
+    use super::*;
+
+    #[test]
+    fn test_no_syntaxes_yields_error() {
+        Tester::default().compile_command([]).exp_error(CallError::SyntaxError).check();
+    }
+
+    #[test]
+    fn test_no_args_ok() {
+        Tester::default().syntax(&[], None).compile_command([]).check();
+    }
+
+    #[test]
+    fn test_no_args_mismatch() {
+        Tester::default()
+            .syntax(&[], None)
+            .compile_command([ArgSpan {
+                expr: Some(Expr::Integer(IntegerSpan { value: 3, pos: lc(1, 2) })),
+                sep: ArgSep::End,
+                sep_pos: lc(1, 3),
+            }])
+            .exp_error(CallError::SyntaxError)
+            .check();
+    }
+
+    #[test]
+    fn test_one_required_value_ok() {
+        Tester::default()
+            .syntax(
+                &[SingularArgSyntax::RequiredValue(
+                    RequiredValueSyntax { name: "arg1", vtype: ExprType::Integer },
+                    ArgSepSyntax::End,
+                )],
+                None,
+            )
+            .compile_command([ArgSpan {
+                expr: Some(Expr::Integer(IntegerSpan { value: 3, pos: lc(1, 2) })),
+                sep: ArgSep::End,
+                sep_pos: lc(1, 3),
+            }])
+            .exp_instr(Instruction::Push(Value::Integer(3), lc(1, 2)))
+            .exp_nargs(1)
+            .check();
+    }
+
+    #[test]
+    fn test_one_required_value_type_promotion() {
+        Tester::default()
+            .syntax(
+                &[SingularArgSyntax::RequiredValue(
+                    RequiredValueSyntax { name: "arg1", vtype: ExprType::Integer },
+                    ArgSepSyntax::End,
+                )],
+                None,
+            )
+            .compile_command([ArgSpan {
+                expr: Some(Expr::Double(DoubleSpan { value: 3.0, pos: lc(1, 2) })),
+                sep: ArgSep::End,
+                sep_pos: lc(1, 5),
+            }])
+            .exp_instr(Instruction::Push(Value::Double(3.0), lc(1, 2)))
+            .exp_instr(Instruction::DoubleToInteger)
+            .exp_nargs(1)
+            .check();
+    }
+
+    #[test]
+    fn test_one_required_ref_variable_ok() {
+        Tester::default()
+            .symbol("foo", SymbolPrototype::Variable(ExprType::Text))
+            .syntax(
+                &[SingularArgSyntax::RequiredRef(
+                    RequiredRefSyntax {
+                        name: "ref",
+                        require_array: false,
+                        define_undefined: false,
+                    },
+                    ArgSepSyntax::End,
+                )],
+                None,
+            )
+            .compile_command([ArgSpan {
+                expr: Some(Expr::Symbol(SymbolSpan {
+                    vref: VarRef::new("foo", VarType::Auto),
+                    pos: lc(1, 2),
+                })),
+                sep: ArgSep::End,
+                sep_pos: lc(1, 5),
+            }])
+            .exp_instr(Instruction::LoadRef(VarRef::new("foo", VarType::Auto), lc(1, 2)))
+            .exp_nargs(1)
+            .check();
+    }
+
+    #[test]
+    fn test_one_required_ref_variable_not_defined() {
+        Tester::default()
+            .syntax(
+                &[SingularArgSyntax::RequiredRef(
+                    RequiredRefSyntax {
+                        name: "ref",
+                        require_array: false,
+                        define_undefined: false,
+                    },
+                    ArgSepSyntax::End,
+                )],
+                None,
+            )
+            .compile_command([ArgSpan {
+                expr: Some(Expr::Symbol(SymbolSpan {
+                    vref: VarRef::new("foo", VarType::Auto),
+                    pos: lc(1, 2),
+                })),
+                sep: ArgSep::End,
+                sep_pos: lc(1, 5),
+            }])
+            .exp_error(CallError::ArgumentError(lc(1, 2), "Undefined variable foo".to_owned()))
+            .check();
+    }
+
+    #[test]
+    fn test_one_required_ref_variable_disallow_value() {
+        // Trust that the correspondig function test validates this same error path.
+    }
+
+    #[test]
+    fn test_one_required_ref_variable_wrong_type() {
+        // Trust that the correspondig function test validates this same error path.
+    }
+
+    #[test]
+    fn test_one_required_ref_variable_wrong_annotation() {
+        // Trust that the correspondig function test validates this same error path.
+    }
+
+    #[test]
+    fn test_one_required_ref_variable_define_undefined_default_type() {
+        Tester::default()
+            .syntax(
+                &[SingularArgSyntax::RequiredRef(
+                    RequiredRefSyntax { name: "ref", require_array: false, define_undefined: true },
+                    ArgSepSyntax::End,
+                )],
+                None,
+            )
+            .compile_command([ArgSpan {
+                expr: Some(Expr::Symbol(SymbolSpan {
+                    vref: VarRef::new("foo", VarType::Auto),
+                    pos: lc(1, 2),
+                })),
+                sep: ArgSep::End,
+                sep_pos: lc(1, 5),
+            }])
+            .exp_instr(Instruction::LoadRef(VarRef::new("foo", VarType::Auto), lc(1, 2)))
+            .exp_nargs(1)
+            .exp_symbol("foo", ExprType::Integer)
+            .check();
+    }
+
+    #[test]
+    fn test_one_required_ref_variable_define_undefined_explicit_type() {
+        Tester::default()
+            .syntax(
+                &[SingularArgSyntax::RequiredRef(
+                    RequiredRefSyntax { name: "ref", require_array: false, define_undefined: true },
+                    ArgSepSyntax::End,
+                )],
+                None,
+            )
+            .compile_command([ArgSpan {
+                expr: Some(Expr::Symbol(SymbolSpan {
+                    vref: VarRef::new("foo", VarType::Text),
+                    pos: lc(1, 2),
+                })),
+                sep: ArgSep::End,
+                sep_pos: lc(1, 6),
+            }])
+            .exp_instr(Instruction::LoadRef(VarRef::new("foo", VarType::Text), lc(1, 2)))
+            .exp_nargs(1)
+            .exp_symbol("foo", ExprType::Text)
+            .check();
+    }
+
+    #[test]
+    fn test_one_required_ref_array_ok() {
+        // Trust that the correspondig function test validates this same error path.
+    }
+
+    #[test]
+    fn test_one_required_ref_array_not_defined() {
+        // Trust that the correspondig function test validates this same error path.
+    }
+
+    #[test]
+    fn test_one_required_ref_array_disallow_value() {
+        // Trust that the correspondig function test validates this same error path.
+    }
+
+    #[test]
+    fn test_one_required_ref_array_wrong_type() {
+        // Trust that the correspondig function test validates this same error path.
+    }
+
+    #[test]
+    fn test_one_required_ref_array_wrong_annotation() {
+        // Trust that the correspondig function test validates this same error path.
+    }
+
+    #[test]
+    fn test_one_optional_value_ok_is_present() {
+        Tester::default()
+            .syntax(
+                &[SingularArgSyntax::OptionalValue(
+                    OptionalValueSyntax {
+                        name: "ref",
+                        vtype: ExprType::Double,
+                        missing_value: 10,
+                        present_value: 20,
+                    },
+                    ArgSepSyntax::End,
+                )],
+                None,
+            )
+            .compile_command([ArgSpan {
+                expr: Some(Expr::Double(DoubleSpan { value: 3.0, pos: lc(1, 2) })),
+                sep: ArgSep::End,
+                sep_pos: lc(1, 5),
+            }])
+            .exp_instr(Instruction::Push(Value::Double(3.0), lc(1, 2)))
+            .exp_instr(Instruction::Push(Value::Integer(20), lc(1, 2)))
+            .exp_nargs(2)
+            .check();
+    }
+
+    #[test]
+    fn test_one_optional_value_ok_is_missing() {
+        Tester::default()
+            .syntax(
+                &[SingularArgSyntax::OptionalValue(
+                    OptionalValueSyntax {
+                        name: "ref",
+                        vtype: ExprType::Double,
+                        missing_value: 10,
+                        present_value: 20,
+                    },
+                    ArgSepSyntax::End,
+                )],
+                None,
+            )
+            .compile_command([ArgSpan { expr: None, sep: ArgSep::End, sep_pos: lc(1, 2) }])
+            .exp_instr(Instruction::Push(Value::Integer(10), lc(1, 2)))
+            .exp_nargs(1)
+            .check();
+    }
+
+    #[test]
+    fn test_multiple_any_value_ok() {
+        Tester::default()
+            .syntax(
+                &[
+                    SingularArgSyntax::AnyValue(
+                        AnyValueSyntax { name: "arg1", allow_missing: false },
+                        ArgSepSyntax::Exactly(ArgSep::Long),
+                    ),
+                    SingularArgSyntax::AnyValue(
+                        AnyValueSyntax { name: "arg2", allow_missing: false },
+                        ArgSepSyntax::Exactly(ArgSep::Long),
+                    ),
+                    SingularArgSyntax::AnyValue(
+                        AnyValueSyntax { name: "arg3", allow_missing: false },
+                        ArgSepSyntax::Exactly(ArgSep::Long),
+                    ),
+                    SingularArgSyntax::AnyValue(
+                        AnyValueSyntax { name: "arg4", allow_missing: false },
+                        ArgSepSyntax::End,
+                    ),
+                ],
+                None,
+            )
+            .compile_command([
+                ArgSpan {
+                    expr: Some(Expr::Boolean(BooleanSpan { value: false, pos: lc(1, 2) })),
+                    sep: ArgSep::Long,
+                    sep_pos: lc(1, 3),
+                },
+                ArgSpan {
+                    expr: Some(Expr::Double(DoubleSpan { value: 2.0, pos: lc(1, 4) })),
+                    sep: ArgSep::Long,
+                    sep_pos: lc(1, 5),
+                },
+                ArgSpan {
+                    expr: Some(Expr::Integer(IntegerSpan { value: 3, pos: lc(1, 6) })),
+                    sep: ArgSep::Long,
+                    sep_pos: lc(1, 7),
+                },
+                ArgSpan {
+                    expr: Some(Expr::Text(TextSpan { value: "foo".to_owned(), pos: lc(1, 8) })),
+                    sep: ArgSep::End,
+                    sep_pos: lc(1, 9),
+                },
+            ])
+            .exp_instr(Instruction::Push(Value::Text("foo".to_owned()), lc(1, 8)))
+            .exp_instr(Instruction::Push(Value::Integer(ValueTag::Text as i32), lc(1, 8)))
+            .exp_instr(Instruction::Push(Value::Integer(3), lc(1, 6)))
+            .exp_instr(Instruction::Push(Value::Integer(ValueTag::Integer as i32), lc(1, 6)))
+            .exp_instr(Instruction::Push(Value::Double(2.0), lc(1, 4)))
+            .exp_instr(Instruction::Push(Value::Integer(ValueTag::Double as i32), lc(1, 4)))
+            .exp_instr(Instruction::Push(Value::Boolean(false), lc(1, 2)))
+            .exp_instr(Instruction::Push(Value::Integer(ValueTag::Boolean as i32), lc(1, 2)))
+            .exp_nargs(8)
+            .check();
+    }
+
+    #[test]
+    fn test_one_any_value_expr_error() {
+        Tester::default()
+            .symbol("foo", SymbolPrototype::Variable(ExprType::Double))
+            .syntax(
+                &[SingularArgSyntax::AnyValue(
+                    AnyValueSyntax { name: "arg1", allow_missing: false },
+                    ArgSepSyntax::End,
+                )],
+                None,
+            )
+            .compile_command([ArgSpan {
+                expr: Some(Expr::Symbol(SymbolSpan {
+                    vref: VarRef::new("foo", VarType::Boolean),
+                    pos: lc(1, 2),
+                })),
+                sep: ArgSep::End,
+                sep_pos: lc(1, 3),
+            }])
+            .exp_error(CallError::ArgumentError(
+                lc(1, 2),
+                "Incompatible type annotation in foo? reference".to_owned(),
+            ))
+            .check();
+    }
+
+    #[test]
+    fn test_one_any_value_disallow_missing() {
+        Tester::default()
+            .symbol("foo", SymbolPrototype::Variable(ExprType::Double))
+            .syntax(
+                &[SingularArgSyntax::AnyValue(
+                    AnyValueSyntax { name: "arg1", allow_missing: false },
+                    ArgSepSyntax::End,
+                )],
+                None,
+            )
+            .compile_command([ArgSpan { expr: None, sep: ArgSep::End, sep_pos: lc(1, 3) }])
+            .exp_error(CallError::ArgumentError(
+                lc(1, 3),
+                "Missing expression before separator".to_owned(),
+            ))
+            .check();
+    }
+
+    #[test]
+    fn test_one_any_value_allow_missing() {
+        Tester::default()
+            .syntax(
+                &[SingularArgSyntax::AnyValue(
+                    AnyValueSyntax { name: "arg1", allow_missing: true },
+                    ArgSepSyntax::End,
+                )],
+                None,
+            )
+            .compile_command([ArgSpan { expr: None, sep: ArgSep::End, sep_pos: lc(1, 3) }])
+            .exp_instr(Instruction::Push(Value::Integer(ValueTag::Missing as i32), lc(1, 3)))
+            .exp_nargs(1)
+            .check();
+    }
+
+    #[test]
+    fn test_multiple_separator_types_ok() {
+        Tester::default()
+            .syntax(
+                &[
+                    SingularArgSyntax::AnyValue(
+                        AnyValueSyntax { name: "arg1", allow_missing: true },
+                        ArgSepSyntax::Exactly(ArgSep::As),
+                    ),
+                    SingularArgSyntax::AnyValue(
+                        AnyValueSyntax { name: "arg2", allow_missing: true },
+                        ArgSepSyntax::OneOf(ArgSep::Long, ArgSep::Short),
+                    ),
+                    SingularArgSyntax::AnyValue(
+                        AnyValueSyntax { name: "arg3", allow_missing: true },
+                        ArgSepSyntax::OneOf(ArgSep::Long, ArgSep::Short),
+                    ),
+                    SingularArgSyntax::AnyValue(
+                        AnyValueSyntax { name: "arg4", allow_missing: true },
+                        ArgSepSyntax::End,
+                    ),
+                ],
+                None,
+            )
+            .compile_command([
+                ArgSpan { expr: None, sep: ArgSep::As, sep_pos: lc(1, 1) },
+                ArgSpan { expr: None, sep: ArgSep::Long, sep_pos: lc(1, 2) },
+                ArgSpan { expr: None, sep: ArgSep::Short, sep_pos: lc(1, 3) },
+                ArgSpan { expr: None, sep: ArgSep::End, sep_pos: lc(1, 4) },
+            ])
+            .exp_instr(Instruction::Push(Value::Integer(ValueTag::Missing as i32), lc(1, 4)))
+            .exp_instr(Instruction::Push(Value::Integer(ArgSep::Short as i32), lc(1, 3)))
+            .exp_instr(Instruction::Push(Value::Integer(ValueTag::Missing as i32), lc(1, 3)))
+            .exp_instr(Instruction::Push(Value::Integer(ArgSep::Long as i32), lc(1, 2)))
+            .exp_instr(Instruction::Push(Value::Integer(ValueTag::Missing as i32), lc(1, 2)))
+            .exp_instr(Instruction::Push(Value::Integer(ValueTag::Missing as i32), lc(1, 1)))
+            .exp_nargs(6)
+            .check();
+    }
+
+    #[test]
+    fn test_multiple_separator_exactly_mismatch() {
+        Tester::default()
+            .syntax(
+                &[
+                    SingularArgSyntax::AnyValue(
+                        AnyValueSyntax { name: "arg1", allow_missing: true },
+                        ArgSepSyntax::Exactly(ArgSep::As),
+                    ),
+                    SingularArgSyntax::AnyValue(
+                        AnyValueSyntax { name: "arg2", allow_missing: true },
+                        ArgSepSyntax::End,
+                    ),
+                ],
+                None,
+            )
+            .compile_command([
+                ArgSpan { expr: None, sep: ArgSep::Short, sep_pos: lc(1, 1) },
+                ArgSpan { expr: None, sep: ArgSep::End, sep_pos: lc(1, 4) },
+            ])
+            .exp_error(CallError::SyntaxError)
+            .check();
+    }
+
+    #[test]
+    fn test_multiple_separator_oneof_mismatch() {
+        Tester::default()
+            .syntax(
+                &[
+                    SingularArgSyntax::AnyValue(
+                        AnyValueSyntax { name: "arg1", allow_missing: true },
+                        ArgSepSyntax::OneOf(ArgSep::Short, ArgSep::Long),
+                    ),
+                    SingularArgSyntax::AnyValue(
+                        AnyValueSyntax { name: "arg2", allow_missing: true },
+                        ArgSepSyntax::End,
+                    ),
+                ],
+                None,
+            )
+            .compile_command([
+                ArgSpan { expr: None, sep: ArgSep::As, sep_pos: lc(1, 1) },
+                ArgSpan { expr: None, sep: ArgSep::End, sep_pos: lc(1, 4) },
+            ])
+            .exp_error(CallError::SyntaxError)
+            .check();
+    }
+
+    #[test]
+    fn test_repeated_none() {
+        Tester::default()
+            .syntax(
+                &[],
+                Some(&RepeatedSyntax {
+                    name: "arg",
+                    type_syn: RepeatedTypeSyntax::TypedValue(ExprType::Integer),
+                    sep: ArgSepSyntax::Exactly(ArgSep::Long),
+                    allow_missing: false,
+                    require_one: false,
+                }),
+            )
+            .compile_command([])
+            .exp_nargs(0)
+            .check();
+    }
+
+    #[test]
+    fn test_repeated_multiple_and_cast() {
+        Tester::default()
+            .syntax(
+                &[],
+                Some(&RepeatedSyntax {
+                    name: "arg",
+                    type_syn: RepeatedTypeSyntax::TypedValue(ExprType::Integer),
+                    sep: ArgSepSyntax::Exactly(ArgSep::Long),
+                    allow_missing: false,
+                    require_one: false,
+                }),
+            )
+            .compile_command([
+                ArgSpan {
+                    expr: Some(Expr::Double(DoubleSpan { value: 3.0, pos: lc(1, 2) })),
+                    sep: ArgSep::Long,
+                    sep_pos: lc(1, 2),
+                },
+                ArgSpan {
+                    expr: Some(Expr::Integer(IntegerSpan { value: 5, pos: lc(1, 4) })),
+                    sep: ArgSep::End,
+                    sep_pos: lc(1, 3),
+                },
+            ])
+            .exp_instr(Instruction::Push(Value::Integer(5), lc(1, 4)))
+            .exp_instr(Instruction::Push(Value::Double(3.0), lc(1, 2)))
+            .exp_instr(Instruction::DoubleToInteger)
+            .exp_nargs(2)
+            .check();
+    }
+
+    #[test]
+    fn test_repeated_require_one_just_one() {
+        Tester::default()
+            .syntax(
+                &[],
+                Some(&RepeatedSyntax {
+                    name: "arg",
+                    type_syn: RepeatedTypeSyntax::TypedValue(ExprType::Integer),
+                    sep: ArgSepSyntax::Exactly(ArgSep::Long),
+                    allow_missing: false,
+                    require_one: true,
+                }),
+            )
+            .compile_command([ArgSpan {
+                expr: Some(Expr::Integer(IntegerSpan { value: 5, pos: lc(1, 2) })),
+                sep: ArgSep::End,
+                sep_pos: lc(1, 2),
+            }])
+            .exp_instr(Instruction::Push(Value::Integer(5), lc(1, 2)))
+            .exp_nargs(1)
+            .check();
+    }
+
+    #[test]
+    fn test_repeated_require_one_missing() {
+        Tester::default()
+            .syntax(
+                &[],
+                Some(&RepeatedSyntax {
+                    name: "arg",
+                    type_syn: RepeatedTypeSyntax::TypedValue(ExprType::Integer),
+                    sep: ArgSepSyntax::Exactly(ArgSep::Long),
+                    allow_missing: false,
+                    require_one: true,
+                }),
+            )
+            .compile_command([])
+            .exp_error(CallError::SyntaxError)
+            .check();
+    }
+
+    #[test]
+    fn test_repeated_require_one_ref_ok() {
+        Tester::default()
+            .syntax(
+                &[],
+                Some(&RepeatedSyntax {
+                    name: "arg",
+                    type_syn: RepeatedTypeSyntax::VariableRef,
+                    sep: ArgSepSyntax::Exactly(ArgSep::Long),
+                    allow_missing: false,
+                    require_one: true,
+                }),
+            )
+            .compile_command([ArgSpan {
+                expr: Some(Expr::Symbol(SymbolSpan {
+                    vref: VarRef::new("foo", VarType::Text),
+                    pos: lc(1, 2),
+                })),
+                sep: ArgSep::End,
+                sep_pos: lc(1, 2),
+            }])
+            .exp_instr(Instruction::LoadRef(VarRef::new("foo", VarType::Text), lc(1, 2)))
+            .exp_nargs(1)
+            .check();
+    }
+
+    #[test]
+    fn test_repeated_require_one_ref_error() {
+        Tester::default()
+            .syntax(
+                &[],
+                Some(&RepeatedSyntax {
+                    name: "arg",
+                    type_syn: RepeatedTypeSyntax::VariableRef,
+                    sep: ArgSepSyntax::Exactly(ArgSep::Long),
+                    allow_missing: false,
+                    require_one: true,
+                }),
+            )
+            .compile_command([ArgSpan {
+                expr: Some(Expr::Integer(IntegerSpan { value: 5, pos: lc(1, 2) })),
+                sep: ArgSep::End,
+                sep_pos: lc(1, 2),
+            }])
+            .exp_error(CallError::ArgumentError(
+                lc(1, 2),
+                "Requires a variable reference, not a value".to_owned(),
+            ))
+            .check();
+    }
+
+    #[test]
+    fn test_repeated_oneof_separator() {
+        Tester::default()
+            .syntax(
+                &[],
+                Some(&RepeatedSyntax {
+                    name: "arg",
+                    type_syn: RepeatedTypeSyntax::TypedValue(ExprType::Double),
+                    sep: ArgSepSyntax::OneOf(ArgSep::Long, ArgSep::Short),
+                    allow_missing: false,
+                    require_one: false,
+                }),
+            )
+            .compile_command([
+                ArgSpan {
+                    expr: Some(Expr::Double(DoubleSpan { value: 3.0, pos: lc(1, 2) })),
+                    sep: ArgSep::Short,
+                    sep_pos: lc(1, 3),
+                },
+                ArgSpan {
+                    expr: Some(Expr::Double(DoubleSpan { value: 5.0, pos: lc(1, 4) })),
+                    sep: ArgSep::Long,
+                    sep_pos: lc(1, 5),
+                },
+                ArgSpan {
+                    expr: Some(Expr::Double(DoubleSpan { value: 2.0, pos: lc(1, 6) })),
+                    sep: ArgSep::End,
+                    sep_pos: lc(1, 7),
+                },
+            ])
+            .exp_instr(Instruction::Push(Value::Double(2.0), lc(1, 6)))
+            .exp_instr(Instruction::Push(Value::Integer(ArgSep::Long as i32), lc(1, 5)))
+            .exp_instr(Instruction::Push(Value::Double(5.0), lc(1, 4)))
+            .exp_instr(Instruction::Push(Value::Integer(ArgSep::Short as i32), lc(1, 3)))
+            .exp_instr(Instruction::Push(Value::Double(3.0), lc(1, 2)))
+            .exp_nargs(5)
+            .check();
+    }
+
+    #[test]
+    fn test_repeated_oneof_separator_and_missing_in_last_position() {
+        Tester::default()
+            .syntax(
+                &[],
+                Some(&RepeatedSyntax {
+                    name: "arg",
+                    type_syn: RepeatedTypeSyntax::TypedValue(ExprType::Double),
+                    sep: ArgSepSyntax::OneOf(ArgSep::Long, ArgSep::Short),
+                    allow_missing: true,
+                    require_one: false,
+                }),
+            )
+            .compile_command([
+                ArgSpan {
+                    expr: Some(Expr::Double(DoubleSpan { value: 3.0, pos: lc(1, 2) })),
+                    sep: ArgSep::Short,
+                    sep_pos: lc(1, 3),
+                },
+                ArgSpan { expr: None, sep: ArgSep::End, sep_pos: lc(1, 4) },
+            ])
+            .exp_instr(Instruction::Push(Value::Integer(ValueTag::Missing as i32), lc(1, 4)))
+            .exp_instr(Instruction::Push(Value::Integer(ArgSep::Short as i32), lc(1, 3)))
+            .exp_instr(Instruction::Push(Value::Double(3.0), lc(1, 2)))
+            .exp_instr(Instruction::Push(Value::Integer(ValueTag::Double as i32), lc(1, 2)))
+            .exp_nargs(4)
+            .check();
+    }
+
+    #[test]
+    fn test_repeated_any_value() {
+        Tester::default()
+            .syntax(
+                &[],
+                Some(&RepeatedSyntax {
+                    name: "arg",
+                    type_syn: RepeatedTypeSyntax::AnyValue,
+                    sep: ArgSepSyntax::Exactly(ArgSep::Long),
+                    allow_missing: true,
+                    require_one: false,
+                }),
+            )
+            .compile_command([
+                ArgSpan {
+                    expr: Some(Expr::Boolean(BooleanSpan { value: false, pos: lc(1, 2) })),
+                    sep: ArgSep::Long,
+                    sep_pos: lc(1, 3),
+                },
+                ArgSpan {
+                    expr: Some(Expr::Double(DoubleSpan { value: 2.0, pos: lc(1, 4) })),
+                    sep: ArgSep::Long,
+                    sep_pos: lc(1, 5),
+                },
+                ArgSpan {
+                    expr: Some(Expr::Integer(IntegerSpan { value: 3, pos: lc(1, 6) })),
+                    sep: ArgSep::Long,
+                    sep_pos: lc(1, 7),
+                },
+                ArgSpan {
+                    expr: Some(Expr::Text(TextSpan { value: "foo".to_owned(), pos: lc(1, 8) })),
+                    sep: ArgSep::Long,
+                    sep_pos: lc(1, 9),
+                },
+                ArgSpan { expr: None, sep: ArgSep::End, sep_pos: lc(1, 10) },
+            ])
+            .exp_instr(Instruction::Push(Value::Integer(ValueTag::Missing as i32), lc(1, 10)))
+            .exp_instr(Instruction::Push(Value::Text("foo".to_owned()), lc(1, 8)))
+            .exp_instr(Instruction::Push(Value::Integer(ValueTag::Text as i32), lc(1, 8)))
+            .exp_instr(Instruction::Push(Value::Integer(3), lc(1, 6)))
+            .exp_instr(Instruction::Push(Value::Integer(ValueTag::Integer as i32), lc(1, 6)))
+            .exp_instr(Instruction::Push(Value::Double(2.0), lc(1, 4)))
+            .exp_instr(Instruction::Push(Value::Integer(ValueTag::Double as i32), lc(1, 4)))
+            .exp_instr(Instruction::Push(Value::Boolean(false), lc(1, 2)))
+            .exp_instr(Instruction::Push(Value::Integer(ValueTag::Boolean as i32), lc(1, 2)))
+            .exp_nargs(9)
+            .check();
+    }
+
+    #[test]
+    fn test_singular_and_repeated() {
+        Tester::default()
+            .syntax(
+                &[SingularArgSyntax::RequiredValue(
+                    RequiredValueSyntax { name: "arg", vtype: ExprType::Double },
+                    ArgSepSyntax::Exactly(ArgSep::Short),
+                )],
+                Some(&RepeatedSyntax {
+                    name: "rep",
+                    type_syn: RepeatedTypeSyntax::TypedValue(ExprType::Integer),
+                    sep: ArgSepSyntax::Exactly(ArgSep::Long),
+                    allow_missing: false,
+                    require_one: false,
+                }),
+            )
+            .compile_command([
+                ArgSpan {
+                    expr: Some(Expr::Double(DoubleSpan { value: 4.0, pos: lc(1, 2) })),
+                    sep: ArgSep::Short,
+                    sep_pos: lc(1, 2),
+                },
+                ArgSpan {
+                    expr: Some(Expr::Integer(IntegerSpan { value: 5, pos: lc(1, 5) })),
+                    sep: ArgSep::Long,
+                    sep_pos: lc(1, 2),
+                },
+                ArgSpan {
+                    expr: Some(Expr::Integer(IntegerSpan { value: 6, pos: lc(1, 7) })),
+                    sep: ArgSep::End,
+                    sep_pos: lc(1, 2),
+                },
+            ])
+            .exp_nargs(3)
+            .exp_instr(Instruction::Push(Value::Integer(6), lc(1, 7)))
+            .exp_instr(Instruction::Push(Value::Integer(5), lc(1, 5)))
+            .exp_instr(Instruction::Push(Value::Double(4.0), lc(1, 2)))
+            .check();
     }
 }

--- a/core/src/compiler/exprs.rs
+++ b/core/src/compiler/exprs.rs
@@ -18,6 +18,7 @@
 use super::{Error, ExprType, Result, SymbolPrototype, SymbolsTable};
 use crate::ast::*;
 use crate::bytecode::*;
+use crate::compiler::compile_function_args;
 use crate::reader::LineCol;
 use crate::syms::SymbolKey;
 
@@ -383,9 +384,7 @@ fn compile_expr_symbol(
                 ));
             }
 
-            let nargs = md
-                .args_compiler()
-                .compile_simple(instrs, symtable, span.pos, vec![])
+            let nargs = compile_function_args(md.syntaxes(), instrs, symtable, span.pos, vec![])
                 .map_err(|e| Error::from_call_error(md, e, span.pos))?;
             debug_assert_eq!(0, nargs, "Argless compiler must have returned zero arguments");
             (Instruction::FunctionCall(key, md.return_type(), span.pos, 0), md.return_type().into())
@@ -734,10 +733,9 @@ pub fn compile_expr(
                     }
 
                     let span_pos = span.pos;
-                    let nargs = md
-                        .args_compiler()
-                        .compile_simple(instrs, symtable, span_pos, span.args)
-                        .map_err(|e| Error::from_call_error(md, e, span_pos))?;
+                    let nargs =
+                        compile_function_args(md.syntaxes(), instrs, symtable, span_pos, span.args)
+                            .map_err(|e| Error::from_call_error(md, e, span_pos))?;
                     instrs.push(Instruction::FunctionCall(key, md.return_type(), span_pos, nargs));
                     Ok(vtype)
                 }

--- a/core/src/compiler/exprs.rs
+++ b/core/src/compiler/exprs.rs
@@ -826,15 +826,13 @@ mod tests {
     #[test]
     fn test_compile_expr_argless_call_not_argless() {
         Tester::default()
-            .define_callable(CallableMetadataBuilder::new("F", VarType::Integer).with_typed_syntax(
-                &[(
-                    &[SingularArgSyntax::RequiredValue(
-                        RequiredValueSyntax { name: "i", vtype: ExprType::Integer },
-                        ArgSepSyntax::End,
-                    )],
-                    None,
+            .define_callable(CallableMetadataBuilder::new("F", VarType::Integer).with_syntax(&[(
+                &[SingularArgSyntax::RequiredValue(
+                    RequiredValueSyntax { name: "i", vtype: ExprType::Integer },
+                    ArgSepSyntax::End,
                 )],
-            ))
+                None,
+            )]))
             .parse("i = f")
             .compile()
             .expect_err("1:5: In call to f: function requires arguments")
@@ -844,19 +842,13 @@ mod tests {
     #[test]
     fn test_compile_expr_ref_argless_not_allowed() {
         Tester::default()
-            .define_callable(CallableMetadataBuilder::new("C", VarType::Void).with_typed_syntax(&[
-                (
-                    &[SingularArgSyntax::RequiredRef(
-                        RequiredRefSyntax {
-                            name: "x",
-                            require_array: false,
-                            define_undefined: false,
-                        },
-                        ArgSepSyntax::End,
-                    )],
-                    None,
-                ),
-            ]))
+            .define_callable(CallableMetadataBuilder::new("C", VarType::Void).with_syntax(&[(
+                &[SingularArgSyntax::RequiredRef(
+                    RequiredRefSyntax { name: "x", require_array: false, define_undefined: false },
+                    ArgSepSyntax::End,
+                )],
+                None,
+            )]))
             .define_callable(CallableMetadataBuilder::new("F", VarType::Integer))
             .parse("c f")
             .compile()
@@ -886,19 +878,13 @@ mod tests {
     #[test]
     fn test_compile_expr_ref_bad_annotation_in_varref() {
         Tester::default()
-            .define_callable(CallableMetadataBuilder::new("C", VarType::Void).with_typed_syntax(&[
-                (
-                    &[SingularArgSyntax::RequiredRef(
-                        RequiredRefSyntax {
-                            name: "x",
-                            require_array: false,
-                            define_undefined: false,
-                        },
-                        ArgSepSyntax::End,
-                    )],
-                    None,
-                ),
-            ]))
+            .define_callable(CallableMetadataBuilder::new("C", VarType::Void).with_syntax(&[(
+                &[SingularArgSyntax::RequiredRef(
+                    RequiredRefSyntax { name: "x", require_array: false, define_undefined: false },
+                    ArgSepSyntax::End,
+                )],
+                None,
+            )]))
             .parse("a = 3: c a$")
             .compile()
             .expect_err("1:8: In call to C: 1:10: Incompatible type annotation in a$ reference")
@@ -908,19 +894,13 @@ mod tests {
     #[test]
     fn test_compile_expr_ref_bad_annotation_in_argless_call() {
         Tester::default()
-            .define_callable(CallableMetadataBuilder::new("C", VarType::Void).with_typed_syntax(&[
-                (
-                    &[SingularArgSyntax::RequiredRef(
-                        RequiredRefSyntax {
-                            name: "x",
-                            require_array: false,
-                            define_undefined: false,
-                        },
-                        ArgSepSyntax::End,
-                    )],
-                    None,
-                ),
-            ]))
+            .define_callable(CallableMetadataBuilder::new("C", VarType::Void).with_syntax(&[(
+                &[SingularArgSyntax::RequiredRef(
+                    RequiredRefSyntax { name: "x", require_array: false, define_undefined: false },
+                    ArgSepSyntax::End,
+                )],
+                None,
+            )]))
             .define_callable(CallableMetadataBuilder::new("F", VarType::Integer))
             .parse("c f$")
             .compile()
@@ -942,19 +922,13 @@ mod tests {
     fn test_compile_expr_ref_try_load_array_as_var() {
         Tester::default()
             .define(SymbolKey::from("a"), SymbolPrototype::Array(ExprType::Integer, 1))
-            .define_callable(CallableMetadataBuilder::new("C", VarType::Void).with_typed_syntax(&[
-                (
-                    &[SingularArgSyntax::RequiredRef(
-                        RequiredRefSyntax {
-                            name: "x",
-                            require_array: true,
-                            define_undefined: false,
-                        },
-                        ArgSepSyntax::End,
-                    )],
-                    None,
-                ),
-            ]))
+            .define_callable(CallableMetadataBuilder::new("C", VarType::Void).with_syntax(&[(
+                &[SingularArgSyntax::RequiredRef(
+                    RequiredRefSyntax { name: "x", require_array: true, define_undefined: false },
+                    ArgSepSyntax::End,
+                )],
+                None,
+            )]))
             .parse("c a")
             .compile()
             .expect_instr(0, Instruction::LoadRef(VarRef::new("a", VarType::Auto), lc(1, 3)))
@@ -975,19 +949,13 @@ mod tests {
     #[test]
     fn test_compile_expr_ref_try_load_command_as_var() {
         Tester::default()
-            .define_callable(CallableMetadataBuilder::new("C", VarType::Void).with_typed_syntax(&[
-                (
-                    &[SingularArgSyntax::RequiredRef(
-                        RequiredRefSyntax {
-                            name: "x",
-                            require_array: false,
-                            define_undefined: false,
-                        },
-                        ArgSepSyntax::End,
-                    )],
-                    None,
-                ),
-            ]))
+            .define_callable(CallableMetadataBuilder::new("C", VarType::Void).with_syntax(&[(
+                &[SingularArgSyntax::RequiredRef(
+                    RequiredRefSyntax { name: "x", require_array: false, define_undefined: false },
+                    ArgSepSyntax::End,
+                )],
+                None,
+            )]))
             .parse("c c")
             .compile()
             .expect_err("1:1: In call to C: 1:3: c is not an array nor a function")
@@ -1220,8 +1188,8 @@ mod tests {
     #[test]
     fn test_compile_expr_function_call() {
         Tester::default()
-            .define_callable(
-                CallableMetadataBuilder::new("FOO", VarType::Integer).with_typed_syntax(&[(
+            .define_callable(CallableMetadataBuilder::new("FOO", VarType::Integer).with_syntax(&[
+                (
                     &[],
                     Some(&RepeatedSyntax {
                         name: "expr",
@@ -1230,8 +1198,8 @@ mod tests {
                         require_one: true,
                         allow_missing: false,
                     }),
-                )]),
-            )
+                ),
+            ]))
             .define("j", SymbolPrototype::Variable(ExprType::Integer))
             .define("k", SymbolPrototype::Variable(ExprType::Double))
             .parse("i = FOO(3, j, k + 1)")

--- a/core/src/compiler/mod.rs
+++ b/core/src/compiler/mod.rs
@@ -1411,18 +1411,16 @@ mod tests {
     #[test]
     fn test_compile_builtin_call_increments_next_pc() {
         Tester::default()
-            .define_callable(CallableMetadataBuilder::new("CMD", VarType::Void).with_typed_syntax(
-                &[(
-                    &[],
-                    Some(&RepeatedSyntax {
-                        name: "expr",
-                        type_syn: RepeatedTypeSyntax::TypedValue(ExprType::Integer),
-                        sep: ArgSepSyntax::Exactly(ArgSep::Long),
-                        require_one: false,
-                        allow_missing: false,
-                    }),
-                )],
-            ))
+            .define_callable(CallableMetadataBuilder::new("CMD", VarType::Void).with_syntax(&[(
+                &[],
+                Some(&RepeatedSyntax {
+                    name: "expr",
+                    type_syn: RepeatedTypeSyntax::TypedValue(ExprType::Integer),
+                    sep: ArgSepSyntax::Exactly(ArgSep::Long),
+                    require_one: false,
+                    allow_missing: false,
+                }),
+            )]))
             .parse("IF TRUE THEN: CMD 1, 2: END IF")
             .compile()
             .expect_instr(0, Instruction::Push(Value::Boolean(true), lc(1, 4)))

--- a/core/src/compiler/mod.rs
+++ b/core/src/compiler/mod.rs
@@ -22,6 +22,8 @@ use crate::syms::CallError;
 use crate::syms::CallableMetadata;
 use crate::syms::{Symbol, SymbolKey, Symbols};
 use std::collections::HashMap;
+#[cfg(test)]
+use std::collections::HashSet;
 use std::fmt;
 
 mod args;
@@ -103,6 +105,15 @@ impl ExprType {
     /// Returns true if this expression type is numerical.
     fn is_numerical(self) -> bool {
         self == Self::Double || self == Self::Integer
+    }
+
+    pub(crate) fn annotation(&self) -> char {
+        match self {
+            ExprType::Boolean => '?',
+            ExprType::Double => '#',
+            ExprType::Integer => '%',
+            ExprType::Text => '$',
+        }
     }
 }
 
@@ -290,6 +301,12 @@ impl SymbolsTable {
     fn remove(&mut self, key: SymbolKey) {
         let previous = self.table.remove(&key);
         assert!(previous.is_some(), "Cannot unset a non-existing symbol");
+    }
+
+    /// Returns a view of the keys in the symbols table.
+    #[cfg(test)]
+    fn keys(&self) -> HashSet<&SymbolKey> {
+        self.table.keys().collect()
     }
 }
 

--- a/core/src/exec.rs
+++ b/core/src/exec.rs
@@ -2524,7 +2524,7 @@ mod tests {
             100 OUT GETHIDDEN("0ERRMSG")
             "#,
             &[],
-            &["1", "4:17: In call to RAISEF: expected arg1$"],
+            &["1", "4:17: In call to RAISEF: expected arg$"],
         );
     }
 
@@ -2540,7 +2540,7 @@ mod tests {
             OUT GETHIDDEN("0ERRMSG")
             "#,
             &[],
-            &["1", "4:17: In call to RAISEF: expected arg1$"],
+            &["1", "4:17: In call to RAISEF: expected arg$"],
         );
     }
 
@@ -2558,7 +2558,7 @@ mod tests {
             "#,
             &[],
             &["1", "2"],
-            "8:17: In call to RAISEF: expected arg1$",
+            "8:17: In call to RAISEF: expected arg$",
         );
     }
 
@@ -2572,7 +2572,7 @@ mod tests {
             OUT GETHIDDEN("0ERRMSG")
             "#,
             &[],
-            &["1", "4:17: In call to RAISEF: expected arg1$"],
+            &["1", "4:17: In call to RAISEF: expected arg$"],
         );
     }
 
@@ -2586,7 +2586,7 @@ mod tests {
             OUT GETHIDDEN("0ERRMSG")
             "#,
             &[],
-            &["1", "4:13: In call to RAISE: expected arg1$"],
+            &["1", "4:13: In call to RAISE: expected arg$"],
         );
     }
 
@@ -2598,7 +2598,7 @@ mod tests {
             OUT 1: OUT RAISEF("syntax"): OUT GETHIDDEN("0ERRMSG")
             "#,
             &[],
-            &["1", "3:24: In call to RAISEF: expected arg1$"],
+            &["1", "3:24: In call to RAISEF: expected arg$"],
         );
     }
 
@@ -2610,7 +2610,7 @@ mod tests {
             OUT 1: RAISE "syntax": OUT GETHIDDEN("0ERRMSG")
             "#,
             &[],
-            &["1", "3:20: In call to RAISE: expected arg1$"],
+            &["1", "3:20: In call to RAISE: expected arg$"],
         );
     }
 
@@ -2643,7 +2643,7 @@ mod tests {
         do_ok_test(
             r#"ON ERROR RESUME NEXT: OUT RAISEF("syntax"): OUT GETHIDDEN("0ERRMSG")"#,
             &[],
-            &["1:27: In call to RAISEF: expected arg1$"],
+            &["1:27: In call to RAISEF: expected arg$"],
         );
     }
 

--- a/core/src/exec.rs
+++ b/core/src/exec.rs
@@ -300,6 +300,22 @@ impl<'s> Scope<'s> {
         }
     }
 
+    /// Pops the top of the stack as a separator tag.
+    pub fn pop_sep_tag(&mut self) -> ArgSep {
+        const END_I32: i32 = ArgSep::End as i32;
+        const SHORT_I32: i32 = ArgSep::Short as i32;
+        const LONG_I32: i32 = ArgSep::Long as i32;
+        const AS_I32: i32 = ArgSep::As as i32;
+
+        match self.pop_integer() {
+            END_I32 => ArgSep::End,
+            SHORT_I32 => ArgSep::Short,
+            LONG_I32 => ArgSep::Long,
+            AS_I32 => ArgSep::As,
+            _ => unreachable!(),
+        }
+    }
+
     /// Pops the top of the stack as a string value.
     pub fn pop_string(&mut self) -> String {
         self.pop_string_with_pos().0

--- a/core/src/syms.rs
+++ b/core/src/syms.rs
@@ -579,10 +579,9 @@ impl CallableMetadataBuilder {
             syntax: self.syntax.unwrap_or("".to_owned()),
             category: self.category.unwrap_or(""),
             description: self.description.unwrap_or(""),
-            args_compiler: self
-                .args_compiler
-                .take()
-                .expect("All callables must specify an arguments parser"),
+            args_compiler: self.args_compiler.take().unwrap_or_else(|| {
+                Rc::from(ArgsCompiler::new(vec![CallableSyntax::new(&[], None)]))
+            }),
         }
     }
 }

--- a/core/src/syms.rs
+++ b/core/src/syms.rs
@@ -494,7 +494,7 @@ impl CallableMetadataBuilder {
     }
 
     /// Sets the syntax specifications for this callable.
-    pub fn with_typed_syntax(
+    pub fn with_syntax(
         mut self,
         syntaxes: &'static [(&'static [SingularArgSyntax], Option<&'static RepeatedSyntax>)],
     ) -> Self {
@@ -517,15 +517,6 @@ impl CallableMetadataBuilder {
         self
     }
 
-    /// Sets the syntax specification for this callable.  The `syntax` is provided as a free-form
-    /// string that is expected to use whatever representation suits the function best.
-    // TODO(jmmv): This is now deprecated in favor of `with_typed_syntax`.
-    pub fn with_syntax(mut self, syntax: &'static str) -> Self {
-        assert!(syntax != "()", "No arguments should be expressed as an empty syntax definition");
-        self.syntax = Some(syntax.to_owned());
-        self
-    }
-
     /// Sets the category for this callable.  All callables with the same category name will be
     /// grouped together in help messages.
     pub fn with_category(mut self, category: &'static str) -> Self {
@@ -542,16 +533,6 @@ impl CallableMetadataBuilder {
             assert!(!l.is_empty(), "Description cannot contain empty lines");
         }
         self.description = Some(description);
-        self
-    }
-
-    /// Sets the arguments compiler for this callable.
-    // TODO(jmmv): This is now deprecated in favor of `with_typed_syntax`.
-    pub fn with_args_compiler<T: CallableArgsCompiler + 'static>(
-        mut self,
-        args_compiler: T,
-    ) -> Self {
-        self.args_compiler = Some(Rc::from(args_compiler));
         self
     }
 

--- a/core/src/syms.rs
+++ b/core/src/syms.rs
@@ -17,7 +17,7 @@
 
 use crate::ast::{Value, VarRef, VarType};
 use crate::compiler::{self, CallableArgsCompiler};
-use crate::exec::Machine;
+use crate::exec::{Machine, Scope};
 use crate::reader::LineCol;
 use crate::value::{Error, Result};
 use async_trait::async_trait;
@@ -638,7 +638,7 @@ pub trait Callable {
     /// `args` contains the arguments to the function call.
     ///
     /// `machine` provides mutable access to the current state of the machine invoking the function.
-    async fn exec(&self, args: Vec<(Value, LineCol)>, machine: &mut Machine) -> CallResult;
+    async fn exec(&self, scope: Scope<'_>, machine: &mut Machine) -> CallResult;
 }
 
 #[cfg(test)]

--- a/core/src/testutils.rs
+++ b/core/src/testutils.rs
@@ -41,8 +41,6 @@ fn format_value(v: Value, o: &mut String) {
         Value::Boolean(false) => o.push_str("FALSE"),
         Value::Double(d) => o.push_str(&format!("{}", d)),
         Value::Integer(i) => o.push_str(&format!("{}", i)),
-        Value::Missing => panic!("Should never try to format missing arguments in tests"),
-        Value::Separator(s) => o.push_str(&format!("{:?}", s)),
         Value::Text(s) => o.push_str(&s),
         Value::VarRef(v) => o.push_str(&format!("{}", v)),
         Value::Void => panic!("Should never try to format void in tests"),

--- a/core/src/testutils.rs
+++ b/core/src/testutils.rs
@@ -42,7 +42,7 @@ impl ArglessFunction {
     pub fn new(value: Value) -> Rc<Self> {
         Rc::from(Self {
             metadata: CallableMetadataBuilder::new("ARGLESS", value.as_vartype())
-                .with_typed_syntax(&[(&[], None)])
+                .with_syntax(&[(&[], None)])
                 .test_build(),
             value,
         })
@@ -70,7 +70,7 @@ impl ClearCommand {
     pub(crate) fn new() -> Rc<Self> {
         Rc::from(Self {
             metadata: CallableMetadataBuilder::new("CLEAR", VarType::Void)
-                .with_typed_syntax(&[(&[], None)])
+                .with_syntax(&[(&[], None)])
                 .test_build(),
         })
     }
@@ -99,7 +99,7 @@ impl CountFunction {
     pub(crate) fn new() -> Rc<Self> {
         Rc::from(Self {
             metadata: CallableMetadataBuilder::new("COUNT", VarType::Integer)
-                .with_typed_syntax(&[(&[], None)])
+                .with_syntax(&[(&[], None)])
                 .test_build(),
             counter: Rc::from(RefCell::from(0)),
         })
@@ -130,7 +130,7 @@ impl RaisefFunction {
     pub fn new() -> Rc<Self> {
         Rc::from(Self {
             metadata: CallableMetadataBuilder::new("RAISEF", VarType::Boolean)
-                .with_typed_syntax(&[(
+                .with_syntax(&[(
                     &[SingularArgSyntax::RequiredValue(
                         RequiredValueSyntax { name: "arg", vtype: ExprType::Text },
                         ArgSepSyntax::End,
@@ -171,7 +171,7 @@ impl RaiseCommand {
     pub fn new() -> Rc<Self> {
         Rc::from(Self {
             metadata: CallableMetadataBuilder::new("RAISE", VarType::Void)
-                .with_typed_syntax(&[(
+                .with_syntax(&[(
                     &[SingularArgSyntax::RequiredValue(
                         RequiredValueSyntax { name: "arg", vtype: ExprType::Text },
                         ArgSepSyntax::End,
@@ -213,7 +213,7 @@ impl GetHiddenFunction {
     pub(crate) fn new() -> Rc<Self> {
         Rc::from(Self {
             metadata: CallableMetadataBuilder::new("GETHIDDEN", VarType::Text)
-                .with_typed_syntax(&[(
+                .with_syntax(&[(
                     &[SingularArgSyntax::RequiredValue(
                         RequiredValueSyntax { name: "varname", vtype: ExprType::Text },
                         ArgSepSyntax::End,
@@ -252,7 +252,7 @@ impl GetDataCommand {
     pub(crate) fn new(data: Rc<RefCell<Vec<Option<Value>>>>) -> Rc<Self> {
         Rc::from(Self {
             metadata: CallableMetadataBuilder::new("GETDATA", VarType::Void)
-                .with_typed_syntax(&[(&[], None)])
+                .with_syntax(&[(&[], None)])
                 .test_build(),
             data,
         })
@@ -286,7 +286,7 @@ impl InCommand {
     pub fn new(data: Box<RefCell<dyn Iterator<Item = &'static &'static str>>>) -> Rc<Self> {
         Rc::from(Self {
             metadata: CallableMetadataBuilder::new("IN", VarType::Void)
-                .with_typed_syntax(&[(
+                .with_syntax(&[(
                     &[SingularArgSyntax::RequiredRef(
                         RequiredRefSyntax {
                             name: "vref",
@@ -336,7 +336,7 @@ impl OutCommand {
     pub fn new(data: Rc<RefCell<Vec<String>>>) -> Rc<Self> {
         Rc::from(Self {
             metadata: CallableMetadataBuilder::new("OUT", VarType::Void)
-                .with_typed_syntax(&[(
+                .with_syntax(&[(
                     &[],
                     Some(&RepeatedSyntax {
                         name: "arg",
@@ -410,7 +410,7 @@ impl OutfFunction {
     pub fn new(data: Rc<RefCell<Vec<String>>>) -> Rc<Self> {
         Rc::from(Self {
             metadata: CallableMetadataBuilder::new("OUTF", VarType::Integer)
-                .with_typed_syntax(&[(
+                .with_syntax(&[(
                     &[],
                     Some(&RepeatedSyntax {
                         name: "expr",
@@ -463,7 +463,7 @@ impl SumFunction {
     pub fn new() -> Rc<Self> {
         Rc::from(Self {
             metadata: CallableMetadataBuilder::new("SUM", VarType::Integer)
-                .with_typed_syntax(&[(
+                .with_syntax(&[(
                     &[],
                     Some(&RepeatedSyntax {
                         name: "n",
@@ -547,7 +547,7 @@ impl TypeCheckFunction {
     pub fn new(value: Value) -> Rc<Self> {
         Rc::from(Self {
             metadata: CallableMetadataBuilder::new("TYPE_CHECK", VarType::Boolean)
-                .with_typed_syntax(&[(&[], None)])
+                .with_syntax(&[(&[], None)])
                 .test_build(),
             value,
         })

--- a/core/src/value.rs
+++ b/core/src/value.rs
@@ -609,21 +609,6 @@ mod tests {
     }
 
     #[test]
-    fn test_value_to_text_and_parse() {
-        let v = Boolean(false);
-        assert_eq!(v.clone(), Value::parse_as(VarType::Boolean, v.to_text()).unwrap());
-
-        let v = Double(-10.1);
-        assert_eq!(v.clone(), Value::parse_as(VarType::Double, v.to_text()).unwrap());
-
-        let v = Integer(-9);
-        assert_eq!(v.clone(), Value::parse_as(VarType::Integer, v.to_text()).unwrap());
-
-        let v = Text("Some long text".to_owned());
-        assert_eq!(v.clone(), Value::parse_as(VarType::Text, v.to_text()).unwrap());
-    }
-
-    #[test]
     fn test_value_display_and_parse() {
         let v = Boolean(false);
         assert_eq!(v, Value::parse_as(VarType::Boolean, format!("{}", v)).unwrap());

--- a/std/src/arrays.rs
+++ b/std/src/arrays.rs
@@ -91,7 +91,7 @@ impl LboundFunction {
     pub fn new() -> Rc<Self> {
         Rc::from(Self {
             metadata: CallableMetadataBuilder::new("LBOUND", VarType::Integer)
-                .with_typed_syntax(&[
+                .with_syntax(&[
                     (
                         &[SingularArgSyntax::RequiredRef(
                             RequiredRefSyntax {
@@ -156,7 +156,7 @@ impl UboundFunction {
     pub fn new() -> Rc<Self> {
         Rc::from(Self {
             metadata: CallableMetadataBuilder::new("UBOUND", VarType::Integer)
-                .with_typed_syntax(&[
+                .with_syntax(&[
                     (
                         &[SingularArgSyntax::RequiredRef(
                             RequiredRefSyntax {

--- a/std/src/console/cmds.rs
+++ b/std/src/console/cmds.rs
@@ -63,7 +63,7 @@ impl ClsCommand {
     pub fn new(console: Rc<RefCell<dyn Console>>) -> Rc<Self> {
         Rc::from(Self {
             metadata: CallableMetadataBuilder::new("CLS", VarType::Void)
-                .with_typed_syntax(&[(&[], None)])
+                .with_syntax(&[(&[], None)])
                 .with_category(CATEGORY)
                 .with_description("Clears the screen.")
                 .build(),
@@ -99,7 +99,7 @@ impl ColorCommand {
     pub fn new(console: Rc<RefCell<dyn Console>>) -> Rc<Self> {
         Rc::from(Self {
             metadata: CallableMetadataBuilder::new("COLOR", VarType::Void)
-                .with_typed_syntax(&[
+                .with_syntax(&[
                     (&[], None),
                     (
                         &[SingularArgSyntax::RequiredValue(
@@ -192,7 +192,7 @@ impl InKeyFunction {
     pub fn new(console: Rc<RefCell<dyn Console>>) -> Rc<Self> {
         Rc::from(Self {
             metadata: CallableMetadataBuilder::new("INKEY", VarType::Text)
-                .with_typed_syntax(&[(&[], None)])
+                .with_syntax(&[(&[], None)])
                 .with_category(CATEGORY)
                 .with_description(
                     "Checks for an available key press and returns it.
@@ -260,7 +260,7 @@ impl InputCommand {
     pub fn new(console: Rc<RefCell<dyn Console>>) -> Rc<Self> {
         Rc::from(Self {
             metadata: CallableMetadataBuilder::new("INPUT", VarType::Void)
-                .with_typed_syntax(&[
+                .with_syntax(&[
                     (
                         &[SingularArgSyntax::RequiredRef(
                             RequiredRefSyntax {
@@ -383,7 +383,7 @@ impl LocateCommand {
     pub fn new(console: Rc<RefCell<dyn Console>>) -> Rc<Self> {
         Rc::from(Self {
             metadata: CallableMetadataBuilder::new("LOCATE", VarType::Void)
-                .with_typed_syntax(&[(
+                .with_syntax(&[(
                     &[
                         SingularArgSyntax::RequiredValue(
                             RequiredValueSyntax { name: "column", vtype: ExprType::Integer },
@@ -454,7 +454,7 @@ impl PrintCommand {
     pub fn new(console: Rc<RefCell<dyn Console>>) -> Rc<Self> {
         Rc::from(Self {
             metadata: CallableMetadataBuilder::new("PRINT", VarType::Void)
-                .with_typed_syntax(&[(
+                .with_syntax(&[(
                     &[],
                     Some(&RepeatedSyntax {
                         name: "expr",
@@ -562,7 +562,7 @@ impl ScrColsFunction {
     pub fn new(console: Rc<RefCell<dyn Console>>) -> Rc<Self> {
         Rc::from(Self {
             metadata: CallableMetadataBuilder::new("SCRCOLS", VarType::Integer)
-                .with_typed_syntax(&[(&[], None)])
+                .with_syntax(&[(&[], None)])
                 .with_category(CATEGORY)
                 .with_description(
                     "Returns the number of columns in the text console.
@@ -598,7 +598,7 @@ impl ScrRowsFunction {
     pub fn new(console: Rc<RefCell<dyn Console>>) -> Rc<Self> {
         Rc::from(Self {
             metadata: CallableMetadataBuilder::new("SCRROWS", VarType::Integer)
-                .with_typed_syntax(&[(&[], None)])
+                .with_syntax(&[(&[], None)])
                 .with_category(CATEGORY)
                 .with_description(
                     "Returns the number of rows in the text console.

--- a/std/src/data.rs
+++ b/std/src/data.rs
@@ -47,7 +47,7 @@ impl ReadCommand {
     pub fn new(index: Rc<RefCell<usize>>) -> Rc<Self> {
         Rc::from(Self {
             metadata: CallableMetadataBuilder::new("READ", VarType::Void)
-                .with_typed_syntax(&[(
+                .with_syntax(&[(
                     &[],
                     Some(&RepeatedSyntax {
                         name: "vref",
@@ -147,7 +147,7 @@ impl RestoreCommand {
     pub fn new(index: Rc<RefCell<usize>>) -> Rc<Self> {
         Rc::from(Self {
             metadata: CallableMetadataBuilder::new("RESTORE", VarType::Void)
-                .with_typed_syntax(&[(&[], None)])
+                .with_syntax(&[(&[], None)])
                 .with_category(CATEGORY)
                 .with_description(
                     "Resets the index of the data element to be returned.

--- a/std/src/exec.rs
+++ b/std/src/exec.rs
@@ -41,7 +41,7 @@ impl ClearCommand {
     pub fn new() -> Rc<Self> {
         Rc::from(Self {
             metadata: CallableMetadataBuilder::new("CLEAR", VarType::Void)
-                .with_typed_syntax(&[(&[], None)])
+                .with_syntax(&[(&[], None)])
                 .with_category(CATEGORY)
                 .with_description(
                     "Restores initial machine state but keeps the stored program.
@@ -80,7 +80,7 @@ impl ErrmsgFunction {
     pub fn new() -> Rc<Self> {
         Rc::from(Self {
             metadata: CallableMetadataBuilder::new("ERRMSG", VarType::Text)
-                .with_typed_syntax(&[(&[], None)])
+                .with_syntax(&[(&[], None)])
                 .with_category(CATEGORY)
                 .with_description(
                     "Returns the last captured error message.
@@ -137,7 +137,7 @@ impl SleepCommand {
     pub fn new(sleep_fn: SleepFn) -> Rc<Self> {
         Rc::from(Self {
             metadata: CallableMetadataBuilder::new("SLEEP", VarType::Void)
-                .with_typed_syntax(&[(
+                .with_syntax(&[(
                     &[SingularArgSyntax::RequiredValue(
                         RequiredValueSyntax { name: "seconds", vtype: ExprType::Double },
                         ArgSepSyntax::End,

--- a/std/src/gfx.rs
+++ b/std/src/gfx.rs
@@ -75,7 +75,7 @@ impl GfxCircleCommand {
     pub fn new(console: Rc<RefCell<dyn Console>>) -> Rc<Self> {
         Rc::from(Self {
             metadata: CallableMetadataBuilder::new("GFX_CIRCLE", VarType::Void)
-                .with_typed_syntax(&[(
+                .with_syntax(&[(
                     &[
                         SingularArgSyntax::RequiredValue(
                             RequiredValueSyntax { name: "x", vtype: ExprType::Integer },
@@ -135,7 +135,7 @@ impl GfxCirclefCommand {
     pub fn new(console: Rc<RefCell<dyn Console>>) -> Rc<Self> {
         Rc::from(Self {
             metadata: CallableMetadataBuilder::new("GFX_CIRCLEF", VarType::Void)
-                .with_typed_syntax(&[(
+                .with_syntax(&[(
                     &[
                         SingularArgSyntax::RequiredValue(
                             RequiredValueSyntax { name: "x", vtype: ExprType::Integer },
@@ -194,7 +194,7 @@ impl GfxHeightFunction {
     pub fn new(console: Rc<RefCell<dyn Console>>) -> Rc<Self> {
         Rc::from(Self {
             metadata: CallableMetadataBuilder::new("GFX_HEIGHT", VarType::Integer)
-                .with_typed_syntax(&[(&[], None)])
+                .with_syntax(&[(&[], None)])
                 .with_category(CATEGORY)
                 .with_description(
                     "Returns the height in pixels of the graphical console.
@@ -230,7 +230,7 @@ impl GfxLineCommand {
     pub fn new(console: Rc<RefCell<dyn Console>>) -> Rc<Self> {
         Rc::from(Self {
             metadata: CallableMetadataBuilder::new("GFX_LINE", VarType::Void)
-                .with_typed_syntax(&[(
+                .with_syntax(&[(
                     &[
                         SingularArgSyntax::RequiredValue(
                             RequiredValueSyntax { name: "x1", vtype: ExprType::Integer },
@@ -294,7 +294,7 @@ impl GfxPixelCommand {
     pub fn new(console: Rc<RefCell<dyn Console>>) -> Rc<Self> {
         Rc::from(Self {
             metadata: CallableMetadataBuilder::new("GFX_PIXEL", VarType::Void)
-                .with_typed_syntax(&[(
+                .with_syntax(&[(
                     &[
                         SingularArgSyntax::RequiredValue(
                             RequiredValueSyntax { name: "x", vtype: ExprType::Integer },
@@ -347,7 +347,7 @@ impl GfxRectCommand {
     pub fn new(console: Rc<RefCell<dyn Console>>) -> Rc<Self> {
         Rc::from(Self {
             metadata: CallableMetadataBuilder::new("GFX_RECT", VarType::Void)
-                .with_typed_syntax(&[(
+                .with_syntax(&[(
                     &[
                         SingularArgSyntax::RequiredValue(
                             RequiredValueSyntax { name: "x1", vtype: ExprType::Integer },
@@ -412,7 +412,7 @@ impl GfxRectfCommand {
     pub fn new(console: Rc<RefCell<dyn Console>>) -> Rc<Self> {
         Rc::from(Self {
             metadata: CallableMetadataBuilder::new("GFX_RECTF", VarType::Void)
-                .with_typed_syntax(&[(
+                .with_syntax(&[(
                     &[
                         SingularArgSyntax::RequiredValue(
                             RequiredValueSyntax { name: "x1", vtype: ExprType::Integer },
@@ -476,7 +476,7 @@ impl GfxSyncCommand {
     pub fn new(console: Rc<RefCell<dyn Console>>) -> Rc<Self> {
         Rc::from(Self {
             metadata: CallableMetadataBuilder::new("GFX_SYNC", VarType::Void)
-                .with_typed_syntax(&[
+                .with_syntax(&[
                     (&[], None),
                     (
                         &[SingularArgSyntax::RequiredValue(
@@ -546,7 +546,7 @@ impl GfxWidthFunction {
     pub fn new(console: Rc<RefCell<dyn Console>>) -> Rc<Self> {
         Rc::from(Self {
             metadata: CallableMetadataBuilder::new("GFX_WIDTH", VarType::Integer)
-                .with_typed_syntax(&[(&[], None)])
+                .with_syntax(&[(&[], None)])
                 .with_category(CATEGORY)
                 .with_description(
                     "Returns the width in pixels of the graphical console.

--- a/std/src/gfx.rs
+++ b/std/src/gfx.rs
@@ -17,8 +17,8 @@
 
 use crate::console::{Console, PixelsXY};
 use async_trait::async_trait;
-use endbasic_core::ast::{Value, VarType};
-use endbasic_core::compiler::{ExprType, NoArgsCompiler, SameTypeArgsCompiler};
+use endbasic_core::ast::{ArgSep, Value, VarType};
+use endbasic_core::compiler::{ArgSepSyntax, ExprType, RequiredValueSyntax, SingularArgSyntax};
 use endbasic_core::exec::{Machine, Scope};
 use endbasic_core::syms::{
     CallError, CallResult, Callable, CallableMetadata, CallableMetadataBuilder,
@@ -75,8 +75,23 @@ impl GfxCircleCommand {
     pub fn new(console: Rc<RefCell<dyn Console>>) -> Rc<Self> {
         Rc::from(Self {
             metadata: CallableMetadataBuilder::new("GFX_CIRCLE", VarType::Void)
-                .with_syntax("x%, y%, r%")
-                .with_args_compiler(SameTypeArgsCompiler::new(3, 3, ExprType::Integer))
+                .with_typed_syntax(&[(
+                    &[
+                        SingularArgSyntax::RequiredValue(
+                            RequiredValueSyntax { name: "x", vtype: ExprType::Integer },
+                            ArgSepSyntax::Exactly(ArgSep::Long),
+                        ),
+                        SingularArgSyntax::RequiredValue(
+                            RequiredValueSyntax { name: "y", vtype: ExprType::Integer },
+                            ArgSepSyntax::Exactly(ArgSep::Long),
+                        ),
+                        SingularArgSyntax::RequiredValue(
+                            RequiredValueSyntax { name: "r", vtype: ExprType::Integer },
+                            ArgSepSyntax::End,
+                        ),
+                    ],
+                    None,
+                )])
                 .with_category(CATEGORY)
                 .with_description(
                     "Draws a circle of radius r centered at (x,y).
@@ -120,8 +135,23 @@ impl GfxCirclefCommand {
     pub fn new(console: Rc<RefCell<dyn Console>>) -> Rc<Self> {
         Rc::from(Self {
             metadata: CallableMetadataBuilder::new("GFX_CIRCLEF", VarType::Void)
-                .with_syntax("x%, y%, r%")
-                .with_args_compiler(SameTypeArgsCompiler::new(3, 3, ExprType::Integer))
+                .with_typed_syntax(&[(
+                    &[
+                        SingularArgSyntax::RequiredValue(
+                            RequiredValueSyntax { name: "x", vtype: ExprType::Integer },
+                            ArgSepSyntax::Exactly(ArgSep::Long),
+                        ),
+                        SingularArgSyntax::RequiredValue(
+                            RequiredValueSyntax { name: "y", vtype: ExprType::Integer },
+                            ArgSepSyntax::Exactly(ArgSep::Long),
+                        ),
+                        SingularArgSyntax::RequiredValue(
+                            RequiredValueSyntax { name: "r", vtype: ExprType::Integer },
+                            ArgSepSyntax::End,
+                        ),
+                    ],
+                    None,
+                )])
                 .with_category(CATEGORY)
                 .with_description(
                     "Draws a filled circle of radius r centered at (x,y).
@@ -164,8 +194,7 @@ impl GfxHeightFunction {
     pub fn new(console: Rc<RefCell<dyn Console>>) -> Rc<Self> {
         Rc::from(Self {
             metadata: CallableMetadataBuilder::new("GFX_HEIGHT", VarType::Integer)
-                .with_syntax("")
-                .with_args_compiler(NoArgsCompiler::default())
+                .with_typed_syntax(&[(&[], None)])
                 .with_category(CATEGORY)
                 .with_description(
                     "Returns the height in pixels of the graphical console.
@@ -201,8 +230,27 @@ impl GfxLineCommand {
     pub fn new(console: Rc<RefCell<dyn Console>>) -> Rc<Self> {
         Rc::from(Self {
             metadata: CallableMetadataBuilder::new("GFX_LINE", VarType::Void)
-                .with_syntax("x1%, y1%, x2%, y2%")
-                .with_args_compiler(SameTypeArgsCompiler::new(4, 4, ExprType::Integer))
+                .with_typed_syntax(&[(
+                    &[
+                        SingularArgSyntax::RequiredValue(
+                            RequiredValueSyntax { name: "x1", vtype: ExprType::Integer },
+                            ArgSepSyntax::Exactly(ArgSep::Long),
+                        ),
+                        SingularArgSyntax::RequiredValue(
+                            RequiredValueSyntax { name: "y1", vtype: ExprType::Integer },
+                            ArgSepSyntax::Exactly(ArgSep::Long),
+                        ),
+                        SingularArgSyntax::RequiredValue(
+                            RequiredValueSyntax { name: "x2", vtype: ExprType::Integer },
+                            ArgSepSyntax::Exactly(ArgSep::Long),
+                        ),
+                        SingularArgSyntax::RequiredValue(
+                            RequiredValueSyntax { name: "y2", vtype: ExprType::Integer },
+                            ArgSepSyntax::End,
+                        ),
+                    ],
+                    None,
+                )])
                 .with_category(CATEGORY)
                 .with_description(
                     "Draws a line from (x1,y1) to (x2,y2).
@@ -246,8 +294,19 @@ impl GfxPixelCommand {
     pub fn new(console: Rc<RefCell<dyn Console>>) -> Rc<Self> {
         Rc::from(Self {
             metadata: CallableMetadataBuilder::new("GFX_PIXEL", VarType::Void)
-                .with_syntax("x%, y%")
-                .with_args_compiler(SameTypeArgsCompiler::new(2, 2, ExprType::Integer))
+                .with_typed_syntax(&[(
+                    &[
+                        SingularArgSyntax::RequiredValue(
+                            RequiredValueSyntax { name: "x", vtype: ExprType::Integer },
+                            ArgSepSyntax::Exactly(ArgSep::Long),
+                        ),
+                        SingularArgSyntax::RequiredValue(
+                            RequiredValueSyntax { name: "y", vtype: ExprType::Integer },
+                            ArgSepSyntax::End,
+                        ),
+                    ],
+                    None,
+                )])
                 .with_category(CATEGORY)
                 .with_description(
                     "Draws a pixel at (x,y).
@@ -288,8 +347,27 @@ impl GfxRectCommand {
     pub fn new(console: Rc<RefCell<dyn Console>>) -> Rc<Self> {
         Rc::from(Self {
             metadata: CallableMetadataBuilder::new("GFX_RECT", VarType::Void)
-                .with_syntax("x1%, y1%, x2%, y2%")
-                .with_args_compiler(SameTypeArgsCompiler::new(4, 4, ExprType::Integer))
+                .with_typed_syntax(&[(
+                    &[
+                        SingularArgSyntax::RequiredValue(
+                            RequiredValueSyntax { name: "x1", vtype: ExprType::Integer },
+                            ArgSepSyntax::Exactly(ArgSep::Long),
+                        ),
+                        SingularArgSyntax::RequiredValue(
+                            RequiredValueSyntax { name: "y1", vtype: ExprType::Integer },
+                            ArgSepSyntax::Exactly(ArgSep::Long),
+                        ),
+                        SingularArgSyntax::RequiredValue(
+                            RequiredValueSyntax { name: "x2", vtype: ExprType::Integer },
+                            ArgSepSyntax::Exactly(ArgSep::Long),
+                        ),
+                        SingularArgSyntax::RequiredValue(
+                            RequiredValueSyntax { name: "y2", vtype: ExprType::Integer },
+                            ArgSepSyntax::End,
+                        ),
+                    ],
+                    None,
+                )])
                 .with_category(CATEGORY)
                 .with_description(
                     "Draws a rectangle from (x1,y1) to (x2,y2).
@@ -334,8 +412,27 @@ impl GfxRectfCommand {
     pub fn new(console: Rc<RefCell<dyn Console>>) -> Rc<Self> {
         Rc::from(Self {
             metadata: CallableMetadataBuilder::new("GFX_RECTF", VarType::Void)
-                .with_syntax("x1%, y1%, x2%, y2%")
-                .with_args_compiler(SameTypeArgsCompiler::new(4, 4, ExprType::Integer))
+                .with_typed_syntax(&[(
+                    &[
+                        SingularArgSyntax::RequiredValue(
+                            RequiredValueSyntax { name: "x1", vtype: ExprType::Integer },
+                            ArgSepSyntax::Exactly(ArgSep::Long),
+                        ),
+                        SingularArgSyntax::RequiredValue(
+                            RequiredValueSyntax { name: "y1", vtype: ExprType::Integer },
+                            ArgSepSyntax::Exactly(ArgSep::Long),
+                        ),
+                        SingularArgSyntax::RequiredValue(
+                            RequiredValueSyntax { name: "x2", vtype: ExprType::Integer },
+                            ArgSepSyntax::Exactly(ArgSep::Long),
+                        ),
+                        SingularArgSyntax::RequiredValue(
+                            RequiredValueSyntax { name: "y2", vtype: ExprType::Integer },
+                            ArgSepSyntax::End,
+                        ),
+                    ],
+                    None,
+                )])
                 .with_category(CATEGORY)
                 .with_description(
                     "Draws a filled rectangle from (x1,y1) to (x2,y2).
@@ -379,8 +476,16 @@ impl GfxSyncCommand {
     pub fn new(console: Rc<RefCell<dyn Console>>) -> Rc<Self> {
         Rc::from(Self {
             metadata: CallableMetadataBuilder::new("GFX_SYNC", VarType::Void)
-                .with_syntax("[enabled?]")
-                .with_args_compiler(SameTypeArgsCompiler::new(0, 1, ExprType::Boolean))
+                .with_typed_syntax(&[
+                    (&[], None),
+                    (
+                        &[SingularArgSyntax::RequiredValue(
+                            RequiredValueSyntax { name: "enabled", vtype: ExprType::Boolean },
+                            ArgSepSyntax::End,
+                        )],
+                        None,
+                    ),
+                ])
                 .with_category(CATEGORY)
                 .with_description(
                     "Controls the video syncing flag and/or forces a sync.
@@ -441,8 +546,7 @@ impl GfxWidthFunction {
     pub fn new(console: Rc<RefCell<dyn Console>>) -> Rc<Self> {
         Rc::from(Self {
             metadata: CallableMetadataBuilder::new("GFX_WIDTH", VarType::Integer)
-                .with_syntax("")
-                .with_args_compiler(NoArgsCompiler::default())
+                .with_typed_syntax(&[(&[], None)])
                 .with_category(CATEGORY)
                 .with_description(
                     "Returns the width in pixels of the graphical console.
@@ -774,7 +878,7 @@ mod tests {
     #[test]
     fn test_gfx_sync_errors() {
         check_stmt_compilation_err(
-            "1:1: In call to GFX_SYNC: expected [enabled?]",
+            "1:1: In call to GFX_SYNC: expected <> | <enabled?>",
             "GFX_SYNC 2, 3",
         );
         check_stmt_compilation_err(

--- a/std/src/gpio/mod.rs
+++ b/std/src/gpio/mod.rs
@@ -140,7 +140,7 @@ impl GpioSetupCommand {
     pub fn new(pins: Rc<RefCell<dyn Pins>>) -> Rc<Self> {
         Rc::from(Self {
             metadata: CallableMetadataBuilder::new("GPIO_SETUP", VarType::Void)
-                .with_typed_syntax(&[(
+                .with_syntax(&[(
                     &[
                         SingularArgSyntax::RequiredValue(
                             RequiredValueSyntax { name: "pin", vtype: ExprType::Integer },
@@ -206,7 +206,7 @@ impl GpioClearCommand {
     pub fn new(pins: Rc<RefCell<dyn Pins>>) -> Rc<Self> {
         Rc::from(Self {
             metadata: CallableMetadataBuilder::new("GPIO_CLEAR", VarType::Void)
-                .with_typed_syntax(&[
+                .with_syntax(&[
                     (&[], None),
                     (
                         &[SingularArgSyntax::RequiredValue(
@@ -269,7 +269,7 @@ impl GpioReadFunction {
     pub fn new(pins: Rc<RefCell<dyn Pins>>) -> Rc<Self> {
         Rc::from(Self {
             metadata: CallableMetadataBuilder::new("GPIO_READ", VarType::Boolean)
-                .with_typed_syntax(&[(
+                .with_syntax(&[(
                     &[SingularArgSyntax::RequiredValue(
                         RequiredValueSyntax { name: "pin", vtype: ExprType::Integer },
                         ArgSepSyntax::End,
@@ -319,7 +319,7 @@ impl GpioWriteCommand {
     pub fn new(pins: Rc<RefCell<dyn Pins>>) -> Rc<Self> {
         Rc::from(Self {
             metadata: CallableMetadataBuilder::new("GPIO_WRITE", VarType::Void)
-                .with_typed_syntax(&[(
+                .with_syntax(&[(
                     &[
                         SingularArgSyntax::RequiredValue(
                             RequiredValueSyntax { name: "pin", vtype: ExprType::Integer },

--- a/std/src/help.rs
+++ b/std/src/help.rs
@@ -411,7 +411,7 @@ impl HelpCommand {
     pub fn new(console: Rc<RefCell<dyn Console>>) -> Rc<Self> {
         Rc::from(Self {
             metadata: CallableMetadataBuilder::new("HELP", VarType::Void)
-                .with_typed_syntax(&[
+                .with_syntax(&[
                     (&[], None),
                     (
                         &[SingularArgSyntax::RequiredValue(
@@ -539,7 +539,7 @@ pub(crate) mod testutils {
         pub fn new_with_name(name: &'static str) -> Rc<Self> {
             Rc::from(Self {
                 metadata: CallableMetadataBuilder::new(name, VarType::Void)
-                    .with_typed_syntax(&[(
+                    .with_syntax(&[(
                         &[SingularArgSyntax::RequiredValue(
                             RequiredValueSyntax { name: "sample", vtype: ExprType::Text },
                             ArgSepSyntax::End,
@@ -586,7 +586,7 @@ Second paragraph of the extended description.",
         pub(crate) fn new_with_name(name: &'static str) -> Rc<Self> {
             Rc::from(Self {
                 metadata: CallableMetadataBuilder::new(name, VarType::Text)
-                    .with_typed_syntax(&[(
+                    .with_syntax(&[(
                         &[SingularArgSyntax::RequiredValue(
                             RequiredValueSyntax { name: "sample", vtype: ExprType::Text },
                             ArgSepSyntax::End,

--- a/std/src/numerics.rs
+++ b/std/src/numerics.rs
@@ -16,8 +16,11 @@
 //! Numerical functions for EndBASIC.
 
 use async_trait::async_trait;
-use endbasic_core::ast::{Value, VarType};
-use endbasic_core::compiler::{ExprType, NoArgsCompiler, SameTypeArgsCompiler};
+use endbasic_core::ast::{ArgSep, Value, VarType};
+use endbasic_core::compiler::{
+    ArgSepSyntax, ExprType, RepeatedSyntax, RepeatedTypeSyntax, RequiredValueSyntax,
+    SingularArgSyntax,
+};
 use endbasic_core::exec::{Clearable, Machine, Scope};
 use endbasic_core::syms::{
     CallError, CallResult, Callable, CallableMetadata, CallableMetadataBuilder, Symbols,
@@ -108,8 +111,13 @@ impl AtnFunction {
     pub fn new(angle_mode: Rc<RefCell<AngleMode>>) -> Rc<Self> {
         Rc::from(Self {
             metadata: CallableMetadataBuilder::new("ATN", VarType::Double)
-                .with_syntax("n<%|#>")
-                .with_args_compiler(SameTypeArgsCompiler::new(1, 1, ExprType::Double))
+                .with_typed_syntax(&[(
+                    &[SingularArgSyntax::RequiredValue(
+                        RequiredValueSyntax { name: "n", vtype: ExprType::Double },
+                        ArgSepSyntax::End,
+                    )],
+                    None,
+                )])
                 .with_category(CATEGORY)
                 .with_description(
                     "Computes the arc-tangent of a number.
@@ -149,8 +157,13 @@ impl CintFunction {
     pub fn new() -> Rc<Self> {
         Rc::from(Self {
             metadata: CallableMetadataBuilder::new("CINT", VarType::Integer)
-                .with_syntax("expr<%|#>")
-                .with_args_compiler(SameTypeArgsCompiler::new(1, 1, ExprType::Double))
+                .with_typed_syntax(&[(
+                    &[SingularArgSyntax::RequiredValue(
+                        RequiredValueSyntax { name: "expr", vtype: ExprType::Double },
+                        ArgSepSyntax::End,
+                    )],
+                    None,
+                )])
                 .with_category(CATEGORY)
                 .with_description(
                     "Casts the given numeric expression to an integer (with rounding).
@@ -191,8 +204,13 @@ impl CosFunction {
     pub fn new(angle_mode: Rc<RefCell<AngleMode>>) -> Rc<Self> {
         Rc::from(Self {
             metadata: CallableMetadataBuilder::new("COS", VarType::Double)
-                .with_syntax("angle<%|#>")
-                .with_args_compiler(SameTypeArgsCompiler::new(1, 1, ExprType::Double))
+                .with_typed_syntax(&[(
+                    &[SingularArgSyntax::RequiredValue(
+                        RequiredValueSyntax { name: "angle", vtype: ExprType::Double },
+                        ArgSepSyntax::End,
+                    )],
+                    None,
+                )])
                 .with_category(CATEGORY)
                 .with_description(
                     "Computes the cosine of an angle.
@@ -228,8 +246,7 @@ impl DegCommand {
     pub fn new(angle_mode: Rc<RefCell<AngleMode>>) -> Rc<Self> {
         Rc::from(Self {
             metadata: CallableMetadataBuilder::new("DEG", VarType::Void)
-                .with_syntax("")
-                .with_args_compiler(NoArgsCompiler::default())
+                .with_typed_syntax(&[(&[], None)])
                 .with_category(CATEGORY)
                 .with_description(
                     "Sets degrees mode of calculation.
@@ -265,8 +282,13 @@ impl IntFunction {
     pub fn new() -> Rc<Self> {
         Rc::from(Self {
             metadata: CallableMetadataBuilder::new("INT", VarType::Integer)
-                .with_syntax("expr<%|#>")
-                .with_args_compiler(SameTypeArgsCompiler::new(1, 1, ExprType::Double))
+                .with_typed_syntax(&[(
+                    &[SingularArgSyntax::RequiredValue(
+                        RequiredValueSyntax { name: "expr", vtype: ExprType::Double },
+                        ArgSepSyntax::End,
+                    )],
+                    None,
+                )])
                 .with_category(CATEGORY)
                 .with_description(
                     "Casts the given numeric expression to an integer (with truncation).
@@ -304,8 +326,16 @@ impl MaxFunction {
     pub fn new() -> Rc<Self> {
         Rc::from(Self {
             metadata: CallableMetadataBuilder::new("MAX", VarType::Double)
-                .with_syntax("expr<%|#>[, .., expr<%|#>]")
-                .with_args_compiler(SameTypeArgsCompiler::new(1, usize::MAX, ExprType::Double))
+                .with_typed_syntax(&[(
+                    &[],
+                    Some(&RepeatedSyntax {
+                        name: "expr",
+                        type_syn: RepeatedTypeSyntax::TypedValue(ExprType::Double),
+                        sep: ArgSepSyntax::Exactly(ArgSep::Long),
+                        require_one: true,
+                        allow_missing: false,
+                    }),
+                )])
                 .with_category(CATEGORY)
                 .with_description("Returns the maximum number out of a set of numbers.")
                 .build(),
@@ -341,8 +371,16 @@ impl MinFunction {
     pub fn new() -> Rc<Self> {
         Rc::from(Self {
             metadata: CallableMetadataBuilder::new("MIN", VarType::Double)
-                .with_syntax("expr<%|#>[, .., expr<%|#>]")
-                .with_args_compiler(SameTypeArgsCompiler::new(1, usize::MAX, ExprType::Double))
+                .with_typed_syntax(&[(
+                    &[],
+                    Some(&RepeatedSyntax {
+                        name: "expr",
+                        type_syn: RepeatedTypeSyntax::TypedValue(ExprType::Double),
+                        sep: ArgSepSyntax::Exactly(ArgSep::Long),
+                        require_one: true,
+                        allow_missing: false,
+                    }),
+                )])
                 .with_category(CATEGORY)
                 .with_description("Returns the minimum number out of a set of numbers.")
                 .build(),
@@ -378,8 +416,7 @@ impl PiFunction {
     pub fn new() -> Rc<Self> {
         Rc::from(Self {
             metadata: CallableMetadataBuilder::new("PI", VarType::Double)
-                .with_syntax("")
-                .with_args_compiler(NoArgsCompiler::default())
+                .with_typed_syntax(&[(&[], None)])
                 .with_category(CATEGORY)
                 .with_description("Returns the Archimedes' constant.")
                 .build(),
@@ -410,8 +447,7 @@ impl RadCommand {
     pub fn new(angle_mode: Rc<RefCell<AngleMode>>) -> Rc<Self> {
         Rc::from(Self {
             metadata: CallableMetadataBuilder::new("RAD", VarType::Void)
-                .with_syntax("")
-                .with_args_compiler(NoArgsCompiler::default())
+                .with_typed_syntax(&[(&[], None)])
                 .with_category(CATEGORY)
                 .with_description(
                     "Sets radians mode of calculation.
@@ -448,8 +484,16 @@ impl RandomizeCommand {
     pub fn new(prng: Rc<RefCell<Prng>>) -> Rc<Self> {
         Rc::from(Self {
             metadata: CallableMetadataBuilder::new("RANDOMIZE", VarType::Void)
-                .with_syntax("[seed%]")
-                .with_args_compiler(SameTypeArgsCompiler::new(0, 1, ExprType::Integer))
+                .with_typed_syntax(&[
+                    (&[], None),
+                    (
+                        &[SingularArgSyntax::RequiredValue(
+                            RequiredValueSyntax { name: "seed", vtype: ExprType::Integer },
+                            ArgSepSyntax::End,
+                        )],
+                        None,
+                    ),
+                ])
                 .with_category(CATEGORY)
                 .with_description(
                     "Reinitializes the pseudo-random number generator.
@@ -491,8 +535,16 @@ impl RndFunction {
     pub fn new(prng: Rc<RefCell<Prng>>) -> Rc<Self> {
         Rc::from(Self {
             metadata: CallableMetadataBuilder::new("RND", VarType::Double)
-                .with_syntax("[n%]")
-                .with_args_compiler(SameTypeArgsCompiler::new(0, 1, ExprType::Integer))
+                .with_typed_syntax(&[
+                    (&[], None),
+                    (
+                        &[SingularArgSyntax::RequiredValue(
+                            RequiredValueSyntax { name: "n", vtype: ExprType::Integer },
+                            ArgSepSyntax::End,
+                        )],
+                        None,
+                    ),
+                ])
                 .with_category(CATEGORY)
                 .with_description(
                     "Returns a random number in the [0..1] range.
@@ -542,8 +594,13 @@ impl SinFunction {
     pub fn new(angle_mode: Rc<RefCell<AngleMode>>) -> Rc<Self> {
         Rc::from(Self {
             metadata: CallableMetadataBuilder::new("SIN", VarType::Double)
-                .with_syntax("angle<%|#>")
-                .with_args_compiler(SameTypeArgsCompiler::new(1, 1, ExprType::Double))
+                .with_typed_syntax(&[(
+                    &[SingularArgSyntax::RequiredValue(
+                        RequiredValueSyntax { name: "angle", vtype: ExprType::Double },
+                        ArgSepSyntax::End,
+                    )],
+                    None,
+                )])
                 .with_category(CATEGORY)
                 .with_description(
                     "Computes the sine of an angle.
@@ -578,8 +635,13 @@ impl SqrFunction {
     pub fn new() -> Rc<Self> {
         Rc::from(Self {
             metadata: CallableMetadataBuilder::new("SQR", VarType::Double)
-                .with_syntax("num<%|#>")
-                .with_args_compiler(SameTypeArgsCompiler::new(1, 1, ExprType::Double))
+                .with_typed_syntax(&[(
+                    &[SingularArgSyntax::RequiredValue(
+                        RequiredValueSyntax { name: "num", vtype: ExprType::Double },
+                        ArgSepSyntax::End,
+                    )],
+                    None,
+                )])
                 .with_category(CATEGORY)
                 .with_description("Computes the square root of the given number.")
                 .build(),
@@ -618,8 +680,13 @@ impl TanFunction {
     pub fn new(angle_mode: Rc<RefCell<AngleMode>>) -> Rc<Self> {
         Rc::from(Self {
             metadata: CallableMetadataBuilder::new("TAN", VarType::Double)
-                .with_syntax("angle<%|#>")
-                .with_args_compiler(SameTypeArgsCompiler::new(1, 1, ExprType::Double))
+                .with_typed_syntax(&[(
+                    &[SingularArgSyntax::RequiredValue(
+                        RequiredValueSyntax { name: "angle", vtype: ExprType::Double },
+                        ArgSepSyntax::End,
+                    )],
+                    None,
+                )])
                 .with_category(CATEGORY)
                 .with_description(
                     "Computes the tangent of an angle.
@@ -676,12 +743,12 @@ mod tests {
 
         check_expr_ok_with_vars(123f64.atan(), "ATN(a)", [("a", 123i32.into())]);
 
-        check_expr_compilation_error("1:10: In call to ATN: expected n<%|#>", "ATN()");
+        check_expr_compilation_error("1:10: In call to ATN: expected n#", "ATN()");
         check_expr_compilation_error(
             "1:10: In call to ATN: 1:14: BOOLEAN is not a number",
             "ATN(FALSE)",
         );
-        check_expr_compilation_error("1:10: In call to ATN: expected n<%|#>", "ATN(3, 4)");
+        check_expr_compilation_error("1:10: In call to ATN: expected n#", "ATN(3, 4)");
     }
 
     #[test]
@@ -693,12 +760,12 @@ mod tests {
 
         check_expr_ok_with_vars(1, "CINT(d)", [("d", 0.9f64.into())]);
 
-        check_expr_compilation_error("1:10: In call to CINT: expected expr<%|#>", "CINT()");
+        check_expr_compilation_error("1:10: In call to CINT: expected expr#", "CINT()");
         check_expr_compilation_error(
             "1:10: In call to CINT: 1:15: BOOLEAN is not a number",
             "CINT(FALSE)",
         );
-        check_expr_compilation_error("1:10: In call to CINT: expected expr<%|#>", "CINT(3.0, 4)");
+        check_expr_compilation_error("1:10: In call to CINT: expected expr#", "CINT(3.0, 4)");
 
         check_expr_error(
             "1:10: In call to CINT: 1:15: Cannot cast -1234567890123456 to integer due to overflow",
@@ -713,12 +780,12 @@ mod tests {
 
         check_expr_ok_with_vars(123f64.cos(), "COS(i)", [("i", 123i32.into())]);
 
-        check_expr_compilation_error("1:10: In call to COS: expected angle<%|#>", "COS()");
+        check_expr_compilation_error("1:10: In call to COS: expected angle#", "COS()");
         check_expr_compilation_error(
             "1:10: In call to COS: 1:14: BOOLEAN is not a number",
             "COS(FALSE)",
         );
-        check_expr_compilation_error("1:10: In call to COS: expected angle<%|#>", "COS(3, 4)");
+        check_expr_compilation_error("1:10: In call to COS: expected angle#", "COS(3, 4)");
     }
 
     #[test]
@@ -752,12 +819,12 @@ mod tests {
 
         check_expr_ok_with_vars(0, "INT(d)", [("d", 0.9f64.into())]);
 
-        check_expr_compilation_error("1:10: In call to INT: expected expr<%|#>", "INT()");
+        check_expr_compilation_error("1:10: In call to INT: expected expr#", "INT()");
         check_expr_compilation_error(
             "1:10: In call to INT: 1:14: BOOLEAN is not a number",
             "INT(FALSE)",
         );
-        check_expr_compilation_error("1:10: In call to INT: expected expr<%|#>", "INT(3.0, 4)");
+        check_expr_compilation_error("1:10: In call to INT: expected expr#", "INT(3.0, 4)");
 
         check_expr_error(
             "1:10: In call to INT: 1:14: Cannot cast -1234567890123456 to integer due to overflow",
@@ -790,7 +857,7 @@ mod tests {
         );
 
         check_expr_compilation_error(
-            "1:10: In call to MAX: expected expr<%|#>[, .., expr<%|#>]",
+            "1:10: In call to MAX: expected expr1#[, .., exprN#]",
             "MAX()",
         );
         check_expr_compilation_error(
@@ -824,7 +891,7 @@ mod tests {
         );
 
         check_expr_compilation_error(
-            "1:10: In call to MIN: expected expr<%|#>[, .., expr<%|#>]",
+            "1:10: In call to MIN: expected expr1#[, .., exprN#]",
             "MIN()",
         );
         check_expr_compilation_error(
@@ -868,14 +935,17 @@ mod tests {
 
         t.run("result = RND(1)").expect_var("result", 0.7097578208683426).check();
 
-        check_expr_compilation_error("1:10: In call to RND: expected [n%]", "RND(1, 7)");
+        check_expr_compilation_error("1:10: In call to RND: expected <> | <n%>", "RND(1, 7)");
         check_expr_compilation_error(
             "1:10: In call to RND: 1:14: BOOLEAN is not a number",
             "RND(FALSE)",
         );
         check_expr_error("1:10: In call to RND: 1:14: n% cannot be negative", "RND(-1)");
 
-        check_stmt_compilation_err("1:1: In call to RANDOMIZE: expected [seed%]", "RANDOMIZE ,");
+        check_stmt_compilation_err(
+            "1:1: In call to RANDOMIZE: expected <> | <seed%>",
+            "RANDOMIZE ,",
+        );
         check_stmt_compilation_err(
             "1:1: In call to RANDOMIZE: 1:11: BOOLEAN is not a number",
             "RANDOMIZE TRUE",
@@ -889,12 +959,12 @@ mod tests {
 
         check_expr_ok_with_vars(123f64.sin(), "SIN(i)", [("i", 123i32.into())]);
 
-        check_expr_compilation_error("1:10: In call to SIN: expected angle<%|#>", "SIN()");
+        check_expr_compilation_error("1:10: In call to SIN: expected angle#", "SIN()");
         check_expr_compilation_error(
             "1:10: In call to SIN: 1:14: BOOLEAN is not a number",
             "SIN(FALSE)",
         );
-        check_expr_compilation_error("1:10: In call to SIN: expected angle<%|#>", "SIN(3, 4)");
+        check_expr_compilation_error("1:10: In call to SIN: expected angle#", "SIN(3, 4)");
     }
 
     #[test]
@@ -906,12 +976,12 @@ mod tests {
 
         check_expr_ok_with_vars(9f64.sqrt(), "SQR(i)", [("i", 9i32.into())]);
 
-        check_expr_compilation_error("1:10: In call to SQR: expected num<%|#>", "SQR()");
+        check_expr_compilation_error("1:10: In call to SQR: expected num#", "SQR()");
         check_expr_compilation_error(
             "1:10: In call to SQR: 1:14: BOOLEAN is not a number",
             "SQR(FALSE)",
         );
-        check_expr_compilation_error("1:10: In call to SQR: expected num<%|#>", "SQR(3, 4)");
+        check_expr_compilation_error("1:10: In call to SQR: expected num#", "SQR(3, 4)");
         check_expr_error(
             "1:10: In call to SQR: 1:14: Cannot take square root of a negative number",
             "SQR(-3)",
@@ -929,11 +999,11 @@ mod tests {
 
         check_expr_ok_with_vars(123f64.tan(), "TAN(i)", [("i", 123i32.into())]);
 
-        check_expr_compilation_error("1:10: In call to TAN: expected angle<%|#>", "TAN()");
+        check_expr_compilation_error("1:10: In call to TAN: expected angle#", "TAN()");
         check_expr_compilation_error(
             "1:10: In call to TAN: 1:14: BOOLEAN is not a number",
             "TAN(FALSE)",
         );
-        check_expr_compilation_error("1:10: In call to TAN: expected angle<%|#>", "TAN(3, 4)");
+        check_expr_compilation_error("1:10: In call to TAN: expected angle#", "TAN(3, 4)");
     }
 }

--- a/std/src/numerics.rs
+++ b/std/src/numerics.rs
@@ -111,7 +111,7 @@ impl AtnFunction {
     pub fn new(angle_mode: Rc<RefCell<AngleMode>>) -> Rc<Self> {
         Rc::from(Self {
             metadata: CallableMetadataBuilder::new("ATN", VarType::Double)
-                .with_typed_syntax(&[(
+                .with_syntax(&[(
                     &[SingularArgSyntax::RequiredValue(
                         RequiredValueSyntax { name: "n", vtype: ExprType::Double },
                         ArgSepSyntax::End,
@@ -157,7 +157,7 @@ impl CintFunction {
     pub fn new() -> Rc<Self> {
         Rc::from(Self {
             metadata: CallableMetadataBuilder::new("CINT", VarType::Integer)
-                .with_typed_syntax(&[(
+                .with_syntax(&[(
                     &[SingularArgSyntax::RequiredValue(
                         RequiredValueSyntax { name: "expr", vtype: ExprType::Double },
                         ArgSepSyntax::End,
@@ -204,7 +204,7 @@ impl CosFunction {
     pub fn new(angle_mode: Rc<RefCell<AngleMode>>) -> Rc<Self> {
         Rc::from(Self {
             metadata: CallableMetadataBuilder::new("COS", VarType::Double)
-                .with_typed_syntax(&[(
+                .with_syntax(&[(
                     &[SingularArgSyntax::RequiredValue(
                         RequiredValueSyntax { name: "angle", vtype: ExprType::Double },
                         ArgSepSyntax::End,
@@ -246,7 +246,7 @@ impl DegCommand {
     pub fn new(angle_mode: Rc<RefCell<AngleMode>>) -> Rc<Self> {
         Rc::from(Self {
             metadata: CallableMetadataBuilder::new("DEG", VarType::Void)
-                .with_typed_syntax(&[(&[], None)])
+                .with_syntax(&[(&[], None)])
                 .with_category(CATEGORY)
                 .with_description(
                     "Sets degrees mode of calculation.
@@ -282,7 +282,7 @@ impl IntFunction {
     pub fn new() -> Rc<Self> {
         Rc::from(Self {
             metadata: CallableMetadataBuilder::new("INT", VarType::Integer)
-                .with_typed_syntax(&[(
+                .with_syntax(&[(
                     &[SingularArgSyntax::RequiredValue(
                         RequiredValueSyntax { name: "expr", vtype: ExprType::Double },
                         ArgSepSyntax::End,
@@ -326,7 +326,7 @@ impl MaxFunction {
     pub fn new() -> Rc<Self> {
         Rc::from(Self {
             metadata: CallableMetadataBuilder::new("MAX", VarType::Double)
-                .with_typed_syntax(&[(
+                .with_syntax(&[(
                     &[],
                     Some(&RepeatedSyntax {
                         name: "expr",
@@ -371,7 +371,7 @@ impl MinFunction {
     pub fn new() -> Rc<Self> {
         Rc::from(Self {
             metadata: CallableMetadataBuilder::new("MIN", VarType::Double)
-                .with_typed_syntax(&[(
+                .with_syntax(&[(
                     &[],
                     Some(&RepeatedSyntax {
                         name: "expr",
@@ -416,7 +416,7 @@ impl PiFunction {
     pub fn new() -> Rc<Self> {
         Rc::from(Self {
             metadata: CallableMetadataBuilder::new("PI", VarType::Double)
-                .with_typed_syntax(&[(&[], None)])
+                .with_syntax(&[(&[], None)])
                 .with_category(CATEGORY)
                 .with_description("Returns the Archimedes' constant.")
                 .build(),
@@ -447,7 +447,7 @@ impl RadCommand {
     pub fn new(angle_mode: Rc<RefCell<AngleMode>>) -> Rc<Self> {
         Rc::from(Self {
             metadata: CallableMetadataBuilder::new("RAD", VarType::Void)
-                .with_typed_syntax(&[(&[], None)])
+                .with_syntax(&[(&[], None)])
                 .with_category(CATEGORY)
                 .with_description(
                     "Sets radians mode of calculation.
@@ -484,7 +484,7 @@ impl RandomizeCommand {
     pub fn new(prng: Rc<RefCell<Prng>>) -> Rc<Self> {
         Rc::from(Self {
             metadata: CallableMetadataBuilder::new("RANDOMIZE", VarType::Void)
-                .with_typed_syntax(&[
+                .with_syntax(&[
                     (&[], None),
                     (
                         &[SingularArgSyntax::RequiredValue(
@@ -535,7 +535,7 @@ impl RndFunction {
     pub fn new(prng: Rc<RefCell<Prng>>) -> Rc<Self> {
         Rc::from(Self {
             metadata: CallableMetadataBuilder::new("RND", VarType::Double)
-                .with_typed_syntax(&[
+                .with_syntax(&[
                     (&[], None),
                     (
                         &[SingularArgSyntax::RequiredValue(
@@ -594,7 +594,7 @@ impl SinFunction {
     pub fn new(angle_mode: Rc<RefCell<AngleMode>>) -> Rc<Self> {
         Rc::from(Self {
             metadata: CallableMetadataBuilder::new("SIN", VarType::Double)
-                .with_typed_syntax(&[(
+                .with_syntax(&[(
                     &[SingularArgSyntax::RequiredValue(
                         RequiredValueSyntax { name: "angle", vtype: ExprType::Double },
                         ArgSepSyntax::End,
@@ -635,7 +635,7 @@ impl SqrFunction {
     pub fn new() -> Rc<Self> {
         Rc::from(Self {
             metadata: CallableMetadataBuilder::new("SQR", VarType::Double)
-                .with_typed_syntax(&[(
+                .with_syntax(&[(
                     &[SingularArgSyntax::RequiredValue(
                         RequiredValueSyntax { name: "num", vtype: ExprType::Double },
                         ArgSepSyntax::End,
@@ -680,7 +680,7 @@ impl TanFunction {
     pub fn new(angle_mode: Rc<RefCell<AngleMode>>) -> Rc<Self> {
         Rc::from(Self {
             metadata: CallableMetadataBuilder::new("TAN", VarType::Double)
-                .with_typed_syntax(&[(
+                .with_syntax(&[(
                     &[SingularArgSyntax::RequiredValue(
                         RequiredValueSyntax { name: "angle", vtype: ExprType::Double },
                         ArgSepSyntax::End,

--- a/std/src/program.rs
+++ b/std/src/program.rs
@@ -164,7 +164,7 @@ impl KillCommand {
     pub fn new(storage: Rc<RefCell<Storage>>) -> Rc<Self> {
         Rc::from(Self {
             metadata: CallableMetadataBuilder::new("KILL", VarType::Void)
-                .with_typed_syntax(&[(
+                .with_syntax(&[(
                     &[SingularArgSyntax::RequiredValue(
                         RequiredValueSyntax { name: "filename", vtype: ExprType::Text },
                         ArgSepSyntax::End,
@@ -213,7 +213,7 @@ impl EditCommand {
     pub fn new(console: Rc<RefCell<dyn Console>>, program: Rc<RefCell<dyn Program>>) -> Rc<Self> {
         Rc::from(Self {
             metadata: CallableMetadataBuilder::new("EDIT", VarType::Void)
-                .with_typed_syntax(&[(&[], None)])
+                .with_syntax(&[(&[], None)])
                 .with_category(CATEGORY)
                 .with_description("Interactively edits the stored program.")
                 .build(),
@@ -251,7 +251,7 @@ impl ListCommand {
     pub fn new(console: Rc<RefCell<dyn Console>>, program: Rc<RefCell<dyn Program>>) -> Rc<Self> {
         Rc::from(Self {
             metadata: CallableMetadataBuilder::new("LIST", VarType::Void)
-                .with_typed_syntax(&[(&[], None)])
+                .with_syntax(&[(&[], None)])
                 .with_category(CATEGORY)
                 .with_description("Prints the currently-loaded program.")
                 .build(),
@@ -296,7 +296,7 @@ impl LoadCommand {
     ) -> Rc<Self> {
         Rc::from(Self {
             metadata: CallableMetadataBuilder::new("LOAD", VarType::Void)
-                .with_typed_syntax(&[(
+                .with_syntax(&[(
                     &[SingularArgSyntax::RequiredValue(
                         RequiredValueSyntax { name: "filename", vtype: ExprType::Text },
                         ArgSepSyntax::End,
@@ -358,7 +358,7 @@ impl NewCommand {
     pub fn new(console: Rc<RefCell<dyn Console>>, program: Rc<RefCell<dyn Program>>) -> Rc<Self> {
         Rc::from(Self {
             metadata: CallableMetadataBuilder::new("NEW", VarType::Void)
-                .with_typed_syntax(&[(&[], None)])
+                .with_syntax(&[(&[], None)])
                 .with_category(CATEGORY)
                 .with_description(
                     "Restores initial machine state and creates a new program.
@@ -411,7 +411,7 @@ impl RunCommand {
     pub fn new(console: Rc<RefCell<dyn Console>>, program: Rc<RefCell<dyn Program>>) -> Rc<Self> {
         Rc::from(Self {
             metadata: CallableMetadataBuilder::new("RUN", VarType::Void)
-                .with_typed_syntax(&[(&[], None)])
+                .with_syntax(&[(&[], None)])
                 .with_category(CATEGORY)
                 .with_description(
                     "Runs the stored program.
@@ -472,7 +472,7 @@ impl SaveCommand {
     ) -> Rc<Self> {
         Rc::from(Self {
             metadata: CallableMetadataBuilder::new("SAVE", VarType::Void)
-                .with_typed_syntax(&[
+                .with_syntax(&[
                     (&[], None),
                     (
                         &[SingularArgSyntax::RequiredValue(

--- a/std/src/storage/cmds.rs
+++ b/std/src/storage/cmds.rs
@@ -129,7 +129,7 @@ impl CdCommand {
     pub fn new(storage: Rc<RefCell<Storage>>) -> Rc<Self> {
         Rc::from(Self {
             metadata: CallableMetadataBuilder::new("CD", VarType::Void)
-                .with_typed_syntax(&[(
+                .with_syntax(&[(
                     &[SingularArgSyntax::RequiredValue(
                         RequiredValueSyntax { name: "path", vtype: ExprType::Text },
                         ArgSepSyntax::End,
@@ -172,7 +172,7 @@ impl DirCommand {
     pub fn new(console: Rc<RefCell<dyn Console>>, storage: Rc<RefCell<Storage>>) -> Rc<Self> {
         Rc::from(Self {
             metadata: CallableMetadataBuilder::new("DIR", VarType::Void)
-                .with_typed_syntax(&[
+                .with_syntax(&[
                     (&[], None),
                     (
                         &[SingularArgSyntax::RequiredValue(
@@ -223,7 +223,7 @@ impl MountCommand {
     pub fn new(console: Rc<RefCell<dyn Console>>, storage: Rc<RefCell<Storage>>) -> Rc<Self> {
         Rc::from(Self {
             metadata: CallableMetadataBuilder::new("MOUNT", VarType::Void)
-                .with_typed_syntax(&[
+                .with_syntax(&[
                     (&[], None),
                     (
                         &[
@@ -286,7 +286,7 @@ impl PwdCommand {
     pub fn new(console: Rc<RefCell<dyn Console>>, storage: Rc<RefCell<Storage>>) -> Rc<Self> {
         Rc::from(Self {
             metadata: CallableMetadataBuilder::new("PWD", VarType::Void)
-                .with_typed_syntax(&[(&[], None)])
+                .with_syntax(&[(&[], None)])
                 .with_category(CATEGORY)
                 .with_description(
                     "Prints the current working location.
@@ -337,7 +337,7 @@ impl UnmountCommand {
     pub fn new(storage: Rc<RefCell<Storage>>) -> Rc<Self> {
         Rc::from(Self {
             metadata: CallableMetadataBuilder::new("UNMOUNT", VarType::Void)
-                .with_typed_syntax(&[(
+                .with_syntax(&[(
                     &[SingularArgSyntax::RequiredValue(
                         RequiredValueSyntax { name: "drive_name", vtype: ExprType::Text },
                         ArgSepSyntax::End,

--- a/std/src/strings.rs
+++ b/std/src/strings.rs
@@ -68,7 +68,7 @@ impl AscFunction {
     pub fn new() -> Rc<Self> {
         Rc::from(Self {
             metadata: CallableMetadataBuilder::new("ASC", VarType::Integer)
-                .with_typed_syntax(&[(
+                .with_syntax(&[(
                     &[SingularArgSyntax::RequiredValue(
                         RequiredValueSyntax { name: "char", vtype: ExprType::Text },
                         ArgSepSyntax::End,
@@ -134,7 +134,7 @@ impl ChrFunction {
     pub fn new() -> Rc<Self> {
         Rc::from(Self {
             metadata: CallableMetadataBuilder::new("CHR", VarType::Text)
-                .with_typed_syntax(&[(
+                .with_syntax(&[(
                     &[SingularArgSyntax::RequiredValue(
                         RequiredValueSyntax { name: "code", vtype: ExprType::Integer },
                         ArgSepSyntax::End,
@@ -186,7 +186,7 @@ impl LeftFunction {
     pub fn new() -> Rc<Self> {
         Rc::from(Self {
             metadata: CallableMetadataBuilder::new("LEFT", VarType::Text)
-                .with_typed_syntax(&[(
+                .with_syntax(&[(
                     &[
                         SingularArgSyntax::RequiredValue(
                             RequiredValueSyntax { name: "expr", vtype: ExprType::Text },
@@ -240,7 +240,7 @@ impl LenFunction {
     pub fn new() -> Rc<Self> {
         Rc::from(Self {
             metadata: CallableMetadataBuilder::new("LEN", VarType::Integer)
-                .with_typed_syntax(&[(
+                .with_syntax(&[(
                     &[SingularArgSyntax::RequiredValue(
                         RequiredValueSyntax { name: "expr", vtype: ExprType::Text },
                         ArgSepSyntax::End,
@@ -282,7 +282,7 @@ impl LtrimFunction {
     pub fn new() -> Rc<Self> {
         Rc::from(Self {
             metadata: CallableMetadataBuilder::new("LTRIM", VarType::Text)
-                .with_typed_syntax(&[(
+                .with_syntax(&[(
                     &[SingularArgSyntax::RequiredValue(
                         RequiredValueSyntax { name: "expr", vtype: ExprType::Text },
                         ArgSepSyntax::End,
@@ -320,7 +320,7 @@ impl MidFunction {
     pub fn new() -> Rc<Self> {
         Rc::from(Self {
             metadata: CallableMetadataBuilder::new("MID", VarType::Text)
-                .with_typed_syntax(&[
+                .with_syntax(&[
                     (
                         &[
                             SingularArgSyntax::RequiredValue(
@@ -408,7 +408,7 @@ impl RightFunction {
     pub fn new() -> Rc<Self> {
         Rc::from(Self {
             metadata: CallableMetadataBuilder::new("RIGHT", VarType::Text)
-                .with_typed_syntax(&[(
+                .with_syntax(&[(
                     &[
                         SingularArgSyntax::RequiredValue(
                             RequiredValueSyntax { name: "expr", vtype: ExprType::Text },
@@ -462,7 +462,7 @@ impl RtrimFunction {
     pub fn new() -> Rc<Self> {
         Rc::from(Self {
             metadata: CallableMetadataBuilder::new("RTRIM", VarType::Text)
-                .with_typed_syntax(&[(
+                .with_syntax(&[(
                     &[SingularArgSyntax::RequiredValue(
                         RequiredValueSyntax { name: "expr", vtype: ExprType::Text },
                         ArgSepSyntax::End,
@@ -500,7 +500,7 @@ impl StrFunction {
     pub fn new() -> Rc<Self> {
         Rc::from(Self {
             metadata: CallableMetadataBuilder::new("STR", VarType::Text)
-                .with_typed_syntax(&[(
+                .with_syntax(&[(
                     &[SingularArgSyntax::AnyValue(
                         AnyValueSyntax { name: "expr", allow_missing: false },
                         ArgSepSyntax::End,


### PR DESCRIPTION
Introduce the concept of a scope so that we can pop typed arguments and then proceed to unify all arguments compilers into a single implementation. This finally fixes the hack the textual "syntax" representation was and also paves the way to eliminate the `Value` type from the execution stack.