### PR TITLE
Multiple cleanups and fixes

### DIFF
--- a/client/src/cmds.rs
+++ b/client/src/cmds.rs
@@ -17,7 +17,7 @@
 
 use crate::*;
 use async_trait::async_trait;
-use endbasic_core::ast::{ArgSep, ExprType, Value};
+use endbasic_core::ast::{ArgSep, ExprType};
 use endbasic_core::compiler::{
     ArgSepSyntax, RepeatedSyntax, RepeatedTypeSyntax, RequiredValueSyntax, SingularArgSyntax,
 };
@@ -28,6 +28,7 @@ use endbasic_core::syms::{
 use endbasic_core::LineCol;
 use endbasic_std::console::{is_narrow, read_line, read_line_secure, refill_and_print, Console};
 use endbasic_std::storage::{FileAcls, Storage};
+use endbasic_std::strings::parse_boolean;
 use std::cell::RefCell;
 use std::rc::Rc;
 use std::str;
@@ -456,9 +457,8 @@ cloud service.  You will be asked for confirmation before proceeding.",
         loop {
             match read_line(console, prompt, "", None).await? {
                 s if s.is_empty() => return Ok(default),
-                s => match Value::parse_as(ExprType::Boolean, s.trim_end()) {
-                    Ok(Value::Boolean(b)) => return Ok(b),
-                    Ok(_) => unreachable!(),
+                s => match parse_boolean(s.trim_end()) {
+                    Ok(b) => return Ok(b),
                     Err(_) => {
                         console.print("Invalid input; try again.")?;
                         continue;

--- a/client/src/cmds.rs
+++ b/client/src/cmds.rs
@@ -121,7 +121,7 @@ To create an account, use the SIGNUP command.",
         let mut storage = self.storage.borrow_mut();
         storage.mount("CLOUD", &format!("cloud://{}", username))?;
 
-        Ok(Value::Void)
+        Ok(())
     }
 }
 
@@ -227,7 +227,7 @@ impl Callable for LogoutCommand {
             console.print("")?;
         }
 
-        Ok(Value::Void)
+        Ok(())
     }
 }
 
@@ -344,7 +344,7 @@ impl ShareCommand {
         }
         console.print("")?;
 
-        Ok(Value::Void)
+        Ok(())
     }
 }
 
@@ -399,7 +399,7 @@ auto-run your public file by visiting:",
             console.print("")?;
         }
 
-        Ok(Value::Void)
+        Ok(())
     }
 }
 
@@ -550,7 +550,7 @@ have no adverse impact in the service you receive.",
         if !proceed {
             // TODO(jmmv): This should return an error of some form once we have error handling in
             // the language.
-            return Ok(Value::Void);
+            return Ok(());
         }
 
         let request = SignupRequest { username, password, email, promotional_email };
@@ -568,7 +568,7 @@ in it to activate your account.  Make sure to check your spam folder.",
         )?;
         console.print("")?;
 
-        Ok(Value::Void)
+        Ok(())
     }
 }
 

--- a/client/src/cmds.rs
+++ b/client/src/cmds.rs
@@ -17,7 +17,7 @@
 
 use crate::*;
 use async_trait::async_trait;
-use endbasic_core::ast::{ArgSep, ExprType, Value, VarType};
+use endbasic_core::ast::{ArgSep, ExprType, Value};
 use endbasic_core::compiler::{
     ArgSepSyntax, RepeatedSyntax, RepeatedTypeSyntax, RequiredValueSyntax, SingularArgSyntax,
 };
@@ -456,7 +456,7 @@ cloud service.  You will be asked for confirmation before proceeding.",
         loop {
             match read_line(console, prompt, "", None).await? {
                 s if s.is_empty() => return Ok(default),
-                s => match Value::parse_as(VarType::Boolean, s.trim_end()) {
+                s => match Value::parse_as(ExprType::Boolean, s.trim_end()) {
                     Ok(Value::Boolean(b)) => return Ok(b),
                     Ok(_) => unreachable!(),
                     Err(_) => {

--- a/client/src/cmds.rs
+++ b/client/src/cmds.rs
@@ -17,10 +17,9 @@
 
 use crate::*;
 use async_trait::async_trait;
-use endbasic_core::ast::{ArgSep, Value, VarType};
+use endbasic_core::ast::{ArgSep, ExprType, Value, VarType};
 use endbasic_core::compiler::{
-    ArgSepSyntax, ExprType, RepeatedSyntax, RepeatedTypeSyntax, RequiredValueSyntax,
-    SingularArgSyntax,
+    ArgSepSyntax, RepeatedSyntax, RepeatedTypeSyntax, RequiredValueSyntax, SingularArgSyntax,
 };
 use endbasic_core::exec::{Machine, Scope};
 use endbasic_core::syms::{

--- a/client/src/cmds.rs
+++ b/client/src/cmds.rs
@@ -63,7 +63,7 @@ impl LoginCommand {
         storage: Rc<RefCell<Storage>>,
     ) -> Rc<Self> {
         Rc::from(Self {
-            metadata: CallableMetadataBuilder::new("LOGIN", VarType::Void)
+            metadata: CallableMetadataBuilder::new("LOGIN")
                 .with_syntax(&[
                     (
                         &[SingularArgSyntax::RequiredValue(
@@ -168,7 +168,7 @@ impl LogoutCommand {
         storage: Rc<RefCell<Storage>>,
     ) -> Rc<Self> {
         Rc::from(Self {
-            metadata: CallableMetadataBuilder::new("LOGOUT", VarType::Void)
+            metadata: CallableMetadataBuilder::new("LOGOUT")
                 .with_syntax(&[(&[], None)])
                 .with_category(CATEGORY)
                 .with_description(
@@ -254,7 +254,7 @@ impl ShareCommand {
         exec_base_url: S,
     ) -> Rc<Self> {
         Rc::from(Self {
-            metadata: CallableMetadataBuilder::new("SHARE", VarType::Void)
+            metadata: CallableMetadataBuilder::new("SHARE")
                 .with_syntax(&[(
                     &[SingularArgSyntax::RequiredValue(
                         RequiredValueSyntax { name: "filename", vtype: ExprType::Text },
@@ -437,7 +437,7 @@ impl SignupCommand {
     /// Creates a new `SIGNUP` command.
     pub fn new(service: Rc<RefCell<dyn Service>>, console: Rc<RefCell<dyn Console>>) -> Rc<Self> {
         Rc::from(Self {
-            metadata: CallableMetadataBuilder::new("SIGNUP", VarType::Void)
+            metadata: CallableMetadataBuilder::new("SIGNUP")
                 .with_syntax(&[(&[], None)])
                 .with_category(CATEGORY)
                 .with_description(

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -14,7 +14,6 @@ edition = "2018"
 [dependencies]
 async-channel = "2.2"
 async-trait = "0.1"
-paste = "1.0"
 thiserror = "1.0"
 
 [dev-dependencies]

--- a/core/examples/dsl.rs
+++ b/core/examples/dsl.rs
@@ -22,7 +22,7 @@
 //! of the lights, and finally dumps the resulting state to the screen.
 
 use async_trait::async_trait;
-use endbasic_core::ast::{ExprType, Value};
+use endbasic_core::ast::ExprType;
 use endbasic_core::compiler::{ArgSepSyntax, RequiredValueSyntax, SingularArgSyntax};
 use endbasic_core::exec::{Machine, Scope, StopReason};
 use endbasic_core::syms::{
@@ -80,7 +80,7 @@ impl Callable for NumLightsFunction {
         debug_assert_eq!(0, scope.nargs());
         let num = self.lights.borrow().len();
         assert!(num <= std::i32::MAX as usize, "Ended up with too many lights");
-        Ok(Value::Integer(num as i32))
+        scope.return_integer(num as i32)
     }
 }
 
@@ -137,7 +137,7 @@ impl Callable for SwitchLightCommand {
             println!("Turning light {} on", i);
         }
         lights[i - 1] = !lights[i - 1];
-        Ok(Value::Void)
+        Ok(())
     }
 }
 

--- a/core/examples/dsl.rs
+++ b/core/examples/dsl.rs
@@ -79,7 +79,7 @@ impl Callable for NumLightsFunction {
     async fn exec(&self, scope: Scope<'_>, _machine: &mut Machine) -> CallResult {
         debug_assert_eq!(0, scope.nargs());
         let num = self.lights.borrow().len();
-        assert!(num <= std::i32::MAX as usize, "Ended up with too many lights");
+        assert!(num <= i32::MAX as usize, "Ended up with too many lights");
         scope.return_integer(num as i32)
     }
 }

--- a/core/examples/dsl.rs
+++ b/core/examples/dsl.rs
@@ -22,7 +22,7 @@
 //! of the lights, and finally dumps the resulting state to the screen.
 
 use async_trait::async_trait;
-use endbasic_core::ast::{ExprType, Value, VarType};
+use endbasic_core::ast::{ExprType, Value};
 use endbasic_core::compiler::{ArgSepSyntax, RequiredValueSyntax, SingularArgSyntax};
 use endbasic_core::exec::{Machine, Scope, StopReason};
 use endbasic_core::syms::{
@@ -59,7 +59,8 @@ impl NumLightsFunction {
     /// Creates a new function that queries the `lights` state.
     pub fn new(lights: Rc<RefCell<Lights>>) -> Rc<Self> {
         Rc::from(Self {
-            metadata: CallableMetadataBuilder::new("NUM_LIGHTS", VarType::Integer)
+            metadata: CallableMetadataBuilder::new("NUM_LIGHTS")
+                .with_return_type(ExprType::Integer)
                 .with_syntax(&[(&[], None)])
                 .with_category("Demonstration")
                 .with_description("Returns the number of available lights.")
@@ -93,7 +94,7 @@ impl SwitchLightCommand {
     /// Creates a new command that modifies the `lights` state.
     pub fn new(lights: Rc<RefCell<Lights>>) -> Rc<Self> {
         Rc::from(Self {
-            metadata: CallableMetadataBuilder::new("SWITCH_LIGHT", VarType::Void)
+            metadata: CallableMetadataBuilder::new("SWITCH_LIGHT")
                 .with_syntax(&[(
                     &[SingularArgSyntax::RequiredValue(
                         RequiredValueSyntax { name: "id", vtype: ExprType::Integer },

--- a/core/examples/dsl.rs
+++ b/core/examples/dsl.rs
@@ -22,8 +22,8 @@
 //! of the lights, and finally dumps the resulting state to the screen.
 
 use async_trait::async_trait;
-use endbasic_core::ast::{Value, VarType};
-use endbasic_core::compiler::{ArgSepSyntax, ExprType, RequiredValueSyntax, SingularArgSyntax};
+use endbasic_core::ast::{ExprType, Value, VarType};
+use endbasic_core::compiler::{ArgSepSyntax, RequiredValueSyntax, SingularArgSyntax};
 use endbasic_core::exec::{Machine, Scope, StopReason};
 use endbasic_core::syms::{
     CallError, CallResult, Callable, CallableMetadata, CallableMetadataBuilder,

--- a/core/src/ast.rs
+++ b/core/src/ast.rs
@@ -192,7 +192,7 @@ impl Expr {
 }
 
 /// Represents type of an expression.
-#[derive(Clone, Copy, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum ExprType {
     /// Type for an expression that evaluates to a boolean.
     Boolean,
@@ -306,18 +306,6 @@ impl VarType {
             VarType::Integer => "%",
             VarType::Text => "$",
             VarType::Void => "",
-        }
-    }
-
-    /// Returns the default value to assign to this type.
-    pub(crate) fn default_value(&self) -> Value {
-        match self {
-            VarType::Auto => Value::Integer(0),
-            VarType::Boolean => Value::Boolean(false),
-            VarType::Double => Value::Double(0.0),
-            VarType::Integer => Value::Integer(0),
-            VarType::Text => Value::Text("".to_owned()),
-            VarType::Void => panic!("Cannot represent a default value for void"),
         }
     }
 }
@@ -613,7 +601,7 @@ pub struct DimSpan {
     pub name_pos: LineCol,
 
     /// Type of the variable to be defined.
-    pub vtype: VarType,
+    pub vtype: ExprType,
 
     /// Position of the type.
     pub vtype_pos: LineCol,
@@ -634,7 +622,7 @@ pub struct DimArraySpan {
     pub dimensions: Vec<Expr>,
 
     /// Type of the array to be defined.
-    pub subtype: VarType,
+    pub subtype: ExprType,
 
     /// Position of the subtype.
     pub subtype_pos: LineCol,

--- a/core/src/ast.rs
+++ b/core/src/ast.rs
@@ -91,19 +91,6 @@ pub struct BinaryOpSpan {
     pub pos: LineCol,
 }
 
-/// Components of an function call or an array reference expression.
-#[derive(Clone, Debug, PartialEq)]
-pub struct FunctionCallSpan {
-    /// Reference to the function to call or array to reference.
-    pub fref: VarRef,
-
-    /// Sequence of arguments to pass to the function.
-    pub args: Vec<Expr>,
-
-    /// Starting position of the function call.
-    pub pos: LineCol,
-}
-
 /// Represents an expression and provides mechanisms to evaluate it.
 #[derive(Clone, Debug, PartialEq)]
 pub enum Expr {
@@ -162,7 +149,7 @@ pub enum Expr {
     ShiftRight(Box<BinaryOpSpan>),
 
     /// A function call or an array reference.
-    Call(FunctionCallSpan),
+    Call(CallSpan),
 }
 
 impl Expr {
@@ -199,7 +186,7 @@ impl Expr {
             Expr::Power(span) => span.lhs.start_pos(),
             Expr::Negate(span) => span.pos,
 
-            Expr::Call(span) => span.pos,
+            Expr::Call(span) => span.vref_pos,
         }
     }
 }
@@ -479,8 +466,7 @@ pub struct AssignmentSpan {
 }
 
 /// Single argument to a builtin call statement.
-#[derive(Debug, PartialEq)]
-#[cfg_attr(test, derive(Clone))]
+#[derive(Clone, Debug, PartialEq)]
 pub struct ArgSpan {
     /// Expression to compute the argument's value.  This expression is optional to support calls
     /// of the form `PRINT a, , b` where some arguments are empty.
@@ -494,17 +480,16 @@ pub struct ArgSpan {
     pub sep_pos: LineCol,
 }
 
-/// Components of an builtin call statement.
-#[derive(Debug, PartialEq)]
-#[cfg_attr(test, derive(Clone))]
-pub struct BuiltinCallSpan {
-    /// Name of the builtin to call.
-    pub name: String,
+/// Components of a call statement or expression.
+#[derive(Clone, Debug, PartialEq)]
+pub struct CallSpan {
+    /// Reference to the callable (a command or a function), or the array to index.
+    pub vref: VarRef,
 
-    /// Position of the name.
-    pub name_pos: LineCol,
+    /// Position of the reference.
+    pub vref_pos: LineCol,
 
-    /// Sequence of arguments to pass to the builtin.
+    /// Sequence of arguments to pass to the callable.
     pub args: Vec<ArgSpan>,
 }
 
@@ -774,7 +759,7 @@ pub enum Statement {
     Assignment(AssignmentSpan),
 
     /// Represents a call to a builtin command such as `PRINT`.
-    BuiltinCall(BuiltinCallSpan),
+    Call(CallSpan),
 
     /// Represents a `DATA` statement.
     Data(DataSpan),

--- a/core/src/ast.rs
+++ b/core/src/ast.rs
@@ -418,9 +418,6 @@ pub enum Value {
 
     /// A reference to a variable.
     VarRef(VarRef),
-
-    /// A value that does not exist.
-    Void,
 }
 
 impl From<bool> for Value {
@@ -462,21 +459,19 @@ impl fmt::Display for Value {
             Value::Integer(i) => write!(f, "{}", i),
             Value::Text(s) => write!(f, "\"{}\"", s),
             Value::VarRef(v) => write!(f, "{}", v),
-            Value::Void => write!(f, "()"),
         }
     }
 }
 
 impl Value {
     /// Returns the type of the value as an `ExprType`.
-    pub fn as_exprtype(&self) -> Option<ExprType> {
+    pub fn as_exprtype(&self) -> ExprType {
         match self {
-            Value::Boolean(_) => Some(ExprType::Boolean),
-            Value::Double(_) => Some(ExprType::Double),
-            Value::Integer(_) => Some(ExprType::Integer),
-            Value::Text(_) => Some(ExprType::Text),
-            Value::VarRef(vref) => Some(ExprType::from_vartype(vref.ref_type, None)),
-            Value::Void => None,
+            Value::Boolean(_) => ExprType::Boolean,
+            Value::Double(_) => ExprType::Double,
+            Value::Integer(_) => ExprType::Integer,
+            Value::Text(_) => ExprType::Text,
+            Value::VarRef(vref) => ExprType::from_vartype(vref.ref_type, None),
         }
     }
 
@@ -488,7 +483,6 @@ impl Value {
             Value::Integer(_) => VarType::Integer,
             Value::Text(_) => VarType::Text,
             Value::VarRef(vref) => vref.ref_type,
-            Value::Void => VarType::Void,
         }
     }
 }

--- a/core/src/ast.rs
+++ b/core/src/ast.rs
@@ -246,6 +246,9 @@ impl fmt::Display for ExprType {
 }
 
 /// Represents a reference to a variable (which doesn't have to exist).
+///
+/// Variable references are different from `SymbolKey`s because they maintain the case of the
+/// reference (for error display purposes) and because they carry an optional type annotation.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct VarRef {
     /// Name of the variable this points to.
@@ -307,6 +310,11 @@ impl VarRef {
                 None => false,
             },
         }
+    }
+
+    /// Converts this variable reference to a symbol key.
+    pub(crate) fn as_symbol_key(&self) -> SymbolKey {
+        SymbolKey::from(&self.name)
     }
 }
 

--- a/core/src/ast.rs
+++ b/core/src/ast.rs
@@ -210,11 +210,10 @@ pub enum ExprType {
 impl ExprType {
     /// Converts a `VarType` into an `ExprType`.
     ///
-    /// If the `VarType` represents type inference (the `Auto` value), returns `auto_type` assuming
-    /// there is an `auto_type` to return; otherwise, panics.
-    pub(crate) fn from_vartype(vtype: VarType, auto_type: Option<ExprType>) -> Self {
+    /// If the `VarType` represents type inference (the `Auto` value), returns `auto_type`.
+    pub(crate) fn from_vartype(vtype: VarType, auto_type: ExprType) -> Self {
         match vtype {
-            VarType::Auto => auto_type.unwrap(),
+            VarType::Auto => auto_type,
             VarType::Boolean => ExprType::Boolean,
             VarType::Double => ExprType::Double,
             VarType::Integer => ExprType::Integer,
@@ -369,8 +368,8 @@ impl VarRef {
     }
 
     /// Returns true if this reference is compatible with the given type.
-    pub fn accepts(&self, other: VarType) -> bool {
-        self.ref_type == VarType::Auto || self.ref_type == other
+    pub fn accepts(&self, other: ExprType) -> bool {
+        self.ref_type == VarType::Auto || self.ref_type == other.into()
     }
 
     /// Returns true if this reference is compatible with the return type of a callable.
@@ -460,17 +459,6 @@ impl Value {
             Value::Integer(_) => ExprType::Integer,
             Value::Text(_) => ExprType::Text,
             Value::VarRef(_key, etype) => *etype,
-        }
-    }
-
-    /// Returns the type of the value as a `VarType`.
-    pub fn as_vartype(&self) -> VarType {
-        match self {
-            Value::Boolean(_) => VarType::Boolean,
-            Value::Double(_) => VarType::Double,
-            Value::Integer(_) => VarType::Integer,
-            Value::Text(_) => VarType::Text,
-            Value::VarRef(_key, etype) => (*etype).into(),
         }
     }
 }
@@ -906,30 +894,30 @@ mod tests {
 
     #[test]
     fn test_varref_accepts() {
-        assert!(VarRef::new("a", VarType::Auto).accepts(VarType::Boolean));
-        assert!(VarRef::new("a", VarType::Auto).accepts(VarType::Double));
-        assert!(VarRef::new("a", VarType::Auto).accepts(VarType::Integer));
-        assert!(VarRef::new("a", VarType::Auto).accepts(VarType::Text));
+        assert!(VarRef::new("a", VarType::Auto).accepts(ExprType::Boolean));
+        assert!(VarRef::new("a", VarType::Auto).accepts(ExprType::Double));
+        assert!(VarRef::new("a", VarType::Auto).accepts(ExprType::Integer));
+        assert!(VarRef::new("a", VarType::Auto).accepts(ExprType::Text));
 
-        assert!(VarRef::new("a", VarType::Boolean).accepts(VarType::Boolean));
-        assert!(!VarRef::new("a", VarType::Boolean).accepts(VarType::Double));
-        assert!(!VarRef::new("a", VarType::Boolean).accepts(VarType::Integer));
-        assert!(!VarRef::new("a", VarType::Boolean).accepts(VarType::Text));
+        assert!(VarRef::new("a", VarType::Boolean).accepts(ExprType::Boolean));
+        assert!(!VarRef::new("a", VarType::Boolean).accepts(ExprType::Double));
+        assert!(!VarRef::new("a", VarType::Boolean).accepts(ExprType::Integer));
+        assert!(!VarRef::new("a", VarType::Boolean).accepts(ExprType::Text));
 
-        assert!(!VarRef::new("a", VarType::Double).accepts(VarType::Boolean));
-        assert!(VarRef::new("a", VarType::Double).accepts(VarType::Double));
-        assert!(!VarRef::new("a", VarType::Double).accepts(VarType::Integer));
-        assert!(!VarRef::new("a", VarType::Double).accepts(VarType::Text));
+        assert!(!VarRef::new("a", VarType::Double).accepts(ExprType::Boolean));
+        assert!(VarRef::new("a", VarType::Double).accepts(ExprType::Double));
+        assert!(!VarRef::new("a", VarType::Double).accepts(ExprType::Integer));
+        assert!(!VarRef::new("a", VarType::Double).accepts(ExprType::Text));
 
-        assert!(!VarRef::new("a", VarType::Integer).accepts(VarType::Boolean));
-        assert!(!VarRef::new("a", VarType::Integer).accepts(VarType::Double));
-        assert!(VarRef::new("a", VarType::Integer).accepts(VarType::Integer));
-        assert!(!VarRef::new("a", VarType::Integer).accepts(VarType::Text));
+        assert!(!VarRef::new("a", VarType::Integer).accepts(ExprType::Boolean));
+        assert!(!VarRef::new("a", VarType::Integer).accepts(ExprType::Double));
+        assert!(VarRef::new("a", VarType::Integer).accepts(ExprType::Integer));
+        assert!(!VarRef::new("a", VarType::Integer).accepts(ExprType::Text));
 
-        assert!(!VarRef::new("a", VarType::Text).accepts(VarType::Boolean));
-        assert!(!VarRef::new("a", VarType::Text).accepts(VarType::Double));
-        assert!(!VarRef::new("a", VarType::Text).accepts(VarType::Integer));
-        assert!(VarRef::new("a", VarType::Text).accepts(VarType::Text));
+        assert!(!VarRef::new("a", VarType::Text).accepts(ExprType::Boolean));
+        assert!(!VarRef::new("a", VarType::Text).accepts(ExprType::Double));
+        assert!(!VarRef::new("a", VarType::Text).accepts(ExprType::Integer));
+        assert!(VarRef::new("a", VarType::Text).accepts(ExprType::Text));
     }
 
     #[test]

--- a/core/src/ast.rs
+++ b/core/src/ast.rs
@@ -191,6 +191,76 @@ impl Expr {
     }
 }
 
+/// Represents type of an expression.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum ExprType {
+    /// Type for an expression that evaluates to a boolean.
+    Boolean,
+
+    /// Type for an expression that evaluates to a double.
+    Double,
+
+    /// Type for an expression that evaluates to an integer.
+    Integer,
+
+    /// Type for an expression that evaluates to a string.
+    Text,
+}
+
+impl ExprType {
+    /// Converts a `VarType` into an `ExprType`.
+    ///
+    /// If the `VarType` represents type inference (the `Auto` value), returns `auto_type` assuming
+    /// there is an `auto_type` to return; otherwise, panics.
+    pub(crate) fn from_vartype(vtype: VarType, auto_type: Option<ExprType>) -> Self {
+        match vtype {
+            VarType::Auto => auto_type.unwrap(),
+            VarType::Boolean => ExprType::Boolean,
+            VarType::Double => ExprType::Double,
+            VarType::Integer => ExprType::Integer,
+            VarType::Text => ExprType::Text,
+            VarType::Void => unreachable!(),
+        }
+    }
+
+    /// Returns true if this expression type is numerical.
+    pub(crate) fn is_numerical(self) -> bool {
+        self == Self::Double || self == Self::Integer
+    }
+
+    /// Returns the textual representation of the annotation for this type.
+    pub(crate) fn annotation(&self) -> char {
+        match self {
+            ExprType::Boolean => '?',
+            ExprType::Double => '#',
+            ExprType::Integer => '%',
+            ExprType::Text => '$',
+        }
+    }
+}
+
+impl From<ExprType> for VarType {
+    fn from(value: ExprType) -> Self {
+        match value {
+            ExprType::Boolean => VarType::Boolean,
+            ExprType::Double => VarType::Double,
+            ExprType::Integer => VarType::Integer,
+            ExprType::Text => VarType::Text,
+        }
+    }
+}
+
+impl fmt::Display for ExprType {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            ExprType::Boolean => write!(f, "BOOLEAN"),
+            ExprType::Double => write!(f, "DOUBLE"),
+            ExprType::Integer => write!(f, "INTEGER"),
+            ExprType::Text => write!(f, "STRING"),
+        }
+    }
+}
+
 /// Collection of types for a variable.
 // TODO(jmmv): Consider combining with `Value` and using `Discriminant<Value>` for the variable
 // types.

--- a/core/src/ast.rs
+++ b/core/src/ast.rs
@@ -15,7 +15,7 @@
 
 //! Abstract Syntax Tree (AST) for the EndBASIC language.
 
-use crate::reader::LineCol;
+use crate::{reader::LineCol, syms::SymbolKey};
 use std::fmt;
 
 /// Components of a boolean literal expression.
@@ -405,7 +405,7 @@ pub enum Value {
     Text(String), // Should be `String` but would get confusing with the built-in Rust type.
 
     /// A reference to a variable.
-    VarRef(VarRef),
+    VarRef(SymbolKey, ExprType),
 }
 
 impl From<bool> for Value {
@@ -446,7 +446,7 @@ impl fmt::Display for Value {
             }
             Value::Integer(i) => write!(f, "{}", i),
             Value::Text(s) => write!(f, "\"{}\"", s),
-            Value::VarRef(v) => write!(f, "{}", v),
+            Value::VarRef(key, etype) => write!(f, "{}{}", key, etype),
         }
     }
 }
@@ -459,7 +459,7 @@ impl Value {
             Value::Double(_) => ExprType::Double,
             Value::Integer(_) => ExprType::Integer,
             Value::Text(_) => ExprType::Text,
-            Value::VarRef(vref) => ExprType::from_vartype(vref.ref_type, None),
+            Value::VarRef(_key, etype) => *etype,
         }
     }
 
@@ -470,7 +470,7 @@ impl Value {
             Value::Double(_) => VarType::Double,
             Value::Integer(_) => VarType::Integer,
             Value::Text(_) => VarType::Text,
-            Value::VarRef(vref) => vref.ref_type,
+            Value::VarRef(_key, etype) => (*etype).into(),
         }
     }
 }

--- a/core/src/ast.rs
+++ b/core/src/ast.rs
@@ -218,7 +218,6 @@ impl ExprType {
             VarType::Double => ExprType::Double,
             VarType::Integer => ExprType::Integer,
             VarType::Text => ExprType::Text,
-            VarType::Void => unreachable!(),
         }
     }
 
@@ -290,9 +289,6 @@ pub enum VarType {
     /// A string variable.  This should really be called `String` but it would get confusing with
     /// the built-in Rust type.
     Text,
-
-    /// The nothingness type.  Used to represent the return value of commands.
-    Void,
 }
 
 impl VarType {
@@ -304,7 +300,6 @@ impl VarType {
             VarType::Double => "#",
             VarType::Integer => "%",
             VarType::Text => "$",
-            VarType::Void => "",
         }
     }
 }
@@ -317,7 +312,6 @@ impl fmt::Display for VarType {
             VarType::Double => write!(f, "DOUBLE"),
             VarType::Integer => write!(f, "INTEGER"),
             VarType::Text => write!(f, "STRING"),
-            VarType::Void => panic!("Should not try to display a void type"),
         }
     }
 }
@@ -357,7 +351,7 @@ impl VarRef {
     pub(crate) fn qualify(self, expr_type: Option<ExprType>) -> Self {
         assert!(self.ref_type == VarType::Auto, "Reference already qualified");
         match expr_type {
-            None => Self { name: self.name, ref_type: VarType::Void },
+            None => Self { name: self.name, ref_type: VarType::Auto },
             Some(expr_type) => Self { name: self.name, ref_type: expr_type.into() },
         }
     }
@@ -376,7 +370,7 @@ impl VarRef {
     pub fn accepts_callable(&self, other: Option<ExprType>) -> bool {
         let other_type = match other {
             Some(other) => other.into(),
-            None => VarType::Void,
+            None => VarType::Auto,
         };
         self.ref_type == VarType::Auto || self.ref_type == other_type
     }

--- a/core/src/ast.rs
+++ b/core/src/ast.rs
@@ -237,6 +237,16 @@ impl ExprType {
             ExprType::Text => '$',
         }
     }
+
+    /// Returns the default value to assign to this type.
+    pub(crate) fn default_value(&self) -> Value {
+        match self {
+            ExprType::Boolean => Value::Boolean(false),
+            ExprType::Double => Value::Double(0.0),
+            ExprType::Integer => Value::Integer(0),
+            ExprType::Text => Value::Text("".to_owned()),
+        }
+    }
 }
 
 impl From<ExprType> for VarType {
@@ -300,7 +310,7 @@ impl VarType {
     }
 
     /// Returns the default value to assign to this type.
-    pub fn default_value(&self) -> Value {
+    pub(crate) fn default_value(&self) -> Value {
         match self {
             VarType::Auto => Value::Integer(0),
             VarType::Boolean => Value::Boolean(false),

--- a/core/src/ast.rs
+++ b/core/src/ast.rs
@@ -277,17 +277,6 @@ impl VarRef {
         self.name
     }
 
-    /// Adds the type annotation `ref_type` to this reference.
-    ///
-    /// Assumes that the current annotation for this reference is not present.
-    pub(crate) fn qualify(self, expr_type: Option<ExprType>) -> Self {
-        assert!(self.ref_type.is_none(), "Reference already qualified");
-        match expr_type {
-            None => Self { name: self.name, ref_type: None },
-            Some(expr_type) => Self { name: self.name, ref_type: Some(expr_type) },
-        }
-    }
-
     /// Returns the type of this reference.
     pub fn ref_type(&self) -> Option<ExprType> {
         self.ref_type

--- a/core/src/bytecode.rs
+++ b/core/src/bytecode.rs
@@ -270,8 +270,17 @@ pub enum Instruction {
     /// Represents an conditional jump that jumps if the condition is not met.
     JumpIfNotTrue(Address),
 
-    /// Represents a load of a variable's value from main memory into the stack.
-    Load(SymbolKey, LineCol),
+    /// Represents a load of a boolean variable's value from main memory into the stack.
+    LoadBoolean(SymbolKey, LineCol),
+
+    /// Represents a load of a double variable's value from main memory into the stack.
+    LoadDouble(SymbolKey, LineCol),
+
+    /// Represents a load of an integer variable's value from main memory into the stack.
+    LoadInteger(SymbolKey, LineCol),
+
+    /// Represents a load of a string variable's value from main memory into the stack.
+    LoadString(SymbolKey, LineCol),
 
     /// Represents a load of a variable's reference into the stack.
     LoadRef(VarRef, LineCol),
@@ -344,7 +353,10 @@ impl Instruction {
             | Instruction::FunctionCall(_, _, _, _)
             | Instruction::DoubleToInteger
             | Instruction::IntegerToDouble
-            | Instruction::Load(_, _)
+            | Instruction::LoadBoolean(_, _)
+            | Instruction::LoadDouble(_, _)
+            | Instruction::LoadInteger(_, _)
+            | Instruction::LoadString(_, _)
             | Instruction::LoadRef(_, _)
             | Instruction::Push(_, _) => false,
 

--- a/core/src/bytecode.rs
+++ b/core/src/bytecode.rs
@@ -288,8 +288,17 @@ pub enum Instruction {
     /// Represents an instruction that does nothing.
     Nop,
 
-    /// Represents a load of a literal value into the top of the stack.
-    Push(Value, LineCol),
+    /// Represents a load of a literal boolean value into the top of the stack.
+    PushBoolean(bool, LineCol),
+
+    /// Represents a load of a literal double value into the top of the stack.
+    PushDouble(f64, LineCol),
+
+    /// Represents a load of a literal integer value into the top of the stack.
+    PushInteger(i32, LineCol),
+
+    /// Represents a load of a literal string value into the top of the stack.
+    PushString(String, LineCol),
 
     /// Represents a return after a call.
     Return(LineCol),
@@ -358,7 +367,10 @@ impl Instruction {
             | Instruction::LoadInteger(_, _)
             | Instruction::LoadString(_, _)
             | Instruction::LoadRef(_, _)
-            | Instruction::Push(_, _) => false,
+            | Instruction::PushBoolean(_, _)
+            | Instruction::PushDouble(_, _)
+            | Instruction::PushInteger(_, _)
+            | Instruction::PushString(_, _) => false,
 
             Instruction::ArrayAssignment(_, _, _)
             | Instruction::Assign(_)

--- a/core/src/bytecode.rs
+++ b/core/src/bytecode.rs
@@ -36,7 +36,7 @@ pub struct DimArrayISpan {
     pub dimensions: usize,
 
     /// Type of the array to be defined.
-    pub subtype: VarType,
+    pub subtype: ExprType,
 
     /// Position of the subtype.
     pub subtype_pos: LineCol,
@@ -243,7 +243,7 @@ pub enum Instruction {
     FunctionCall(SymbolKey, VarType, LineCol, usize),
 
     /// Represents a variable definition.
-    Dim(SymbolKey, VarType),
+    Dim(SymbolKey, ExprType),
 
     /// Represents an array definition.
     DimArray(DimArrayISpan),

--- a/core/src/bytecode.rs
+++ b/core/src/bytecode.rs
@@ -15,7 +15,7 @@
 
 //! Low-level representation of an EndBASIC program for execution.
 
-use crate::ast::*;
+use crate::ast::{ExprType, Value, VarRef};
 use crate::reader::LineCol;
 use crate::syms::SymbolKey;
 
@@ -240,7 +240,7 @@ pub enum Instruction {
     Call(JumpISpan),
 
     /// Represents a call to the given function with the given number of arguments.
-    FunctionCall(SymbolKey, VarType, LineCol, usize),
+    FunctionCall(SymbolKey, ExprType, LineCol, usize),
 
     /// Represents a variable definition.
     Dim(SymbolKey, ExprType),

--- a/core/src/bytecode.rs
+++ b/core/src/bytecode.rs
@@ -15,7 +15,7 @@
 
 //! Low-level representation of an EndBASIC program for execution.
 
-use crate::ast::{ExprType, Value, VarRef};
+use crate::ast::{ExprType, Value};
 use crate::reader::LineCol;
 use crate::syms::SymbolKey;
 
@@ -283,7 +283,7 @@ pub enum Instruction {
     LoadString(SymbolKey, LineCol),
 
     /// Represents a load of a variable's reference into the stack.
-    LoadRef(VarRef, LineCol),
+    LoadRef(SymbolKey, ExprType, LineCol),
 
     /// Represents an instruction that does nothing.
     Nop,
@@ -366,7 +366,7 @@ impl Instruction {
             | Instruction::LoadDouble(_, _)
             | Instruction::LoadInteger(_, _)
             | Instruction::LoadString(_, _)
-            | Instruction::LoadRef(_, _)
+            | Instruction::LoadRef(_, _, _)
             | Instruction::PushBoolean(_, _)
             | Instruction::PushDouble(_, _)
             | Instruction::PushInteger(_, _)

--- a/core/src/compiler/args.rs
+++ b/core/src/compiler/args.rs
@@ -335,11 +335,8 @@ fn compile_required_ref(
                     }
                     debug_assert!(!require_array);
 
-                    let vtype = if span.vref.ref_type() == VarType::Auto {
-                        ExprType::Integer
-                    } else {
-                        span.vref.ref_type().into()
-                    };
+                    let vtype =
+                        ExprType::from_vartype(span.vref.ref_type(), Some(ExprType::Integer));
 
                     if !span.vref.accepts(vtype.into()) {
                         return Err(CallError::ArgumentError(

--- a/core/src/compiler/args.rs
+++ b/core/src/compiler/args.rs
@@ -392,7 +392,7 @@ fn compile_required_ref(
                 }
 
                 Some(SymbolPrototype::Callable(md)) => {
-                    if !span.vref.accepts(md.return_type()) {
+                    if !span.vref.accepts_callable(md.return_type()) {
                         return Err(CallError::ArgumentError(
                             span.pos,
                             format!("Incompatible type annotation in {} reference", span.vref),

--- a/core/src/compiler/args.rs
+++ b/core/src/compiler/args.rs
@@ -345,7 +345,7 @@ fn compile_required_ref(
                         ));
                     }
 
-                    instrs.push(Instruction::LoadRef(span.vref, span.pos));
+                    instrs.push(Instruction::LoadRef(key.clone(), vtype, span.pos));
                     Ok(Some((key, SymbolPrototype::Variable(vtype))))
                 }
 
@@ -366,7 +366,7 @@ fn compile_required_ref(
                         ));
                     }
 
-                    instrs.push(Instruction::LoadRef(span.vref, span.pos));
+                    instrs.push(Instruction::LoadRef(key, vtype, span.pos));
                     Ok(None)
                 }
 
@@ -387,7 +387,7 @@ fn compile_required_ref(
                         ));
                     }
 
-                    instrs.push(Instruction::LoadRef(span.vref, span.pos));
+                    instrs.push(Instruction::LoadRef(key, vtype, span.pos));
                     Ok(None)
                 }
 
@@ -1196,7 +1196,7 @@ mod compile_tests {
                 sep: ArgSep::End,
                 sep_pos: lc(1, 5),
             }])
-            .exp_instr(Instruction::LoadRef(VarRef::new("foo", VarType::Auto), lc(1, 2)))
+            .exp_instr(Instruction::LoadRef(SymbolKey::from("foo"), ExprType::Text, lc(1, 2)))
             .exp_nargs(1)
             .check();
     }
@@ -1331,7 +1331,7 @@ mod compile_tests {
                 sep: ArgSep::End,
                 sep_pos: lc(1, 5),
             }])
-            .exp_instr(Instruction::LoadRef(VarRef::new("foo", VarType::Auto), lc(1, 2)))
+            .exp_instr(Instruction::LoadRef(SymbolKey::from("foo"), ExprType::Integer, lc(1, 2)))
             .exp_nargs(1)
             .exp_symbol("foo", ExprType::Integer)
             .check();
@@ -1355,7 +1355,7 @@ mod compile_tests {
                 sep: ArgSep::End,
                 sep_pos: lc(1, 6),
             }])
-            .exp_instr(Instruction::LoadRef(VarRef::new("foo", VarType::Text), lc(1, 2)))
+            .exp_instr(Instruction::LoadRef(SymbolKey::from("foo"), ExprType::Text, lc(1, 2)))
             .exp_nargs(1)
             .exp_symbol("foo", ExprType::Text)
             .check();
@@ -1403,8 +1403,8 @@ mod compile_tests {
                     sep_pos: lc(1, 5),
                 },
             ])
-            .exp_instr(Instruction::LoadRef(VarRef::new("foo", VarType::Auto), lc(1, 2)))
-            .exp_instr(Instruction::LoadRef(VarRef::new("foo", VarType::Auto), lc(1, 2)))
+            .exp_instr(Instruction::LoadRef(SymbolKey::from("foo"), ExprType::Integer, lc(1, 2)))
+            .exp_instr(Instruction::LoadRef(SymbolKey::from("foo"), ExprType::Integer, lc(1, 2)))
             .exp_nargs(2)
             .exp_symbol("foo", ExprType::Integer)
             .check();
@@ -1429,7 +1429,7 @@ mod compile_tests {
                 sep: ArgSep::End,
                 sep_pos: lc(1, 5),
             }])
-            .exp_instr(Instruction::LoadRef(VarRef::new("foo", VarType::Auto), lc(1, 2)))
+            .exp_instr(Instruction::LoadRef(SymbolKey::from("foo"), ExprType::Text, lc(1, 2)))
             .exp_nargs(1)
             .check();
     }
@@ -1896,7 +1896,7 @@ mod compile_tests {
                 sep: ArgSep::End,
                 sep_pos: lc(1, 2),
             }])
-            .exp_instr(Instruction::LoadRef(VarRef::new("foo", VarType::Text), lc(1, 2)))
+            .exp_instr(Instruction::LoadRef(SymbolKey::from("foo"), ExprType::Text, lc(1, 2)))
             .exp_nargs(1)
             .check();
     }

--- a/core/src/compiler/args.rs
+++ b/core/src/compiler/args.rs
@@ -1189,7 +1189,7 @@ mod compile_tests {
             )
             .compile_command([ArgSpan {
                 expr: Some(Expr::Symbol(SymbolSpan {
-                    vref: VarRef::new("foo", VarType::Auto),
+                    vref: VarRef::new("foo", None),
                     pos: lc(1, 2),
                 })),
                 sep: ArgSep::End,
@@ -1216,7 +1216,7 @@ mod compile_tests {
             )
             .compile_command([ArgSpan {
                 expr: Some(Expr::Symbol(SymbolSpan {
-                    vref: VarRef::new("foo", VarType::Auto),
+                    vref: VarRef::new("foo", None),
                     pos: lc(1, 2),
                 })),
                 sep: ArgSep::End,
@@ -1269,7 +1269,7 @@ mod compile_tests {
             )
             .compile_command([ArgSpan {
                 expr: Some(Expr::Symbol(SymbolSpan {
-                    vref: VarRef::new("foo", VarType::Auto),
+                    vref: VarRef::new("foo", None),
                     pos: lc(1, 2),
                 })),
                 sep: ArgSep::End,
@@ -1299,7 +1299,7 @@ mod compile_tests {
             )
             .compile_command([ArgSpan {
                 expr: Some(Expr::Symbol(SymbolSpan {
-                    vref: VarRef::new("foo", VarType::Integer),
+                    vref: VarRef::new("foo", Some(VarType::Integer)),
                     pos: lc(1, 2),
                 })),
                 sep: ArgSep::End,
@@ -1324,7 +1324,7 @@ mod compile_tests {
             )
             .compile_command([ArgSpan {
                 expr: Some(Expr::Symbol(SymbolSpan {
-                    vref: VarRef::new("foo", VarType::Auto),
+                    vref: VarRef::new("foo", None),
                     pos: lc(1, 2),
                 })),
                 sep: ArgSep::End,
@@ -1348,7 +1348,7 @@ mod compile_tests {
             )
             .compile_command([ArgSpan {
                 expr: Some(Expr::Symbol(SymbolSpan {
-                    vref: VarRef::new("foo", VarType::Text),
+                    vref: VarRef::new("foo", Some(VarType::Text)),
                     pos: lc(1, 2),
                 })),
                 sep: ArgSep::End,
@@ -1387,7 +1387,7 @@ mod compile_tests {
             .compile_command([
                 ArgSpan {
                     expr: Some(Expr::Symbol(SymbolSpan {
-                        vref: VarRef::new("foo", VarType::Auto),
+                        vref: VarRef::new("foo", None),
                         pos: lc(1, 2),
                     })),
                     sep: ArgSep::Long,
@@ -1395,7 +1395,7 @@ mod compile_tests {
                 },
                 ArgSpan {
                     expr: Some(Expr::Symbol(SymbolSpan {
-                        vref: VarRef::new("foo", VarType::Auto),
+                        vref: VarRef::new("foo", None),
                         pos: lc(1, 2),
                     })),
                     sep: ArgSep::End,
@@ -1422,7 +1422,7 @@ mod compile_tests {
             )
             .compile_command([ArgSpan {
                 expr: Some(Expr::Symbol(SymbolSpan {
-                    vref: VarRef::new("foo", VarType::Auto),
+                    vref: VarRef::new("foo", None),
                     pos: lc(1, 2),
                 })),
                 sep: ArgSep::End,
@@ -1445,7 +1445,7 @@ mod compile_tests {
             )
             .compile_command([ArgSpan {
                 expr: Some(Expr::Symbol(SymbolSpan {
-                    vref: VarRef::new("foo", VarType::Auto),
+                    vref: VarRef::new("foo", None),
                     pos: lc(1, 2),
                 })),
                 sep: ArgSep::End,
@@ -1490,7 +1490,7 @@ mod compile_tests {
             )
             .compile_command([ArgSpan {
                 expr: Some(Expr::Symbol(SymbolSpan {
-                    vref: VarRef::new("foo", VarType::Auto),
+                    vref: VarRef::new("foo", None),
                     pos: lc(1, 2),
                 })),
                 sep: ArgSep::End,
@@ -1516,7 +1516,7 @@ mod compile_tests {
             )
             .compile_command([ArgSpan {
                 expr: Some(Expr::Symbol(SymbolSpan {
-                    vref: VarRef::new("foo", VarType::Integer),
+                    vref: VarRef::new("foo", Some(VarType::Integer)),
                     pos: lc(1, 2),
                 })),
                 sep: ArgSep::End,
@@ -1647,7 +1647,7 @@ mod compile_tests {
             )
             .compile_command([ArgSpan {
                 expr: Some(Expr::Symbol(SymbolSpan {
-                    vref: VarRef::new("foo", VarType::Boolean),
+                    vref: VarRef::new("foo", Some(VarType::Boolean)),
                     pos: lc(1, 2),
                 })),
                 sep: ArgSep::End,
@@ -1889,7 +1889,7 @@ mod compile_tests {
             )
             .compile_command([ArgSpan {
                 expr: Some(Expr::Symbol(SymbolSpan {
-                    vref: VarRef::new("foo", VarType::Text),
+                    vref: VarRef::new("foo", Some(VarType::Text)),
                     pos: lc(1, 2),
                 })),
                 sep: ArgSep::End,

--- a/core/src/compiler/args.rs
+++ b/core/src/compiler/args.rs
@@ -335,7 +335,7 @@ fn compile_required_ref(
                     }
                     debug_assert!(!require_array);
 
-                    let vtype = ExprType::from_vartype(span.vref.ref_type(), ExprType::Integer);
+                    let vtype = span.vref.ref_type().unwrap_or(ExprType::Integer);
 
                     if !span.vref.accepts(vtype) {
                         return Err(CallError::ArgumentError(
@@ -1299,7 +1299,7 @@ mod compile_tests {
             )
             .compile_command([ArgSpan {
                 expr: Some(Expr::Symbol(SymbolSpan {
-                    vref: VarRef::new("foo", Some(VarType::Integer)),
+                    vref: VarRef::new("foo", Some(ExprType::Integer)),
                     pos: lc(1, 2),
                 })),
                 sep: ArgSep::End,
@@ -1348,7 +1348,7 @@ mod compile_tests {
             )
             .compile_command([ArgSpan {
                 expr: Some(Expr::Symbol(SymbolSpan {
-                    vref: VarRef::new("foo", Some(VarType::Text)),
+                    vref: VarRef::new("foo", Some(ExprType::Text)),
                     pos: lc(1, 2),
                 })),
                 sep: ArgSep::End,
@@ -1516,7 +1516,7 @@ mod compile_tests {
             )
             .compile_command([ArgSpan {
                 expr: Some(Expr::Symbol(SymbolSpan {
-                    vref: VarRef::new("foo", Some(VarType::Integer)),
+                    vref: VarRef::new("foo", Some(ExprType::Integer)),
                     pos: lc(1, 2),
                 })),
                 sep: ArgSep::End,
@@ -1647,7 +1647,7 @@ mod compile_tests {
             )
             .compile_command([ArgSpan {
                 expr: Some(Expr::Symbol(SymbolSpan {
-                    vref: VarRef::new("foo", Some(VarType::Boolean)),
+                    vref: VarRef::new("foo", Some(ExprType::Boolean)),
                     pos: lc(1, 2),
                 })),
                 sep: ArgSep::End,
@@ -1889,7 +1889,7 @@ mod compile_tests {
             )
             .compile_command([ArgSpan {
                 expr: Some(Expr::Symbol(SymbolSpan {
-                    vref: VarRef::new("foo", Some(VarType::Text)),
+                    vref: VarRef::new("foo", Some(ExprType::Text)),
                     pos: lc(1, 2),
                 })),
                 sep: ArgSep::End,

--- a/core/src/compiler/args.rs
+++ b/core/src/compiler/args.rs
@@ -335,10 +335,9 @@ fn compile_required_ref(
                     }
                     debug_assert!(!require_array);
 
-                    let vtype =
-                        ExprType::from_vartype(span.vref.ref_type(), Some(ExprType::Integer));
+                    let vtype = ExprType::from_vartype(span.vref.ref_type(), ExprType::Integer);
 
-                    if !span.vref.accepts(vtype.into()) {
+                    if !span.vref.accepts(vtype) {
                         return Err(CallError::ArgumentError(
                             span.pos,
                             format!("Incompatible type annotation in {} reference", span.vref),
@@ -352,7 +351,7 @@ fn compile_required_ref(
                 Some(SymbolPrototype::Array(vtype, _)) => {
                     let vtype = *vtype;
 
-                    if !span.vref.accepts(vtype.into()) {
+                    if !span.vref.accepts(vtype) {
                         return Err(CallError::ArgumentError(
                             span.pos,
                             format!("Incompatible type annotation in {} reference", span.vref),
@@ -373,7 +372,7 @@ fn compile_required_ref(
                 Some(SymbolPrototype::Variable(vtype)) => {
                     let vtype = *vtype;
 
-                    if !span.vref.accepts(vtype.into()) {
+                    if !span.vref.accepts(vtype) {
                         return Err(CallError::ArgumentError(
                             span.pos,
                             format!("Incompatible type annotation in {} reference", span.vref),

--- a/core/src/compiler/exprs.rs
+++ b/core/src/compiler/exprs.rs
@@ -397,7 +397,7 @@ fn compile_expr_symbol(
             let nargs = compile_function_args(md.syntaxes(), instrs, symtable, span.pos, vec![])
                 .map_err(|e| Error::from_call_error(md, e, span.pos))?;
             debug_assert_eq!(0, nargs, "Argless compiler must have returned zero arguments");
-            (Instruction::FunctionCall(key, etype.into(), span.pos, 0), etype)
+            (Instruction::FunctionCall(key, etype, span.pos, 0), etype)
         }
     };
     if !span.vref.accepts(vtype.into()) {
@@ -745,7 +745,7 @@ pub(super) fn compile_expr(
                     let nargs =
                         compile_function_args(md.syntaxes(), instrs, symtable, span_pos, span.args)
                             .map_err(|e| Error::from_call_error(md, e, span_pos))?;
-                    instrs.push(Instruction::FunctionCall(key, vtype.into(), span_pos, nargs));
+                    instrs.push(Instruction::FunctionCall(key, vtype, span_pos, nargs));
                     Ok(vtype)
                 }
 
@@ -855,7 +855,7 @@ mod tests {
             .compile()
             .expect_instr(
                 0,
-                Instruction::FunctionCall(SymbolKey::from("f"), VarType::Integer, lc(1, 5), 0),
+                Instruction::FunctionCall(SymbolKey::from("f"), ExprType::Integer, lc(1, 5), 0),
             )
             .expect_instr(1, Instruction::Assign(SymbolKey::from("i")))
             .check();
@@ -1299,7 +1299,7 @@ mod tests {
             .expect_instr(6, Instruction::PushInteger(3, lc(1, 9)))
             .expect_instr(
                 7,
-                Instruction::FunctionCall(SymbolKey::from("FOO"), VarType::Integer, lc(1, 5), 3),
+                Instruction::FunctionCall(SymbolKey::from("FOO"), ExprType::Integer, lc(1, 5), 3),
             )
             .expect_instr(8, Instruction::Assign(SymbolKey::from("i")))
             .check();

--- a/core/src/compiler/exprs.rs
+++ b/core/src/compiler/exprs.rs
@@ -353,7 +353,7 @@ fn compile_expr_symbol(
 
         Some(SymbolPrototype::Array(atype, _dims)) => {
             if allow_varrefs {
-                (Instruction::LoadRef(span.vref.clone(), span.pos), *atype)
+                (Instruction::LoadRef(key, *atype, span.pos), *atype)
             } else {
                 return Err(Error::new(
                     span.pos,
@@ -364,7 +364,7 @@ fn compile_expr_symbol(
 
         Some(SymbolPrototype::Variable(vtype)) => {
             if allow_varrefs {
-                (Instruction::LoadRef(span.vref.clone(), span.pos), *vtype)
+                (Instruction::LoadRef(key, *vtype, span.pos), *vtype)
             } else {
                 let instr = match vtype {
                     ExprType::Boolean => Instruction::LoadBoolean,
@@ -428,8 +428,8 @@ fn compile_expr_symbol_ref(
                 ));
             }
 
-            symtable.insert(key, SymbolPrototype::Variable(vtype));
-            instrs.push(Instruction::LoadRef(span.vref, span.pos));
+            symtable.insert(key.clone(), SymbolPrototype::Variable(vtype));
+            instrs.push(Instruction::LoadRef(key, vtype, span.pos));
             Ok(vtype)
         }
 
@@ -443,7 +443,7 @@ fn compile_expr_symbol_ref(
                 ));
             }
 
-            instrs.push(Instruction::LoadRef(span.vref, span.pos));
+            instrs.push(Instruction::LoadRef(key, vtype, span.pos));
             Ok(vtype)
         }
 
@@ -973,7 +973,10 @@ mod tests {
             )]))
             .parse("c a")
             .compile()
-            .expect_instr(0, Instruction::LoadRef(VarRef::new("a", VarType::Auto), lc(1, 3)))
+            .expect_instr(
+                0,
+                Instruction::LoadRef(SymbolKey::from("a"), ExprType::Integer, lc(1, 3)),
+            )
             .expect_instr(1, Instruction::BuiltinCall(SymbolKey::from("C"), lc(1, 1), 1))
             .check();
     }

--- a/core/src/compiler/exprs.rs
+++ b/core/src/compiler/exprs.rs
@@ -400,7 +400,7 @@ fn compile_expr_symbol(
             (Instruction::FunctionCall(key, etype, span.pos, 0), etype)
         }
     };
-    if !span.vref.accepts(vtype.into()) {
+    if !span.vref.accepts(vtype) {
         return Err(Error::new(
             span.pos,
             format!("Incompatible type annotation in {} reference", span.vref),
@@ -419,9 +419,9 @@ fn compile_expr_symbol_ref(
     let key = SymbolKey::from(span.vref.name());
     match symtable.get(&key) {
         None => {
-            let vtype = ExprType::from_vartype(span.vref.ref_type(), Some(ExprType::Integer));
+            let vtype = ExprType::from_vartype(span.vref.ref_type(), ExprType::Integer);
 
-            if !span.vref.accepts(vtype.into()) {
+            if !span.vref.accepts(vtype) {
                 return Err(Error::new(
                     span.pos,
                     format!("Incompatible type annotation in {} reference", span.vref),
@@ -436,7 +436,7 @@ fn compile_expr_symbol_ref(
         Some(SymbolPrototype::Array(vtype, _)) | Some(SymbolPrototype::Variable(vtype)) => {
             let vtype = *vtype;
 
-            if !span.vref.accepts(vtype.into()) {
+            if !span.vref.accepts(vtype) {
                 return Err(Error::new(
                     span.pos,
                     format!("Incompatible type annotation in {} reference", span.vref),
@@ -476,7 +476,7 @@ fn compile_array_ref(
     let nargs = exprs.len();
     compile_array_indices(instrs, symtable, dimensions, exprs, span.vref_pos)?;
 
-    if !span.vref.accepts(vtype.into()) {
+    if !span.vref.accepts(vtype) {
         return Err(Error::new(
             span.vref_pos,
             format!("Incompatible type annotation in {} reference", span.vref),

--- a/core/src/compiler/exprs.rs
+++ b/core/src/compiler/exprs.rs
@@ -419,7 +419,7 @@ fn compile_expr_symbol_ref(
     let key = SymbolKey::from(span.vref.name());
     match symtable.get(&key) {
         None => {
-            let vtype = ExprType::from_vartype(span.vref.ref_type(), ExprType::Integer);
+            let vtype = span.vref.ref_type().unwrap_or(ExprType::Integer);
 
             if !span.vref.accepts(vtype) {
                 return Err(Error::new(

--- a/core/src/compiler/exprs.rs
+++ b/core/src/compiler/exprs.rs
@@ -24,7 +24,7 @@ use crate::reader::LineCol;
 use crate::syms::SymbolKey;
 
 /// Compiles the indices used to address an array.
-pub(crate) fn compile_array_indices(
+pub(super) fn compile_array_indices(
     instrs: &mut Vec<Instruction>,
     symtable: &SymbolsTable,
     exp_nargs: usize,
@@ -402,7 +402,7 @@ fn compile_expr_symbol(
 }
 
 /// Compiles the load of a symbol in the context of a command argument.
-pub fn compile_expr_symbol_ref(
+fn compile_expr_symbol_ref(
     instrs: &mut Vec<Instruction>,
     symtable: &mut SymbolsTable,
     span: SymbolSpan,
@@ -487,7 +487,7 @@ fn compile_array_ref(
 /// `allow_varrefs` should be true for top-level expression compilations within function arguments.
 /// In that specific case, we must leave bare variable and array references unevaluated because we
 /// don't know if the function wants to take the reference or the value.
-pub fn compile_expr(
+pub(super) fn compile_expr(
     instrs: &mut Vec<Instruction>,
     symtable: &SymbolsTable,
     expr: Expr,
@@ -762,7 +762,7 @@ pub fn compile_expr(
 /// This function should be used only when compiling the arguments to a builtin command, because
 /// in that context, we need mutable access to the `symtable`in order to define output variables
 /// (if any).
-pub fn compile_expr_in_command(
+pub(super) fn compile_expr_in_command(
     instrs: &mut Vec<Instruction>,
     symtable: &mut SymbolsTable,
     expr: Expr,

--- a/core/src/compiler/mod.rs
+++ b/core/src/compiler/mod.rs
@@ -155,54 +155,6 @@ impl fmt::Display for ExprType {
     }
 }
 
-/// Represents the type of a callable.
-///
-/// This is a superset of `ExprType` with the addition of the `Void` required to represent
-/// commands.
-#[derive(Clone, Copy, PartialEq)]
-#[cfg_attr(any(debug_assertions, test), derive(Debug))]
-enum CallableType {
-    /// Type for a function that returns a boolean.
-    Boolean,
-
-    /// Type for a function that returns a double.
-    Double,
-
-    /// Type for a function that returns an integer.
-    Integer,
-
-    /// Type for a function that returns a string.
-    Text,
-
-    /// Type for a builtin command.
-    Void,
-}
-
-impl From<VarType> for CallableType {
-    fn from(value: VarType) -> Self {
-        match value {
-            VarType::Auto => unreachable!(),
-            VarType::Boolean => CallableType::Boolean,
-            VarType::Double => CallableType::Double,
-            VarType::Integer => CallableType::Integer,
-            VarType::Text => CallableType::Text,
-            VarType::Void => CallableType::Void,
-        }
-    }
-}
-
-impl From<CallableType> for VarType {
-    fn from(value: CallableType) -> Self {
-        match value {
-            CallableType::Boolean => VarType::Boolean,
-            CallableType::Double => VarType::Double,
-            CallableType::Integer => VarType::Integer,
-            CallableType::Text => VarType::Text,
-            CallableType::Void => VarType::Void,
-        }
-    }
-}
-
 /// Information about a symbol in the symbols table.
 #[derive(Clone)]
 enum SymbolPrototype {

--- a/core/src/compiler/mod.rs
+++ b/core/src/compiler/mod.rs
@@ -122,8 +122,7 @@ impl From<&Symbols> for SymbolsTable {
                 }
                 Symbol::Variable(var) => SymbolPrototype::Variable(var.as_exprtype()),
             };
-            debug_assert_eq!(name, &name.to_ascii_uppercase());
-            table.insert(SymbolKey::from(name), proto);
+            table.insert(name.clone(), proto);
         }
         Self { table }
     }

--- a/core/src/compiler/mod.rs
+++ b/core/src/compiler/mod.rs
@@ -1190,9 +1190,9 @@ mod tests {
             .parse("foo(3, 4 + i, i) = 5")
             .compile()
             .expect_instr(0, Instruction::Push(Value::Integer(5), lc(1, 20)))
-            .expect_instr(1, Instruction::Load(SymbolKey::from("i"), lc(1, 15)))
+            .expect_instr(1, Instruction::LoadInteger(SymbolKey::from("i"), lc(1, 15)))
             .expect_instr(2, Instruction::Push(Value::Integer(4), lc(1, 8)))
-            .expect_instr(3, Instruction::Load(SymbolKey::from("i"), lc(1, 12)))
+            .expect_instr(3, Instruction::LoadInteger(SymbolKey::from("i"), lc(1, 12)))
             .expect_instr(4, Instruction::AddIntegers(lc(1, 10)))
             .expect_instr(5, Instruction::Push(Value::Integer(3), lc(1, 5)))
             .expect_instr(6, Instruction::ArrayAssignment(SymbolKey::from("foo"), lc(1, 1), 3))
@@ -1251,7 +1251,7 @@ mod tests {
             .define("d", SymbolPrototype::Variable(ExprType::Double))
             .parse("a(3) = d")
             .compile()
-            .expect_instr(0, Instruction::Load(SymbolKey::from("d"), lc(1, 8)))
+            .expect_instr(0, Instruction::LoadDouble(SymbolKey::from("d"), lc(1, 8)))
             .expect_instr(1, Instruction::DoubleToInteger)
             .expect_instr(2, Instruction::Push(Value::Integer(3), lc(1, 3)))
             .expect_instr(3, Instruction::ArrayAssignment(SymbolKey::from("a"), lc(1, 1), 1))
@@ -1265,7 +1265,7 @@ mod tests {
             .define("i", SymbolPrototype::Variable(ExprType::Integer))
             .parse("a(3) = i")
             .compile()
-            .expect_instr(0, Instruction::Load(SymbolKey::from("i"), lc(1, 8)))
+            .expect_instr(0, Instruction::LoadInteger(SymbolKey::from("i"), lc(1, 8)))
             .expect_instr(1, Instruction::IntegerToDouble)
             .expect_instr(2, Instruction::Push(Value::Integer(3), lc(1, 3)))
             .expect_instr(3, Instruction::ArrayAssignment(SymbolKey::from("a"), lc(1, 1), 1))
@@ -1329,7 +1329,7 @@ mod tests {
             .define("i", SymbolPrototype::Variable(ExprType::Integer))
             .parse("foo = i")
             .compile()
-            .expect_instr(0, Instruction::Load(SymbolKey::from("i"), lc(1, 7)))
+            .expect_instr(0, Instruction::LoadInteger(SymbolKey::from("i"), lc(1, 7)))
             .expect_instr(1, Instruction::Assign(SymbolKey::from("foo")))
             .check();
     }
@@ -1521,7 +1521,7 @@ mod tests {
             .expect_instr(0, Instruction::Push(Value::Integer(3), lc(1, 12)))
             .expect_instr(1, Instruction::Push(Value::Integer(4), lc(1, 16)))
             .expect_instr(2, Instruction::AddIntegers(lc(1, 14)))
-            .expect_instr(3, Instruction::Load(SymbolKey::from("i"), lc(1, 9)))
+            .expect_instr(3, Instruction::LoadInteger(SymbolKey::from("i"), lc(1, 9)))
             .expect_instr(
                 4,
                 Instruction::DimArray(DimArrayISpan {
@@ -1612,7 +1612,7 @@ mod tests {
             .parse("END 2 + i")
             .compile()
             .expect_instr(0, Instruction::Push(Value::Integer(2), lc(1, 5)))
-            .expect_instr(1, Instruction::Load(SymbolKey::from("i"), lc(1, 9)))
+            .expect_instr(1, Instruction::LoadInteger(SymbolKey::from("i"), lc(1, 9)))
             .expect_instr(2, Instruction::AddIntegers(lc(1, 7)))
             .expect_instr(3, Instruction::End(true))
             .check();
@@ -1624,7 +1624,7 @@ mod tests {
             .define("i", SymbolPrototype::Variable(ExprType::Integer))
             .parse("END i")
             .compile()
-            .expect_instr(0, Instruction::Load(SymbolKey::from("i"), lc(1, 5)))
+            .expect_instr(0, Instruction::LoadInteger(SymbolKey::from("i"), lc(1, 5)))
             .expect_instr(1, Instruction::End(true))
             .check();
     }
@@ -1741,13 +1741,13 @@ mod tests {
             .compile()
             .expect_instr(0, Instruction::Push(Value::Integer(1), lc(1, 12)))
             .expect_instr(1, Instruction::Assign(SymbolKey::from("iter")))
-            .expect_instr(2, Instruction::Load(SymbolKey::from("iter"), lc(1, 5)))
+            .expect_instr(2, Instruction::LoadInteger(SymbolKey::from("iter"), lc(1, 5)))
             .expect_instr(3, Instruction::Push(Value::Integer(5), lc(1, 17)))
             .expect_instr(4, Instruction::LessEqualIntegers(lc(1, 14)))
             .expect_instr(5, Instruction::JumpIfNotTrue(13))
             .expect_instr(6, Instruction::Push(Value::Boolean(false), lc(1, 24)))
             .expect_instr(7, Instruction::Assign(SymbolKey::from("a")))
-            .expect_instr(8, Instruction::Load(SymbolKey::from("iter"), lc(1, 5)))
+            .expect_instr(8, Instruction::LoadInteger(SymbolKey::from("iter"), lc(1, 5)))
             .expect_instr(9, Instruction::Push(Value::Integer(1), lc(1, 18)))
             .expect_instr(10, Instruction::AddIntegers(lc(1, 14)))
             .expect_instr(11, Instruction::Assign(SymbolKey::from("iter")))
@@ -1762,15 +1762,15 @@ mod tests {
             .define("j", SymbolPrototype::Variable(ExprType::Integer))
             .parse("FOR iter = i TO j: a = FALSE: NEXT")
             .compile()
-            .expect_instr(0, Instruction::Load(SymbolKey::from("i"), lc(1, 12)))
+            .expect_instr(0, Instruction::LoadInteger(SymbolKey::from("i"), lc(1, 12)))
             .expect_instr(1, Instruction::Assign(SymbolKey::from("iter")))
-            .expect_instr(2, Instruction::Load(SymbolKey::from("iter"), lc(1, 5)))
-            .expect_instr(3, Instruction::Load(SymbolKey::from("j"), lc(1, 17)))
+            .expect_instr(2, Instruction::LoadInteger(SymbolKey::from("iter"), lc(1, 5)))
+            .expect_instr(3, Instruction::LoadInteger(SymbolKey::from("j"), lc(1, 17)))
             .expect_instr(4, Instruction::LessEqualIntegers(lc(1, 14)))
             .expect_instr(5, Instruction::JumpIfNotTrue(13))
             .expect_instr(6, Instruction::Push(Value::Boolean(false), lc(1, 24)))
             .expect_instr(7, Instruction::Assign(SymbolKey::from("a")))
-            .expect_instr(8, Instruction::Load(SymbolKey::from("iter"), lc(1, 5)))
+            .expect_instr(8, Instruction::LoadInteger(SymbolKey::from("iter"), lc(1, 5)))
             .expect_instr(9, Instruction::Push(Value::Integer(1), lc(1, 18)))
             .expect_instr(10, Instruction::AddIntegers(lc(1, 14)))
             .expect_instr(11, Instruction::Assign(SymbolKey::from("iter")))
@@ -1785,19 +1785,19 @@ mod tests {
             .define("j", SymbolPrototype::Variable(ExprType::Integer))
             .parse("FOR iter = (i + 1) TO (2 + j): a = FALSE: NEXT")
             .compile()
-            .expect_instr(0, Instruction::Load(SymbolKey::from("i"), lc(1, 13)))
+            .expect_instr(0, Instruction::LoadInteger(SymbolKey::from("i"), lc(1, 13)))
             .expect_instr(1, Instruction::Push(Value::Integer(1), lc(1, 17)))
             .expect_instr(2, Instruction::AddIntegers(lc(1, 15)))
             .expect_instr(3, Instruction::Assign(SymbolKey::from("iter")))
-            .expect_instr(4, Instruction::Load(SymbolKey::from("iter"), lc(1, 5)))
+            .expect_instr(4, Instruction::LoadInteger(SymbolKey::from("iter"), lc(1, 5)))
             .expect_instr(5, Instruction::Push(Value::Integer(2), lc(1, 24)))
-            .expect_instr(6, Instruction::Load(SymbolKey::from("j"), lc(1, 28)))
+            .expect_instr(6, Instruction::LoadInteger(SymbolKey::from("j"), lc(1, 28)))
             .expect_instr(7, Instruction::AddIntegers(lc(1, 26)))
             .expect_instr(8, Instruction::LessEqualIntegers(lc(1, 20)))
             .expect_instr(9, Instruction::JumpIfNotTrue(17))
             .expect_instr(10, Instruction::Push(Value::Boolean(false), lc(1, 36)))
             .expect_instr(11, Instruction::Assign(SymbolKey::from("a")))
-            .expect_instr(12, Instruction::Load(SymbolKey::from("iter"), lc(1, 5)))
+            .expect_instr(12, Instruction::LoadInteger(SymbolKey::from("iter"), lc(1, 5)))
             .expect_instr(13, Instruction::Push(Value::Integer(1), lc(1, 30)))
             .expect_instr(14, Instruction::AddIntegers(lc(1, 20)))
             .expect_instr(15, Instruction::Assign(SymbolKey::from("iter")))
@@ -1821,12 +1821,12 @@ mod tests {
             .expect_instr(2, Instruction::Push(Value::Integer(0), lc(1, 12)))
             .expect_instr(3, Instruction::IntegerToDouble)
             .expect_instr(4, Instruction::Assign(SymbolKey::from("iter")))
-            .expect_instr(5, Instruction::Load(SymbolKey::from("iter"), lc(1, 5)))
+            .expect_instr(5, Instruction::LoadDouble(SymbolKey::from("iter"), lc(1, 5)))
             .expect_instr(6, Instruction::Push(Value::Integer(2), lc(1, 17)))
             .expect_instr(7, Instruction::IntegerToDouble)
             .expect_instr(8, Instruction::LessEqualDoubles(lc(1, 14)))
             .expect_instr(9, Instruction::JumpIfNotTrue(15))
-            .expect_instr(10, Instruction::Load(SymbolKey::from("iter"), lc(1, 5)))
+            .expect_instr(10, Instruction::LoadDouble(SymbolKey::from("iter"), lc(1, 5)))
             .expect_instr(11, Instruction::Push(Value::Double(0.1), lc(1, 24)))
             .expect_instr(12, Instruction::AddDoubles(lc(1, 14)))
             .expect_instr(13, Instruction::Assign(SymbolKey::from("iter")))
@@ -1966,7 +1966,7 @@ mod tests {
         do_compile_case_guard_test(
             "1 + 2",
             vec![
-                Instruction::Load(SymbolKey::from("0select1"), lc(2, 6)),
+                Instruction::LoadInteger(SymbolKey::from("0select1"), lc(2, 6)),
                 Instruction::Push(Value::Integer(1), lc(2, 6)),
                 Instruction::Push(Value::Integer(2), lc(2, 10)),
                 Instruction::AddIntegers(lc(2, 8)),
@@ -1980,7 +1980,7 @@ mod tests {
         do_compile_case_guard_test(
             "IS = 9 + 8",
             vec![
-                Instruction::Load(SymbolKey::from("0select1"), lc(2, 11)),
+                Instruction::LoadInteger(SymbolKey::from("0select1"), lc(2, 11)),
                 Instruction::Push(Value::Integer(9), lc(2, 11)),
                 Instruction::Push(Value::Integer(8), lc(2, 15)),
                 Instruction::AddIntegers(lc(2, 13)),
@@ -1991,7 +1991,7 @@ mod tests {
         do_compile_case_guard_test(
             "IS <> 9",
             vec![
-                Instruction::Load(SymbolKey::from("0select1"), lc(2, 12)),
+                Instruction::LoadInteger(SymbolKey::from("0select1"), lc(2, 12)),
                 Instruction::Push(Value::Integer(9), lc(2, 12)),
                 Instruction::NotEqualIntegers(lc(2, 12)),
             ],
@@ -2000,7 +2000,7 @@ mod tests {
         do_compile_case_guard_test(
             "IS < 9",
             vec![
-                Instruction::Load(SymbolKey::from("0select1"), lc(2, 11)),
+                Instruction::LoadInteger(SymbolKey::from("0select1"), lc(2, 11)),
                 Instruction::Push(Value::Integer(9), lc(2, 11)),
                 Instruction::LessIntegers(lc(2, 11)),
             ],
@@ -2009,7 +2009,7 @@ mod tests {
         do_compile_case_guard_test(
             "IS <= 9",
             vec![
-                Instruction::Load(SymbolKey::from("0select1"), lc(2, 12)),
+                Instruction::LoadInteger(SymbolKey::from("0select1"), lc(2, 12)),
                 Instruction::Push(Value::Integer(9), lc(2, 12)),
                 Instruction::LessEqualIntegers(lc(2, 12)),
             ],
@@ -2018,7 +2018,7 @@ mod tests {
         do_compile_case_guard_test(
             "IS > 9",
             vec![
-                Instruction::Load(SymbolKey::from("0select1"), lc(2, 11)),
+                Instruction::LoadInteger(SymbolKey::from("0select1"), lc(2, 11)),
                 Instruction::Push(Value::Integer(9), lc(2, 11)),
                 Instruction::GreaterIntegers(lc(2, 11)),
             ],
@@ -2027,7 +2027,7 @@ mod tests {
         do_compile_case_guard_test(
             "IS >= 9",
             vec![
-                Instruction::Load(SymbolKey::from("0select1"), lc(2, 12)),
+                Instruction::LoadInteger(SymbolKey::from("0select1"), lc(2, 12)),
                 Instruction::Push(Value::Integer(9), lc(2, 12)),
                 Instruction::GreaterEqualIntegers(lc(2, 12)),
             ],
@@ -2039,10 +2039,10 @@ mod tests {
         do_compile_case_guard_test(
             "1 TO 2",
             vec![
-                Instruction::Load(SymbolKey::from("0select1"), lc(2, 6)),
+                Instruction::LoadInteger(SymbolKey::from("0select1"), lc(2, 6)),
                 Instruction::Push(Value::Integer(1), lc(2, 6)),
                 Instruction::GreaterEqualIntegers(lc(2, 6)),
-                Instruction::Load(SymbolKey::from("0select1"), lc(2, 6)),
+                Instruction::LoadInteger(SymbolKey::from("0select1"), lc(2, 6)),
                 Instruction::Push(Value::Integer(2), lc(2, 11)),
                 Instruction::LessEqualIntegers(lc(2, 11)),
                 Instruction::LogicalAnd(lc(2, 6)),
@@ -2055,10 +2055,10 @@ mod tests {
         do_compile_case_guard_test(
             "IS <> 9, 8",
             vec![
-                Instruction::Load(SymbolKey::from("0select1"), lc(2, 12)),
+                Instruction::LoadInteger(SymbolKey::from("0select1"), lc(2, 12)),
                 Instruction::Push(Value::Integer(9), lc(2, 12)),
                 Instruction::NotEqualIntegers(lc(2, 12)),
-                Instruction::Load(SymbolKey::from("0select1"), lc(2, 15)),
+                Instruction::LoadInteger(SymbolKey::from("0select1"), lc(2, 15)),
                 Instruction::Push(Value::Integer(8), lc(2, 15)),
                 Instruction::EqualIntegers(lc(2, 15)),
                 Instruction::LogicalOr(lc(2, 12)),
@@ -2093,7 +2093,7 @@ mod tests {
             .compile()
             .expect_instr(0, Instruction::Push(Value::Integer(5), lc(1, 13)))
             .expect_instr(1, Instruction::Assign(SymbolKey::from("0select1")))
-            .expect_instr(2, Instruction::Load(SymbolKey::from("0select1"), lc(2, 6)))
+            .expect_instr(2, Instruction::LoadInteger(SymbolKey::from("0select1"), lc(2, 6)))
             .expect_instr(3, Instruction::Push(Value::Integer(7), lc(2, 6)))
             .expect_instr(4, Instruction::EqualIntegers(lc(2, 6)))
             .expect_instr(5, Instruction::JumpIfNotTrue(7))
@@ -2111,7 +2111,7 @@ mod tests {
             .define("i", SymbolPrototype::Variable(ExprType::Integer))
             .parse("SELECT CASE i: END SELECT")
             .compile()
-            .expect_instr(0, Instruction::Load(SymbolKey::from("i"), lc(1, 13)))
+            .expect_instr(0, Instruction::LoadInteger(SymbolKey::from("i"), lc(1, 13)))
             .expect_instr(1, Instruction::Assign(SymbolKey::from("0select1")))
             .expect_instr(
                 2,
@@ -2148,13 +2148,13 @@ mod tests {
             .compile()
             .expect_instr(0, Instruction::Push(Value::Integer(5), lc(1, 13)))
             .expect_instr(1, Instruction::Assign(SymbolKey::from("0select1")))
-            .expect_instr(2, Instruction::Load(SymbolKey::from("0select1"), lc(2, 6)))
+            .expect_instr(2, Instruction::LoadInteger(SymbolKey::from("0select1"), lc(2, 6)))
             .expect_instr(3, Instruction::Push(Value::Integer(7), lc(2, 6)))
             .expect_instr(4, Instruction::EqualIntegers(lc(2, 6)))
             .expect_instr(5, Instruction::JumpIfNotTrue(8))
             .expect_instr(6, Instruction::BuiltinCall(SymbolKey::from("FOO"), lc(3, 1), 0))
             .expect_instr(7, Instruction::Jump(JumpISpan { addr: 13 }))
-            .expect_instr(8, Instruction::Load(SymbolKey::from("0select1"), lc(4, 12)))
+            .expect_instr(8, Instruction::LoadInteger(SymbolKey::from("0select1"), lc(4, 12)))
             .expect_instr(9, Instruction::Push(Value::Integer(8), lc(4, 12)))
             .expect_instr(10, Instruction::NotEqualIntegers(lc(4, 12)))
             .expect_instr(11, Instruction::JumpIfNotTrue(13))
@@ -2175,7 +2175,7 @@ mod tests {
             .compile()
             .expect_instr(0, Instruction::Push(Value::Integer(5), lc(1, 13)))
             .expect_instr(1, Instruction::Assign(SymbolKey::from("0select1")))
-            .expect_instr(2, Instruction::Load(SymbolKey::from("0select1"), lc(2, 6)))
+            .expect_instr(2, Instruction::LoadInteger(SymbolKey::from("0select1"), lc(2, 6)))
             .expect_instr(3, Instruction::Push(Value::Integer(7), lc(2, 6)))
             .expect_instr(4, Instruction::EqualIntegers(lc(2, 6)))
             .expect_instr(5, Instruction::JumpIfNotTrue(8))

--- a/core/src/compiler/mod.rs
+++ b/core/src/compiler/mod.rs
@@ -114,10 +114,9 @@ impl From<&Symbols> for SymbolsTable {
         let mut table = HashMap::default();
         for (name, symbol) in syms.as_hashmap() {
             let proto = match symbol {
-                Symbol::Array(array) => SymbolPrototype::Array(
-                    ExprType::from_vartype(array.subtype(), None),
-                    array.dimensions().len(),
-                ),
+                Symbol::Array(array) => {
+                    SymbolPrototype::Array(array.subtype(), array.dimensions().len())
+                }
                 Symbol::Callable(callable) => {
                     SymbolPrototype::Callable(callable.metadata().clone())
                 }

--- a/core/src/compiler/mod.rs
+++ b/core/src/compiler/mod.rs
@@ -812,14 +812,14 @@ impl Compiler {
                 self.compile_assignment(span.vref, span.vref_pos, span.expr)?;
             }
 
-            Statement::BuiltinCall(span) => {
-                let key = SymbolKey::from(&span.name);
+            Statement::Call(span) => {
+                let key = SymbolKey::from(&span.vref.name());
                 let md = match self.symtable.get(&key) {
                     Some(SymbolPrototype::Callable(md)) => {
                         if md.return_type() != VarType::Void {
                             return Err(Error::new(
-                                span.name_pos,
-                                format!("{} is not a command", span.name),
+                                span.vref_pos,
+                                format!("{} is not a command", span.vref.name()),
                             ));
                         }
                         md.clone()
@@ -827,20 +827,20 @@ impl Compiler {
 
                     Some(_) => {
                         return Err(Error::new(
-                            span.name_pos,
-                            format!("{} is not a command", span.name),
+                            span.vref_pos,
+                            format!("{} is not a command", span.vref.name()),
                         ));
                     }
 
                     None => {
                         return Err(Error::new(
-                            span.name_pos,
-                            format!("Unknown builtin {}", span.name),
+                            span.vref_pos,
+                            format!("Unknown builtin {}", span.vref.name()),
                         ))
                     }
                 };
 
-                let name_pos = span.name_pos;
+                let name_pos = span.vref_pos;
                 let nargs = compile_command_args(
                     md.syntaxes(),
                     &mut self.instrs,
@@ -850,7 +850,7 @@ impl Compiler {
                 )
                 .map_err(|e| Error::from_call_error(&md, e, name_pos))?;
                 self.next_pc = self.instrs.len();
-                self.emit(Instruction::BuiltinCall(key, span.name_pos, nargs));
+                self.emit(Instruction::BuiltinCall(key, span.vref_pos, nargs));
             }
 
             Statement::Data(mut span) => {

--- a/core/src/compiler/mod.rs
+++ b/core/src/compiler/mod.rs
@@ -388,8 +388,7 @@ impl Compiler {
         }
 
         self.emit(Instruction::Dim(key.clone(), span.vtype));
-        self.symtable
-            .insert(key, SymbolPrototype::Variable(ExprType::from_vartype(span.vtype, None)));
+        self.symtable.insert(key, SymbolPrototype::Variable(span.vtype));
 
         Ok(())
     }
@@ -463,7 +462,7 @@ impl Compiler {
 
             let iter_key = SymbolKey::from(span.iter.name());
             if self.symtable.get(&key).is_none() {
-                self.emit(Instruction::Dim(key, VarType::Double));
+                self.emit(Instruction::Dim(key, ExprType::Double));
                 self.symtable.insert(iter_key.clone(), SymbolPrototype::Variable(ExprType::Double));
             }
 
@@ -773,10 +772,7 @@ impl Compiler {
                     subtype_pos: span.subtype_pos,
                 }));
 
-                self.symtable.insert(
-                    key,
-                    SymbolPrototype::Array(ExprType::from_vartype(span.subtype, None), nargs),
-                );
+                self.symtable.insert(key, SymbolPrototype::Array(span.subtype, nargs));
             }
 
             Statement::Do(span) => {
@@ -1327,22 +1323,22 @@ mod tests {
         Tester::default()
             .parse("DIM var AS BOOLEAN")
             .compile()
-            .expect_instr(0, Instruction::Dim(SymbolKey::from("var"), VarType::Boolean))
+            .expect_instr(0, Instruction::Dim(SymbolKey::from("var"), ExprType::Boolean))
             .check();
         Tester::default()
             .parse("DIM var AS DOUBLE")
             .compile()
-            .expect_instr(0, Instruction::Dim(SymbolKey::from("var"), VarType::Double))
+            .expect_instr(0, Instruction::Dim(SymbolKey::from("var"), ExprType::Double))
             .check();
         Tester::default()
             .parse("DIM var AS INTEGER")
             .compile()
-            .expect_instr(0, Instruction::Dim(SymbolKey::from("var"), VarType::Integer))
+            .expect_instr(0, Instruction::Dim(SymbolKey::from("var"), ExprType::Integer))
             .check();
         Tester::default()
             .parse("DIM var AS STRING")
             .compile()
-            .expect_instr(0, Instruction::Dim(SymbolKey::from("var"), VarType::Text))
+            .expect_instr(0, Instruction::Dim(SymbolKey::from("var"), ExprType::Text))
             .check();
     }
 
@@ -1393,7 +1389,7 @@ mod tests {
                     name: SymbolKey::from("var"),
                     name_pos: lc(1, 5),
                     dimensions: 1,
-                    subtype: VarType::Integer,
+                    subtype: ExprType::Integer,
                     subtype_pos: lc(1, 15),
                 }),
             )
@@ -1416,7 +1412,7 @@ mod tests {
                     name: SymbolKey::from("var"),
                     name_pos: lc(1, 5),
                     dimensions: 2,
-                    subtype: VarType::Integer,
+                    subtype: ExprType::Integer,
                     subtype_pos: lc(1, 22),
                 }),
             )
@@ -1436,7 +1432,7 @@ mod tests {
                     name: SymbolKey::from("var"),
                     name_pos: lc(1, 5),
                     dimensions: 1,
-                    subtype: VarType::Integer,
+                    subtype: ExprType::Integer,
                     subtype_pos: lc(1, 17),
                 }),
             )
@@ -1705,7 +1701,7 @@ mod tests {
                     addr: 2,
                 }),
             )
-            .expect_instr(1, Instruction::Dim(SymbolKey::from("iter"), VarType::Double))
+            .expect_instr(1, Instruction::Dim(SymbolKey::from("iter"), ExprType::Double))
             .expect_instr(2, Instruction::PushInteger(0, lc(1, 12)))
             .expect_instr(3, Instruction::IntegerToDouble)
             .expect_instr(4, Instruction::Assign(SymbolKey::from("iter")))

--- a/core/src/compiler/mod.rs
+++ b/core/src/compiler/mod.rs
@@ -29,7 +29,7 @@ use std::fmt;
 mod args;
 pub use args::*;
 mod exprs;
-pub use exprs::{compile_expr, compile_expr_in_command, compile_expr_symbol_ref};
+use exprs::{compile_expr, compile_expr_in_command};
 
 /// Compilation errors.
 #[derive(Debug, thiserror::Error)]
@@ -158,7 +158,7 @@ impl fmt::Display for ExprType {
 /// commands.
 #[derive(Clone, Copy, PartialEq)]
 #[cfg_attr(any(debug_assertions, test), derive(Debug))]
-pub enum CallableType {
+enum CallableType {
     /// Type for a function that returns a boolean.
     Boolean,
 
@@ -202,7 +202,7 @@ impl From<CallableType> for VarType {
 
 /// Information about a symbol in the symbols table.
 #[derive(Clone)]
-pub enum SymbolPrototype {
+enum SymbolPrototype {
     /// Information about an array.  The integer indicates the number of dimensions in the array.
     Array(ExprType, usize),
 
@@ -215,7 +215,7 @@ pub enum SymbolPrototype {
 
 /// Type for the symbols table.
 #[derive(Default)]
-pub struct SymbolsTable {
+struct SymbolsTable {
     table: HashMap<SymbolKey, SymbolPrototype>,
 }
 
@@ -247,12 +247,12 @@ impl From<&Symbols> for SymbolsTable {
 
 impl SymbolsTable {
     /// Returns true if the symbols table contains `key`.
-    pub fn contains_key(&mut self, key: &SymbolKey) -> bool {
+    fn contains_key(&mut self, key: &SymbolKey) -> bool {
         self.table.contains_key(key)
     }
 
     /// Returns the information for the symbol `key` if it exists, otherwise `None`.
-    pub fn get(&self, key: &SymbolKey) -> Option<&SymbolPrototype> {
+    fn get(&self, key: &SymbolKey) -> Option<&SymbolPrototype> {
         self.table.get(key)
     }
 
@@ -1010,7 +1010,7 @@ fn compile_aux(stmts: Vec<Statement>, symtable: SymbolsTable) -> Result<(Image, 
 /// that exist in the virtual machine.
 // TODO(jmmv): This is ugly.  Now that we have a symbols table in here, we should not _also_ have a
 // Symbols object to maintain runtime state (or if we do, we shouldn't be getting it here).
-pub fn compile(stmts: Vec<Statement>, syms: &Symbols) -> Result<Image> {
+pub(crate) fn compile(stmts: Vec<Statement>, syms: &Symbols) -> Result<Image> {
     compile_aux(stmts, SymbolsTable::from(syms)).map(|(image, _symtable)| image)
 }
 

--- a/core/src/compiler/mod.rs
+++ b/core/src/compiler/mod.rs
@@ -352,7 +352,7 @@ impl Compiler {
                 // TODO(jmmv): Compile separate Dim instructions for new variables instead of
                 // checking this every time.
                 let key = key.clone();
-                let vtype = ExprType::from_vartype(vref.ref_type(), etype);
+                let vtype = vref.ref_type().unwrap_or(etype);
                 self.symtable.insert(key, SymbolPrototype::Variable(vtype));
                 vtype
             }
@@ -367,7 +367,7 @@ impl Compiler {
         }
 
         if let Some(ref_type) = vref.ref_type() {
-            if ref_type != vtype.into() {
+            if ref_type != vtype {
                 return Err(Error::new(
                     vref_pos,
                     format!("Incompatible types in {} reference", vref),
@@ -455,8 +455,8 @@ impl Compiler {
     fn compile_for(&mut self, span: ForSpan) -> Result<()> {
         debug_assert!(
             span.iter.ref_type().is_none()
-                || span.iter.ref_type().unwrap() == VarType::Double
-                || span.iter.ref_type().unwrap() == VarType::Integer
+                || span.iter.ref_type().unwrap() == ExprType::Double
+                || span.iter.ref_type().unwrap() == ExprType::Integer
         );
 
         if span.iter_double && span.iter.ref_type().is_none() {

--- a/core/src/compiler/mod.rs
+++ b/core/src/compiler/mod.rs
@@ -120,9 +120,7 @@ impl From<&Symbols> for SymbolsTable {
                 Symbol::Callable(callable) => {
                     SymbolPrototype::Callable(callable.metadata().clone())
                 }
-                Symbol::Variable(var) => {
-                    SymbolPrototype::Variable(ExprType::from_vartype(var.as_vartype(), None))
-                }
+                Symbol::Variable(var) => SymbolPrototype::Variable(var.as_exprtype()),
             };
             debug_assert_eq!(name, &name.to_ascii_uppercase());
             table.insert(SymbolKey::from(name), proto);
@@ -313,7 +311,7 @@ impl Compiler {
             }
         };
 
-        if !span.vref.accepts(atype.into()) {
+        if !span.vref.accepts(atype) {
             return Err(Error::new(
                 span.vref_pos,
                 format!("Incompatible types in {} reference", span.vref),
@@ -354,7 +352,7 @@ impl Compiler {
                 // TODO(jmmv): Compile separate Dim instructions for new variables instead of
                 // checking this every time.
                 let key = key.clone();
-                let vtype = ExprType::from_vartype(vref.ref_type(), Some(etype));
+                let vtype = ExprType::from_vartype(vref.ref_type(), etype);
                 self.symtable.insert(key, SymbolPrototype::Variable(vtype));
                 vtype
             }

--- a/core/src/compiler/mod.rs
+++ b/core/src/compiler/mod.rs
@@ -1189,12 +1189,12 @@ mod tests {
             .define("i", SymbolPrototype::Variable(ExprType::Integer))
             .parse("foo(3, 4 + i, i) = 5")
             .compile()
-            .expect_instr(0, Instruction::Push(Value::Integer(5), lc(1, 20)))
+            .expect_instr(0, Instruction::PushInteger(5, lc(1, 20)))
             .expect_instr(1, Instruction::LoadInteger(SymbolKey::from("i"), lc(1, 15)))
-            .expect_instr(2, Instruction::Push(Value::Integer(4), lc(1, 8)))
+            .expect_instr(2, Instruction::PushInteger(4, lc(1, 8)))
             .expect_instr(3, Instruction::LoadInteger(SymbolKey::from("i"), lc(1, 12)))
             .expect_instr(4, Instruction::AddIntegers(lc(1, 10)))
-            .expect_instr(5, Instruction::Push(Value::Integer(3), lc(1, 5)))
+            .expect_instr(5, Instruction::PushInteger(3, lc(1, 5)))
             .expect_instr(6, Instruction::ArrayAssignment(SymbolKey::from("foo"), lc(1, 1), 3))
             .check();
     }
@@ -1205,8 +1205,8 @@ mod tests {
             .define("a", SymbolPrototype::Array(ExprType::Integer, 1))
             .parse("a%(0) = 1")
             .compile()
-            .expect_instr(0, Instruction::Push(Value::Integer(1), lc(1, 9)))
-            .expect_instr(1, Instruction::Push(Value::Integer(0), lc(1, 4)))
+            .expect_instr(0, Instruction::PushInteger(1, lc(1, 9)))
+            .expect_instr(1, Instruction::PushInteger(0, lc(1, 4)))
             .expect_instr(2, Instruction::ArrayAssignment(SymbolKey::from("a"), lc(1, 1), 1))
             .check();
     }
@@ -1217,8 +1217,8 @@ mod tests {
             .define("a", SymbolPrototype::Array(ExprType::Integer, 1))
             .parse("a(1.2) = 1")
             .compile()
-            .expect_instr(0, Instruction::Push(Value::Integer(1), lc(1, 10)))
-            .expect_instr(1, Instruction::Push(Value::Double(1.2), lc(1, 3)))
+            .expect_instr(0, Instruction::PushInteger(1, lc(1, 10)))
+            .expect_instr(1, Instruction::PushDouble(1.2, lc(1, 3)))
             .expect_instr(2, Instruction::DoubleToInteger)
             .expect_instr(3, Instruction::ArrayAssignment(SymbolKey::from("a"), lc(1, 1), 1))
             .check();
@@ -1253,7 +1253,7 @@ mod tests {
             .compile()
             .expect_instr(0, Instruction::LoadDouble(SymbolKey::from("d"), lc(1, 8)))
             .expect_instr(1, Instruction::DoubleToInteger)
-            .expect_instr(2, Instruction::Push(Value::Integer(3), lc(1, 3)))
+            .expect_instr(2, Instruction::PushInteger(3, lc(1, 3)))
             .expect_instr(3, Instruction::ArrayAssignment(SymbolKey::from("a"), lc(1, 1), 1))
             .check();
     }
@@ -1267,7 +1267,7 @@ mod tests {
             .compile()
             .expect_instr(0, Instruction::LoadInteger(SymbolKey::from("i"), lc(1, 8)))
             .expect_instr(1, Instruction::IntegerToDouble)
-            .expect_instr(2, Instruction::Push(Value::Integer(3), lc(1, 3)))
+            .expect_instr(2, Instruction::PushInteger(3, lc(1, 3)))
             .expect_instr(3, Instruction::ArrayAssignment(SymbolKey::from("a"), lc(1, 1), 1))
             .check();
     }
@@ -1318,7 +1318,7 @@ mod tests {
         Tester::default()
             .parse("foo = 5")
             .compile()
-            .expect_instr(0, Instruction::Push(Value::Integer(5), lc(1, 7)))
+            .expect_instr(0, Instruction::PushInteger(5, lc(1, 7)))
             .expect_instr(1, Instruction::Assign(SymbolKey::from("foo")))
             .check();
     }
@@ -1339,7 +1339,7 @@ mod tests {
         Tester::default()
             .parse("foo = 2.3")
             .compile()
-            .expect_instr(0, Instruction::Push(Value::Double(2.3), lc(1, 7)))
+            .expect_instr(0, Instruction::PushDouble(2.3, lc(1, 7)))
             .expect_instr(1, Instruction::Assign(SymbolKey::from("foo")))
             .expect_symtable(SymbolKey::from("foo"), SymbolPrototype::Variable(ExprType::Double))
             .check();
@@ -1350,7 +1350,7 @@ mod tests {
         Tester::default()
             .parse("foo# = 2")
             .compile()
-            .expect_instr(0, Instruction::Push(Value::Integer(2), lc(1, 8)))
+            .expect_instr(0, Instruction::PushInteger(2, lc(1, 8)))
             .expect_instr(1, Instruction::IntegerToDouble)
             .expect_instr(2, Instruction::Assign(SymbolKey::from("foo")))
             .expect_symtable(SymbolKey::from("foo"), SymbolPrototype::Variable(ExprType::Double))
@@ -1401,10 +1401,10 @@ mod tests {
             )]))
             .parse("IF TRUE THEN: CMD 1, 2: END IF")
             .compile()
-            .expect_instr(0, Instruction::Push(Value::Boolean(true), lc(1, 4)))
+            .expect_instr(0, Instruction::PushBoolean(true, lc(1, 4)))
             .expect_instr(1, Instruction::JumpIfNotTrue(5))
-            .expect_instr(2, Instruction::Push(Value::Integer(2), lc(1, 22)))
-            .expect_instr(3, Instruction::Push(Value::Integer(1), lc(1, 19)))
+            .expect_instr(2, Instruction::PushInteger(2, lc(1, 22)))
+            .expect_instr(3, Instruction::PushInteger(1, lc(1, 19)))
             .expect_instr(4, Instruction::BuiltinCall(SymbolKey::from("CMD"), lc(1, 15), 2))
             .check();
     }
@@ -1498,7 +1498,7 @@ mod tests {
         Tester::default()
             .parse("DIM var(1) AS INTEGER")
             .compile()
-            .expect_instr(0, Instruction::Push(Value::Integer(1), lc(1, 9)))
+            .expect_instr(0, Instruction::PushInteger(1, lc(1, 9)))
             .expect_instr(
                 1,
                 Instruction::DimArray(DimArrayISpan {
@@ -1518,8 +1518,8 @@ mod tests {
             .define("i", SymbolPrototype::Variable(ExprType::Integer))
             .parse("DIM var(i, 3 + 4) AS INTEGER")
             .compile()
-            .expect_instr(0, Instruction::Push(Value::Integer(3), lc(1, 12)))
-            .expect_instr(1, Instruction::Push(Value::Integer(4), lc(1, 16)))
+            .expect_instr(0, Instruction::PushInteger(3, lc(1, 12)))
+            .expect_instr(1, Instruction::PushInteger(4, lc(1, 16)))
             .expect_instr(2, Instruction::AddIntegers(lc(1, 14)))
             .expect_instr(3, Instruction::LoadInteger(SymbolKey::from("i"), lc(1, 9)))
             .expect_instr(
@@ -1540,7 +1540,7 @@ mod tests {
         Tester::default()
             .parse("DIM var(3.7) AS INTEGER")
             .compile()
-            .expect_instr(0, Instruction::Push(Value::Double(3.7), lc(1, 9)))
+            .expect_instr(0, Instruction::PushDouble(3.7, lc(1, 9)))
             .expect_instr(1, Instruction::DoubleToInteger)
             .expect_instr(
                 2,
@@ -1581,7 +1581,7 @@ mod tests {
             .define_callable(CallableMetadataBuilder::new("FOO", VarType::Void))
             .parse("DO WHILE TRUE\nFOO\nLOOP")
             .compile()
-            .expect_instr(0, Instruction::Push(Value::Boolean(true), lc(1, 10)))
+            .expect_instr(0, Instruction::PushBoolean(true, lc(1, 10)))
             .expect_instr(1, Instruction::JumpIfNotTrue(4))
             .expect_instr(2, Instruction::BuiltinCall(SymbolKey::from("FOO"), lc(2, 1), 0))
             .expect_instr(3, Instruction::Jump(JumpISpan { addr: 0 }))
@@ -1595,7 +1595,7 @@ mod tests {
             .parse("DO\nFOO\nLOOP WHILE TRUE")
             .compile()
             .expect_instr(0, Instruction::BuiltinCall(SymbolKey::from("FOO"), lc(2, 1), 0))
-            .expect_instr(1, Instruction::Push(Value::Boolean(true), lc(3, 12)))
+            .expect_instr(1, Instruction::PushBoolean(true, lc(3, 12)))
             .expect_instr(2, Instruction::JumpIfTrue(0))
             .check();
     }
@@ -1611,7 +1611,7 @@ mod tests {
             .define("i", SymbolPrototype::Variable(ExprType::Integer))
             .parse("END 2 + i")
             .compile()
-            .expect_instr(0, Instruction::Push(Value::Integer(2), lc(1, 5)))
+            .expect_instr(0, Instruction::PushInteger(2, lc(1, 5)))
             .expect_instr(1, Instruction::LoadInteger(SymbolKey::from("i"), lc(1, 9)))
             .expect_instr(2, Instruction::AddIntegers(lc(1, 7)))
             .expect_instr(3, Instruction::End(true))
@@ -1643,7 +1643,7 @@ mod tests {
         Tester::default()
             .parse("END 2.3")
             .compile()
-            .expect_instr(0, Instruction::Push(Value::Double(2.3), lc(1, 5)))
+            .expect_instr(0, Instruction::PushDouble(2.3, lc(1, 5)))
             .expect_instr(1, Instruction::DoubleToInteger)
             .expect_instr(2, Instruction::End(true))
             .check();
@@ -1664,7 +1664,7 @@ mod tests {
         Tester::default()
             .parse("DO WHILE TRUE\nEXIT DO\nLOOP")
             .compile()
-            .expect_instr(0, Instruction::Push(Value::Boolean(true), lc(1, 10)))
+            .expect_instr(0, Instruction::PushBoolean(true, lc(1, 10)))
             .expect_instr(1, Instruction::JumpIfNotTrue(4))
             .expect_instr(2, Instruction::Jump(JumpISpan { addr: 4 }))
             .expect_instr(3, Instruction::Jump(JumpISpan { addr: 0 }))
@@ -1676,10 +1676,10 @@ mod tests {
         Tester::default()
             .parse("DO WHILE TRUE\nEXIT DO\nDO UNTIL FALSE\nEXIT DO\nLOOP\nLOOP")
             .compile()
-            .expect_instr(0, Instruction::Push(Value::Boolean(true), lc(1, 10)))
+            .expect_instr(0, Instruction::PushBoolean(true, lc(1, 10)))
             .expect_instr(1, Instruction::JumpIfNotTrue(8))
             .expect_instr(2, Instruction::Jump(JumpISpan { addr: 8 }))
-            .expect_instr(3, Instruction::Push(Value::Boolean(false), lc(3, 10)))
+            .expect_instr(3, Instruction::PushBoolean(false, lc(3, 10)))
             .expect_instr(4, Instruction::JumpIfTrue(7))
             .expect_instr(5, Instruction::Jump(JumpISpan { addr: 7 }))
             .expect_instr(6, Instruction::Jump(JumpISpan { addr: 3 }))
@@ -1692,11 +1692,11 @@ mod tests {
         Tester::default()
             .parse("DO WHILE TRUE\nEXIT DO\nLOOP\nDO WHILE TRUE\nEXIT DO\nLOOP")
             .compile()
-            .expect_instr(0, Instruction::Push(Value::Boolean(true), lc(1, 10)))
+            .expect_instr(0, Instruction::PushBoolean(true, lc(1, 10)))
             .expect_instr(1, Instruction::JumpIfNotTrue(4))
             .expect_instr(2, Instruction::Jump(JumpISpan { addr: 4 }))
             .expect_instr(3, Instruction::Jump(JumpISpan { addr: 0 }))
-            .expect_instr(4, Instruction::Push(Value::Boolean(true), lc(4, 10)))
+            .expect_instr(4, Instruction::PushBoolean(true, lc(4, 10)))
             .expect_instr(5, Instruction::JumpIfNotTrue(8))
             .expect_instr(6, Instruction::Jump(JumpISpan { addr: 8 }))
             .expect_instr(7, Instruction::Jump(JumpISpan { addr: 4 }))
@@ -1708,10 +1708,10 @@ mod tests {
         Tester::default()
             .parse("DO WHILE TRUE\nEXIT DO\nWHILE FALSE\nEXIT DO\nWEND\nLOOP")
             .compile()
-            .expect_instr(0, Instruction::Push(Value::Boolean(true), lc(1, 10)))
+            .expect_instr(0, Instruction::PushBoolean(true, lc(1, 10)))
             .expect_instr(1, Instruction::JumpIfNotTrue(8))
             .expect_instr(2, Instruction::Jump(JumpISpan { addr: 8 }))
-            .expect_instr(3, Instruction::Push(Value::Boolean(false), lc(3, 7)))
+            .expect_instr(3, Instruction::PushBoolean(false, lc(3, 7)))
             .expect_instr(4, Instruction::JumpIfNotTrue(7))
             .expect_instr(5, Instruction::Jump(JumpISpan { addr: 8 }))
             .expect_instr(6, Instruction::Jump(JumpISpan { addr: 3 }))
@@ -1739,16 +1739,16 @@ mod tests {
         Tester::default()
             .parse("FOR iter = 1 TO 5: a = FALSE: NEXT")
             .compile()
-            .expect_instr(0, Instruction::Push(Value::Integer(1), lc(1, 12)))
+            .expect_instr(0, Instruction::PushInteger(1, lc(1, 12)))
             .expect_instr(1, Instruction::Assign(SymbolKey::from("iter")))
             .expect_instr(2, Instruction::LoadInteger(SymbolKey::from("iter"), lc(1, 5)))
-            .expect_instr(3, Instruction::Push(Value::Integer(5), lc(1, 17)))
+            .expect_instr(3, Instruction::PushInteger(5, lc(1, 17)))
             .expect_instr(4, Instruction::LessEqualIntegers(lc(1, 14)))
             .expect_instr(5, Instruction::JumpIfNotTrue(13))
-            .expect_instr(6, Instruction::Push(Value::Boolean(false), lc(1, 24)))
+            .expect_instr(6, Instruction::PushBoolean(false, lc(1, 24)))
             .expect_instr(7, Instruction::Assign(SymbolKey::from("a")))
             .expect_instr(8, Instruction::LoadInteger(SymbolKey::from("iter"), lc(1, 5)))
-            .expect_instr(9, Instruction::Push(Value::Integer(1), lc(1, 18)))
+            .expect_instr(9, Instruction::PushInteger(1, lc(1, 18)))
             .expect_instr(10, Instruction::AddIntegers(lc(1, 14)))
             .expect_instr(11, Instruction::Assign(SymbolKey::from("iter")))
             .expect_instr(12, Instruction::Jump(JumpISpan { addr: 2 }))
@@ -1768,10 +1768,10 @@ mod tests {
             .expect_instr(3, Instruction::LoadInteger(SymbolKey::from("j"), lc(1, 17)))
             .expect_instr(4, Instruction::LessEqualIntegers(lc(1, 14)))
             .expect_instr(5, Instruction::JumpIfNotTrue(13))
-            .expect_instr(6, Instruction::Push(Value::Boolean(false), lc(1, 24)))
+            .expect_instr(6, Instruction::PushBoolean(false, lc(1, 24)))
             .expect_instr(7, Instruction::Assign(SymbolKey::from("a")))
             .expect_instr(8, Instruction::LoadInteger(SymbolKey::from("iter"), lc(1, 5)))
-            .expect_instr(9, Instruction::Push(Value::Integer(1), lc(1, 18)))
+            .expect_instr(9, Instruction::PushInteger(1, lc(1, 18)))
             .expect_instr(10, Instruction::AddIntegers(lc(1, 14)))
             .expect_instr(11, Instruction::Assign(SymbolKey::from("iter")))
             .expect_instr(12, Instruction::Jump(JumpISpan { addr: 2 }))
@@ -1786,19 +1786,19 @@ mod tests {
             .parse("FOR iter = (i + 1) TO (2 + j): a = FALSE: NEXT")
             .compile()
             .expect_instr(0, Instruction::LoadInteger(SymbolKey::from("i"), lc(1, 13)))
-            .expect_instr(1, Instruction::Push(Value::Integer(1), lc(1, 17)))
+            .expect_instr(1, Instruction::PushInteger(1, lc(1, 17)))
             .expect_instr(2, Instruction::AddIntegers(lc(1, 15)))
             .expect_instr(3, Instruction::Assign(SymbolKey::from("iter")))
             .expect_instr(4, Instruction::LoadInteger(SymbolKey::from("iter"), lc(1, 5)))
-            .expect_instr(5, Instruction::Push(Value::Integer(2), lc(1, 24)))
+            .expect_instr(5, Instruction::PushInteger(2, lc(1, 24)))
             .expect_instr(6, Instruction::LoadInteger(SymbolKey::from("j"), lc(1, 28)))
             .expect_instr(7, Instruction::AddIntegers(lc(1, 26)))
             .expect_instr(8, Instruction::LessEqualIntegers(lc(1, 20)))
             .expect_instr(9, Instruction::JumpIfNotTrue(17))
-            .expect_instr(10, Instruction::Push(Value::Boolean(false), lc(1, 36)))
+            .expect_instr(10, Instruction::PushBoolean(false, lc(1, 36)))
             .expect_instr(11, Instruction::Assign(SymbolKey::from("a")))
             .expect_instr(12, Instruction::LoadInteger(SymbolKey::from("iter"), lc(1, 5)))
-            .expect_instr(13, Instruction::Push(Value::Integer(1), lc(1, 30)))
+            .expect_instr(13, Instruction::PushInteger(1, lc(1, 30)))
             .expect_instr(14, Instruction::AddIntegers(lc(1, 20)))
             .expect_instr(15, Instruction::Assign(SymbolKey::from("iter")))
             .expect_instr(16, Instruction::Jump(JumpISpan { addr: 4 }))
@@ -1818,16 +1818,16 @@ mod tests {
                 }),
             )
             .expect_instr(1, Instruction::Dim(SymbolKey::from("iter"), VarType::Double))
-            .expect_instr(2, Instruction::Push(Value::Integer(0), lc(1, 12)))
+            .expect_instr(2, Instruction::PushInteger(0, lc(1, 12)))
             .expect_instr(3, Instruction::IntegerToDouble)
             .expect_instr(4, Instruction::Assign(SymbolKey::from("iter")))
             .expect_instr(5, Instruction::LoadDouble(SymbolKey::from("iter"), lc(1, 5)))
-            .expect_instr(6, Instruction::Push(Value::Integer(2), lc(1, 17)))
+            .expect_instr(6, Instruction::PushInteger(2, lc(1, 17)))
             .expect_instr(7, Instruction::IntegerToDouble)
             .expect_instr(8, Instruction::LessEqualDoubles(lc(1, 14)))
             .expect_instr(9, Instruction::JumpIfNotTrue(15))
             .expect_instr(10, Instruction::LoadDouble(SymbolKey::from("iter"), lc(1, 5)))
-            .expect_instr(11, Instruction::Push(Value::Double(0.1), lc(1, 24)))
+            .expect_instr(11, Instruction::PushDouble(0.1, lc(1, 24)))
             .expect_instr(12, Instruction::AddDoubles(lc(1, 14)))
             .expect_instr(13, Instruction::Assign(SymbolKey::from("iter")))
             .expect_instr(14, Instruction::Jump(JumpISpan { addr: 5 }))
@@ -1872,7 +1872,7 @@ mod tests {
             .define_callable(CallableMetadataBuilder::new("FOO", VarType::Void))
             .parse("IF FALSE THEN: FOO: END IF")
             .compile()
-            .expect_instr(0, Instruction::Push(Value::Boolean(false), lc(1, 4)))
+            .expect_instr(0, Instruction::PushBoolean(false, lc(1, 4)))
             .expect_instr(1, Instruction::JumpIfNotTrue(3))
             .expect_instr(2, Instruction::BuiltinCall(SymbolKey::from("FOO"), lc(1, 16), 0))
             .check();
@@ -1886,15 +1886,15 @@ mod tests {
             .define_callable(CallableMetadataBuilder::new("BAZ", VarType::Void))
             .parse("IF FALSE THEN\nFOO\nELSEIF TRUE THEN\nBAR\nELSE\nBAZ\nEND IF")
             .compile()
-            .expect_instr(0, Instruction::Push(Value::Boolean(false), lc(1, 4)))
+            .expect_instr(0, Instruction::PushBoolean(false, lc(1, 4)))
             .expect_instr(1, Instruction::JumpIfNotTrue(4))
             .expect_instr(2, Instruction::BuiltinCall(SymbolKey::from("FOO"), lc(2, 1), 0))
             .expect_instr(3, Instruction::Jump(JumpISpan { addr: 11 }))
-            .expect_instr(4, Instruction::Push(Value::Boolean(true), lc(3, 8)))
+            .expect_instr(4, Instruction::PushBoolean(true, lc(3, 8)))
             .expect_instr(5, Instruction::JumpIfNotTrue(8))
             .expect_instr(6, Instruction::BuiltinCall(SymbolKey::from("BAR"), lc(4, 1), 0))
             .expect_instr(7, Instruction::Jump(JumpISpan { addr: 11 }))
-            .expect_instr(8, Instruction::Push(Value::Boolean(true), lc(5, 1)))
+            .expect_instr(8, Instruction::PushBoolean(true, lc(5, 1)))
             .expect_instr(9, Instruction::JumpIfNotTrue(11))
             .expect_instr(10, Instruction::BuiltinCall(SymbolKey::from("BAZ"), lc(6, 1), 0))
             .check();
@@ -1945,7 +1945,7 @@ mod tests {
             .define_callable(CallableMetadataBuilder::new("FOO", VarType::Void))
             .parse(&format!("SELECT CASE 5\nCASE {}\nFOO\nEND SELECT", guards))
             .compile()
-            .expect_instr(0, Instruction::Push(Value::Integer(5), lc(1, 13)))
+            .expect_instr(0, Instruction::PushInteger(5, lc(1, 13)))
             .expect_instr(1, Instruction::Assign(SymbolKey::from("0select1")));
         let mut n = 2;
         for instr in exp_expr_instrs {
@@ -1967,8 +1967,8 @@ mod tests {
             "1 + 2",
             vec![
                 Instruction::LoadInteger(SymbolKey::from("0select1"), lc(2, 6)),
-                Instruction::Push(Value::Integer(1), lc(2, 6)),
-                Instruction::Push(Value::Integer(2), lc(2, 10)),
+                Instruction::PushInteger(1, lc(2, 6)),
+                Instruction::PushInteger(2, lc(2, 10)),
                 Instruction::AddIntegers(lc(2, 8)),
                 Instruction::EqualIntegers(lc(2, 6)),
             ],
@@ -1981,8 +1981,8 @@ mod tests {
             "IS = 9 + 8",
             vec![
                 Instruction::LoadInteger(SymbolKey::from("0select1"), lc(2, 11)),
-                Instruction::Push(Value::Integer(9), lc(2, 11)),
-                Instruction::Push(Value::Integer(8), lc(2, 15)),
+                Instruction::PushInteger(9, lc(2, 11)),
+                Instruction::PushInteger(8, lc(2, 15)),
                 Instruction::AddIntegers(lc(2, 13)),
                 Instruction::EqualIntegers(lc(2, 11)),
             ],
@@ -1992,7 +1992,7 @@ mod tests {
             "IS <> 9",
             vec![
                 Instruction::LoadInteger(SymbolKey::from("0select1"), lc(2, 12)),
-                Instruction::Push(Value::Integer(9), lc(2, 12)),
+                Instruction::PushInteger(9, lc(2, 12)),
                 Instruction::NotEqualIntegers(lc(2, 12)),
             ],
         );
@@ -2001,7 +2001,7 @@ mod tests {
             "IS < 9",
             vec![
                 Instruction::LoadInteger(SymbolKey::from("0select1"), lc(2, 11)),
-                Instruction::Push(Value::Integer(9), lc(2, 11)),
+                Instruction::PushInteger(9, lc(2, 11)),
                 Instruction::LessIntegers(lc(2, 11)),
             ],
         );
@@ -2010,7 +2010,7 @@ mod tests {
             "IS <= 9",
             vec![
                 Instruction::LoadInteger(SymbolKey::from("0select1"), lc(2, 12)),
-                Instruction::Push(Value::Integer(9), lc(2, 12)),
+                Instruction::PushInteger(9, lc(2, 12)),
                 Instruction::LessEqualIntegers(lc(2, 12)),
             ],
         );
@@ -2019,7 +2019,7 @@ mod tests {
             "IS > 9",
             vec![
                 Instruction::LoadInteger(SymbolKey::from("0select1"), lc(2, 11)),
-                Instruction::Push(Value::Integer(9), lc(2, 11)),
+                Instruction::PushInteger(9, lc(2, 11)),
                 Instruction::GreaterIntegers(lc(2, 11)),
             ],
         );
@@ -2028,7 +2028,7 @@ mod tests {
             "IS >= 9",
             vec![
                 Instruction::LoadInteger(SymbolKey::from("0select1"), lc(2, 12)),
-                Instruction::Push(Value::Integer(9), lc(2, 12)),
+                Instruction::PushInteger(9, lc(2, 12)),
                 Instruction::GreaterEqualIntegers(lc(2, 12)),
             ],
         );
@@ -2040,10 +2040,10 @@ mod tests {
             "1 TO 2",
             vec![
                 Instruction::LoadInteger(SymbolKey::from("0select1"), lc(2, 6)),
-                Instruction::Push(Value::Integer(1), lc(2, 6)),
+                Instruction::PushInteger(1, lc(2, 6)),
                 Instruction::GreaterEqualIntegers(lc(2, 6)),
                 Instruction::LoadInteger(SymbolKey::from("0select1"), lc(2, 6)),
-                Instruction::Push(Value::Integer(2), lc(2, 11)),
+                Instruction::PushInteger(2, lc(2, 11)),
                 Instruction::LessEqualIntegers(lc(2, 11)),
                 Instruction::LogicalAnd(lc(2, 6)),
             ],
@@ -2056,10 +2056,10 @@ mod tests {
             "IS <> 9, 8",
             vec![
                 Instruction::LoadInteger(SymbolKey::from("0select1"), lc(2, 12)),
-                Instruction::Push(Value::Integer(9), lc(2, 12)),
+                Instruction::PushInteger(9, lc(2, 12)),
                 Instruction::NotEqualIntegers(lc(2, 12)),
                 Instruction::LoadInteger(SymbolKey::from("0select1"), lc(2, 15)),
-                Instruction::Push(Value::Integer(8), lc(2, 15)),
+                Instruction::PushInteger(8, lc(2, 15)),
                 Instruction::EqualIntegers(lc(2, 15)),
                 Instruction::LogicalOr(lc(2, 12)),
             ],
@@ -2071,8 +2071,8 @@ mod tests {
         Tester::default()
             .parse("SELECT CASE 5 + 3: END SELECT")
             .compile()
-            .expect_instr(0, Instruction::Push(Value::Integer(5), lc(1, 13)))
-            .expect_instr(1, Instruction::Push(Value::Integer(3), lc(1, 17)))
+            .expect_instr(0, Instruction::PushInteger(5, lc(1, 13)))
+            .expect_instr(1, Instruction::PushInteger(3, lc(1, 17)))
             .expect_instr(2, Instruction::AddIntegers(lc(1, 15)))
             .expect_instr(3, Instruction::Assign(SymbolKey::from("0select1")))
             .expect_instr(
@@ -2091,10 +2091,10 @@ mod tests {
             .define_callable(CallableMetadataBuilder::new("FOO", VarType::Void))
             .parse("SELECT CASE 5\nCASE 7\nFOO\nEND SELECT")
             .compile()
-            .expect_instr(0, Instruction::Push(Value::Integer(5), lc(1, 13)))
+            .expect_instr(0, Instruction::PushInteger(5, lc(1, 13)))
             .expect_instr(1, Instruction::Assign(SymbolKey::from("0select1")))
             .expect_instr(2, Instruction::LoadInteger(SymbolKey::from("0select1"), lc(2, 6)))
-            .expect_instr(3, Instruction::Push(Value::Integer(7), lc(2, 6)))
+            .expect_instr(3, Instruction::PushInteger(7, lc(2, 6)))
             .expect_instr(4, Instruction::EqualIntegers(lc(2, 6)))
             .expect_instr(5, Instruction::JumpIfNotTrue(7))
             .expect_instr(6, Instruction::BuiltinCall(SymbolKey::from("FOO"), lc(3, 1), 0))
@@ -2129,7 +2129,7 @@ mod tests {
             .define_callable(CallableMetadataBuilder::new("FOO", VarType::Void))
             .parse("SELECT CASE 5\nCASE ELSE\nFOO\nEND SELECT")
             .compile()
-            .expect_instr(0, Instruction::Push(Value::Integer(5), lc(1, 13)))
+            .expect_instr(0, Instruction::PushInteger(5, lc(1, 13)))
             .expect_instr(1, Instruction::Assign(SymbolKey::from("0select1")))
             .expect_instr(2, Instruction::BuiltinCall(SymbolKey::from("FOO"), lc(3, 1), 0))
             .expect_instr(
@@ -2146,16 +2146,16 @@ mod tests {
             .define_callable(CallableMetadataBuilder::new("BAR", VarType::Void))
             .parse("SELECT CASE 5\nCASE 7\nFOO\nCASE IS <> 8\nBAR\nEND SELECT")
             .compile()
-            .expect_instr(0, Instruction::Push(Value::Integer(5), lc(1, 13)))
+            .expect_instr(0, Instruction::PushInteger(5, lc(1, 13)))
             .expect_instr(1, Instruction::Assign(SymbolKey::from("0select1")))
             .expect_instr(2, Instruction::LoadInteger(SymbolKey::from("0select1"), lc(2, 6)))
-            .expect_instr(3, Instruction::Push(Value::Integer(7), lc(2, 6)))
+            .expect_instr(3, Instruction::PushInteger(7, lc(2, 6)))
             .expect_instr(4, Instruction::EqualIntegers(lc(2, 6)))
             .expect_instr(5, Instruction::JumpIfNotTrue(8))
             .expect_instr(6, Instruction::BuiltinCall(SymbolKey::from("FOO"), lc(3, 1), 0))
             .expect_instr(7, Instruction::Jump(JumpISpan { addr: 13 }))
             .expect_instr(8, Instruction::LoadInteger(SymbolKey::from("0select1"), lc(4, 12)))
-            .expect_instr(9, Instruction::Push(Value::Integer(8), lc(4, 12)))
+            .expect_instr(9, Instruction::PushInteger(8, lc(4, 12)))
             .expect_instr(10, Instruction::NotEqualIntegers(lc(4, 12)))
             .expect_instr(11, Instruction::JumpIfNotTrue(13))
             .expect_instr(12, Instruction::BuiltinCall(SymbolKey::from("BAR"), lc(5, 1), 0))
@@ -2173,10 +2173,10 @@ mod tests {
             .define_callable(CallableMetadataBuilder::new("BAR", VarType::Void))
             .parse("SELECT CASE 5\nCASE 7\nFOO\nCASE ELSE\nBAR\nEND SELECT")
             .compile()
-            .expect_instr(0, Instruction::Push(Value::Integer(5), lc(1, 13)))
+            .expect_instr(0, Instruction::PushInteger(5, lc(1, 13)))
             .expect_instr(1, Instruction::Assign(SymbolKey::from("0select1")))
             .expect_instr(2, Instruction::LoadInteger(SymbolKey::from("0select1"), lc(2, 6)))
-            .expect_instr(3, Instruction::Push(Value::Integer(7), lc(2, 6)))
+            .expect_instr(3, Instruction::PushInteger(7, lc(2, 6)))
             .expect_instr(4, Instruction::EqualIntegers(lc(2, 6)))
             .expect_instr(5, Instruction::JumpIfNotTrue(8))
             .expect_instr(6, Instruction::BuiltinCall(SymbolKey::from("FOO"), lc(3, 1), 0))
@@ -2194,7 +2194,7 @@ mod tests {
         Tester::default()
             .parse("SELECT CASE 0: END SELECT\nSELECT CASE 0: END SELECT")
             .compile()
-            .expect_instr(0, Instruction::Push(Value::Integer(0), lc(1, 13)))
+            .expect_instr(0, Instruction::PushInteger(0, lc(1, 13)))
             .expect_instr(1, Instruction::Assign(SymbolKey::from("0select1")))
             .expect_instr(
                 2,
@@ -2203,7 +2203,7 @@ mod tests {
                     pos: lc(1, 16),
                 }),
             )
-            .expect_instr(3, Instruction::Push(Value::Integer(0), lc(2, 13)))
+            .expect_instr(3, Instruction::PushInteger(0, lc(2, 13)))
             .expect_instr(4, Instruction::Assign(SymbolKey::from("0select2")))
             .expect_instr(
                 5,
@@ -2221,7 +2221,7 @@ mod tests {
             .define_callable(CallableMetadataBuilder::new("FOO", VarType::Void))
             .parse("WHILE TRUE\nFOO\nWEND")
             .compile()
-            .expect_instr(0, Instruction::Push(Value::Boolean(true), lc(1, 7)))
+            .expect_instr(0, Instruction::PushBoolean(true, lc(1, 7)))
             .expect_instr(1, Instruction::JumpIfNotTrue(4))
             .expect_instr(2, Instruction::BuiltinCall(SymbolKey::from("FOO"), lc(2, 1), 0))
             .expect_instr(3, Instruction::Jump(JumpISpan { addr: 0 }))

--- a/core/src/compiler/mod.rs
+++ b/core/src/compiler/mod.rs
@@ -24,7 +24,6 @@ use crate::syms::{Symbol, SymbolKey, Symbols};
 use std::collections::HashMap;
 #[cfg(test)]
 use std::collections::HashSet;
-use std::fmt;
 
 mod args;
 pub use args::*;
@@ -84,76 +83,6 @@ impl Error {
 
 /// Result for compiler return values.
 pub type Result<T> = std::result::Result<T, Error>;
-
-/// Represents type of an expression.
-#[derive(Clone, Copy, Debug, PartialEq)]
-pub enum ExprType {
-    /// Type for an expression that evaluates to a boolean.
-    Boolean,
-
-    /// Type for an expression that evaluates to a double.
-    Double,
-
-    /// Type for an expression that evaluates to an integer.
-    Integer,
-
-    /// Type for an expression that evaluates to a string.
-    Text,
-}
-
-impl ExprType {
-    /// Converts a `VarType` into an `ExprType`.
-    ///
-    /// If the `VarType` represents type inference (the `Auto` value), returns `auto_type` assuming
-    /// there is an `auto_type` to return; otherwise, panics.
-    fn from_vartype(vtype: VarType, auto_type: Option<ExprType>) -> Self {
-        match vtype {
-            VarType::Auto => auto_type.unwrap(),
-            VarType::Boolean => ExprType::Boolean,
-            VarType::Double => ExprType::Double,
-            VarType::Integer => ExprType::Integer,
-            VarType::Text => ExprType::Text,
-            VarType::Void => unreachable!(),
-        }
-    }
-
-    /// Returns true if this expression type is numerical.
-    fn is_numerical(self) -> bool {
-        self == Self::Double || self == Self::Integer
-    }
-
-    /// Returns the textual representation of the annotation for this type.
-    pub(crate) fn annotation(&self) -> char {
-        match self {
-            ExprType::Boolean => '?',
-            ExprType::Double => '#',
-            ExprType::Integer => '%',
-            ExprType::Text => '$',
-        }
-    }
-}
-
-impl From<ExprType> for VarType {
-    fn from(value: ExprType) -> Self {
-        match value {
-            ExprType::Boolean => VarType::Boolean,
-            ExprType::Double => VarType::Double,
-            ExprType::Integer => VarType::Integer,
-            ExprType::Text => VarType::Text,
-        }
-    }
-}
-
-impl fmt::Display for ExprType {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            ExprType::Boolean => write!(f, "BOOLEAN"),
-            ExprType::Double => write!(f, "DOUBLE"),
-            ExprType::Integer => write!(f, "INTEGER"),
-            ExprType::Text => write!(f, "STRING"),
-        }
-    }
-}
 
 /// Information about a symbol in the symbols table.
 #[derive(Clone)]

--- a/core/src/exec.rs
+++ b/core/src/exec.rs
@@ -1793,7 +1793,7 @@ mod tests {
     #[test]
     fn test_dim_array_errors() {
         do_simple_error_test("DIM i()", "1:6: Arrays require at least one dimension");
-        do_simple_error_test("DIM i(FALSE)", "1:7: Dimensions in DIM array must be integers");
+        do_simple_error_test("DIM i(FALSE)", "1:7: BOOLEAN is not a number");
         do_simple_error_test("DIM i(-3)", "1:7: Dimensions in DIM array must be positive");
         do_simple_error_test("DIM i\nDIM i(3)", "2:5: Cannot DIM already-defined symbol i");
     }
@@ -1837,7 +1837,7 @@ mod tests {
     #[test]
     fn test_end_errors() {
         do_simple_error_test("END 1, 2", "1:6: Expected newline but found ,");
-        do_simple_error_test("END \"b\"", "1:5: \"b\" is not a number");
+        do_simple_error_test("END \"b\"", "1:5: STRING is not a number");
         do_simple_error_test("END -3", "1:5: Exit code must be a positive integer");
         do_simple_error_test("END 128", "1:5: Exit code cannot be larger than 127");
     }

--- a/core/src/exec.rs
+++ b/core/src/exec.rs
@@ -773,11 +773,7 @@ impl Machine {
             }
             ds.push(i as usize);
         }
-        self.symbols.dim_array(
-            span.name.clone(),
-            ExprType::from_vartype(span.subtype, Some(ExprType::Integer)),
-            ds,
-        );
+        self.symbols.dim_array(span.name.clone(), span.subtype, ds);
         Ok(())
     }
 
@@ -1252,8 +1248,8 @@ impl Machine {
                 context.pc += 1;
             }
 
-            Instruction::Dim(name, vtype) => {
-                self.symbols.dim(name.clone(), *vtype);
+            Instruction::Dim(name, etype) => {
+                self.symbols.dim(name.clone(), *etype);
                 context.pc += 1;
             }
 

--- a/core/src/exec.rs
+++ b/core/src/exec.rs
@@ -869,13 +869,13 @@ impl Machine {
     async fn do_function_call(
         &mut self,
         context: &mut Context,
-        return_type: VarType,
+        return_type: ExprType,
         fref_pos: LineCol,
         nargs: usize,
         f: Rc<dyn Callable>,
     ) -> Result<()> {
         let metadata = f.metadata();
-        debug_assert_eq!(return_type, metadata.return_type().unwrap().into());
+        debug_assert_eq!(return_type, metadata.return_type().unwrap());
 
         let scope = Scope::new(&mut context.value_stack, nargs, fref_pos);
         f.exec(scope, self).await.map_err(|e| Error::from_call_error(metadata, e, fref_pos))?;
@@ -884,7 +884,7 @@ impl Machine {
                 Some((value, _pos)) => {
                     debug_assert_eq!(
                         return_type,
-                        value.as_vartype(),
+                        value.as_exprtype(),
                         "Value returned by function is incompatible with its type definition",
                     )
                 }
@@ -922,7 +922,7 @@ impl Machine {
         &mut self,
         context: &mut Context,
         name: &SymbolKey,
-        return_type: VarType,
+        return_type: ExprType,
         fref_pos: LineCol,
         nargs: usize,
     ) -> Result<()> {

--- a/core/src/exec.rs
+++ b/core/src/exec.rs
@@ -730,7 +730,11 @@ impl Machine {
             }
             ds.push(i as usize);
         }
-        self.symbols.dim_array(span.name.clone(), span.subtype, ds);
+        self.symbols.dim_array(
+            span.name.clone(),
+            ExprType::from_vartype(span.subtype, Some(ExprType::Integer)),
+            ds,
+        );
         Ok(())
     }
 

--- a/core/src/exec.rs
+++ b/core/src/exec.rs
@@ -960,7 +960,7 @@ impl Machine {
                 Some((value, _pos)) => {
                     let fref_checker = VarRef::new(fname.to_string(), ftype.into());
                     debug_assert!(
-                        fref_checker.accepts(value.as_vartype()),
+                        fref_checker.accepts(value.as_exprtype()),
                         "Value returned by function is incompatible with its type definition",
                     )
                 }

--- a/core/src/exec.rs
+++ b/core/src/exec.rs
@@ -655,7 +655,7 @@ impl Machine {
     pub fn get_var_as_bool(&self, name: &str) -> Result<bool> {
         match self
             .symbols
-            .get_var(&VarRef::new(name, Some(VarType::Boolean)))
+            .get_var(&VarRef::new(name, Some(ExprType::Boolean)))
             .map_err(Error::from_value_error_without_pos)?
         {
             Value::Boolean(b) => Ok(*b),
@@ -668,7 +668,7 @@ impl Machine {
     pub fn get_var_as_int(&self, name: &str) -> Result<i32> {
         match self
             .symbols
-            .get_var(&VarRef::new(name, Some(VarType::Integer)))
+            .get_var(&VarRef::new(name, Some(ExprType::Integer)))
             .map_err(Error::from_value_error_without_pos)?
         {
             Value::Integer(i) => Ok(*i),
@@ -690,7 +690,7 @@ impl Machine {
     pub fn get_var_as_string(&self, name: &str) -> Result<&str> {
         match self
             .symbols
-            .get_var(&VarRef::new(name, Some(VarType::Text)))
+            .get_var(&VarRef::new(name, Some(ExprType::Text)))
             .map_err(Error::from_value_error_without_pos)?
         {
             Value::Text(s) => Ok(s),
@@ -958,7 +958,7 @@ impl Machine {
         if cfg!(debug_assertions) {
             match context.value_stack.top() {
                 Some((value, _pos)) => {
-                    let fref_checker = VarRef::new(fname.to_string(), Some(ftype.into()));
+                    let fref_checker = VarRef::new(fname.to_string(), Some(ftype));
                     debug_assert!(
                         fref_checker.accepts(value.as_exprtype()),
                         "Value returned by function is incompatible with its type definition",
@@ -1498,8 +1498,8 @@ mod tests {
     impl Clearable for MockClearable {
         fn reset_state(&self, syms: &mut Symbols) {
             // Make sure we can see the symbols before they are cleared.
-            assert!(syms.get_var(&VarRef::new("a", Some(VarType::Boolean))).is_ok());
-            assert!(syms.get_var(&VarRef::new("b", Some(VarType::Integer))).is_ok());
+            assert!(syms.get_var(&VarRef::new("a", Some(ExprType::Boolean))).is_ok());
+            assert!(syms.get_var(&VarRef::new("b", Some(ExprType::Integer))).is_ok());
 
             *self.cleared.borrow_mut() = true;
         }

--- a/core/src/exec.rs
+++ b/core/src/exec.rs
@@ -681,7 +681,8 @@ impl Machine {
     /// Returns an error if the variable is not defined, if the referenced symbol is not a variable,
     /// or if the type annotation in the variable reference does not match the type of the value
     /// that the variable contains.
-    pub fn get_var(&self, vref: &VarRef) -> std::result::Result<&Value, value::Error> {
+    #[cfg(test)]
+    pub(crate) fn get_var(&self, vref: &VarRef) -> std::result::Result<&Value, value::Error> {
         self.symbols.get_var(vref)
     }
 

--- a/core/src/exec.rs
+++ b/core/src/exec.rs
@@ -655,7 +655,7 @@ impl Machine {
     pub fn get_var_as_bool(&self, name: &str) -> Result<bool> {
         match self
             .symbols
-            .get_var(&VarRef::new(name, VarType::Boolean))
+            .get_var(&VarRef::new(name, Some(VarType::Boolean)))
             .map_err(Error::from_value_error_without_pos)?
         {
             Value::Boolean(b) => Ok(*b),
@@ -668,7 +668,7 @@ impl Machine {
     pub fn get_var_as_int(&self, name: &str) -> Result<i32> {
         match self
             .symbols
-            .get_var(&VarRef::new(name, VarType::Integer))
+            .get_var(&VarRef::new(name, Some(VarType::Integer)))
             .map_err(Error::from_value_error_without_pos)?
         {
             Value::Integer(i) => Ok(*i),
@@ -690,7 +690,7 @@ impl Machine {
     pub fn get_var_as_string(&self, name: &str) -> Result<&str> {
         match self
             .symbols
-            .get_var(&VarRef::new(name, VarType::Text))
+            .get_var(&VarRef::new(name, Some(VarType::Text)))
             .map_err(Error::from_value_error_without_pos)?
         {
             Value::Text(s) => Ok(s),
@@ -958,7 +958,7 @@ impl Machine {
         if cfg!(debug_assertions) {
             match context.value_stack.top() {
                 Some((value, _pos)) => {
-                    let fref_checker = VarRef::new(fname.to_string(), ftype.into());
+                    let fref_checker = VarRef::new(fname.to_string(), Some(ftype.into()));
                     debug_assert!(
                         fref_checker.accepts(value.as_exprtype()),
                         "Value returned by function is incompatible with its type definition",
@@ -1498,8 +1498,8 @@ mod tests {
     impl Clearable for MockClearable {
         fn reset_state(&self, syms: &mut Symbols) {
             // Make sure we can see the symbols before they are cleared.
-            assert!(syms.get_var(&VarRef::new("a", VarType::Boolean)).is_ok());
-            assert!(syms.get_var(&VarRef::new("b", VarType::Integer)).is_ok());
+            assert!(syms.get_var(&VarRef::new("a", Some(VarType::Boolean))).is_ok());
+            assert!(syms.get_var(&VarRef::new("b", Some(VarType::Integer))).is_ok());
 
             *self.cleared.borrow_mut() = true;
         }

--- a/core/src/exec.rs
+++ b/core/src/exec.rs
@@ -18,7 +18,6 @@
 use crate::ast::*;
 use crate::bytecode::*;
 use crate::compiler;
-use crate::compiler::ExprType;
 use crate::parser;
 use crate::reader::LineCol;
 use crate::syms::SymbolKey;

--- a/core/src/exec.rs
+++ b/core/src/exec.rs
@@ -1344,8 +1344,23 @@ impl Machine {
                 context.pc += 1;
             }
 
-            Instruction::Push(value, pos) => {
-                context.value_stack.push((value.clone(), *pos));
+            Instruction::PushBoolean(value, pos) => {
+                context.value_stack.push((Value::Boolean(*value), *pos));
+                context.pc += 1;
+            }
+
+            Instruction::PushDouble(value, pos) => {
+                context.value_stack.push((Value::Double(*value), *pos));
+                context.pc += 1;
+            }
+
+            Instruction::PushInteger(value, pos) => {
+                context.value_stack.push((Value::Integer(*value), *pos));
+                context.pc += 1;
+            }
+
+            Instruction::PushString(value, pos) => {
+                context.value_stack.push((Value::Text(value.clone()), *pos));
                 context.pc += 1;
             }
 

--- a/core/src/lexer.rs
+++ b/core/src/lexer.rs
@@ -465,7 +465,7 @@ impl<'a> Lexer<'a> {
     fn consume_symbol(&mut self, first: CharSpan) -> io::Result<TokenSpan> {
         let mut s = String::new();
         s.push(first.ch);
-        let mut vtype = VarType::Auto;
+        let mut vtype = None;
         let mut token_len = 0;
         loop {
             match self.input.peek() {
@@ -473,25 +473,25 @@ impl<'a> Lexer<'a> {
                     ch if ch.is_word() => s.push(self.input.next().unwrap()?.ch),
                     ch if ch.is_separator() => break,
                     '?' => {
-                        vtype = VarType::Boolean;
+                        vtype = Some(VarType::Boolean);
                         self.input.next().unwrap()?;
                         token_len += 1;
                         break;
                     }
                     '#' => {
-                        vtype = VarType::Double;
+                        vtype = Some(VarType::Double);
                         self.input.next().unwrap()?;
                         token_len += 1;
                         break;
                     }
                     '%' => {
-                        vtype = VarType::Integer;
+                        vtype = Some(VarType::Integer);
                         self.input.next().unwrap()?;
                         token_len += 1;
                         break;
                     }
                     '$' => {
-                        vtype = VarType::Text;
+                        vtype = Some(VarType::Text);
                         self.input.next().unwrap()?;
                         token_len += 1;
                         break;
@@ -835,7 +835,7 @@ mod tests {
 
     /// Syntactic sugar to instantiate a `VarRef` without an explicit type annotation.
     fn new_auto_symbol(name: &str) -> Token {
-        Token::Symbol(VarRef::new(name, VarType::Auto))
+        Token::Symbol(VarRef::new(name, None))
     }
 
     #[test]
@@ -1011,10 +1011,10 @@ mod tests {
             "a b? d# i% s$",
             &[
                 ts(new_auto_symbol("a"), 1, 1, 1),
-                ts(Token::Symbol(VarRef::new("b", VarType::Boolean)), 1, 3, 2),
-                ts(Token::Symbol(VarRef::new("d", VarType::Double)), 1, 6, 2),
-                ts(Token::Symbol(VarRef::new("i", VarType::Integer)), 1, 9, 2),
-                ts(Token::Symbol(VarRef::new("s", VarType::Text)), 1, 12, 2),
+                ts(Token::Symbol(VarRef::new("b", Some(VarType::Boolean))), 1, 3, 2),
+                ts(Token::Symbol(VarRef::new("d", Some(VarType::Double))), 1, 6, 2),
+                ts(Token::Symbol(VarRef::new("i", Some(VarType::Integer))), 1, 9, 2),
+                ts(Token::Symbol(VarRef::new("s", Some(VarType::Text))), 1, 12, 2),
                 ts(Token::Eof, 1, 14, 0),
             ],
         );

--- a/core/src/lexer.rs
+++ b/core/src/lexer.rs
@@ -15,7 +15,7 @@
 
 //! Tokenizer for the EndBASIC language.
 
-use crate::ast::{VarRef, VarType};
+use crate::ast::{ExprType, VarRef};
 use crate::reader::{CharReader, CharSpan, LineCol};
 use std::cell::RefCell;
 use std::iter::Peekable;
@@ -473,25 +473,25 @@ impl<'a> Lexer<'a> {
                     ch if ch.is_word() => s.push(self.input.next().unwrap()?.ch),
                     ch if ch.is_separator() => break,
                     '?' => {
-                        vtype = Some(VarType::Boolean);
+                        vtype = Some(ExprType::Boolean);
                         self.input.next().unwrap()?;
                         token_len += 1;
                         break;
                     }
                     '#' => {
-                        vtype = Some(VarType::Double);
+                        vtype = Some(ExprType::Double);
                         self.input.next().unwrap()?;
                         token_len += 1;
                         break;
                     }
                     '%' => {
-                        vtype = Some(VarType::Integer);
+                        vtype = Some(ExprType::Integer);
                         self.input.next().unwrap()?;
                         token_len += 1;
                         break;
                     }
                     '$' => {
-                        vtype = Some(VarType::Text);
+                        vtype = Some(ExprType::Text);
                         self.input.next().unwrap()?;
                         token_len += 1;
                         break;
@@ -1011,10 +1011,10 @@ mod tests {
             "a b? d# i% s$",
             &[
                 ts(new_auto_symbol("a"), 1, 1, 1),
-                ts(Token::Symbol(VarRef::new("b", Some(VarType::Boolean))), 1, 3, 2),
-                ts(Token::Symbol(VarRef::new("d", Some(VarType::Double))), 1, 6, 2),
-                ts(Token::Symbol(VarRef::new("i", Some(VarType::Integer))), 1, 9, 2),
-                ts(Token::Symbol(VarRef::new("s", Some(VarType::Text))), 1, 12, 2),
+                ts(Token::Symbol(VarRef::new("b", Some(ExprType::Boolean))), 1, 3, 2),
+                ts(Token::Symbol(VarRef::new("d", Some(ExprType::Double))), 1, 6, 2),
+                ts(Token::Symbol(VarRef::new("i", Some(ExprType::Integer))), 1, 9, 2),
+                ts(Token::Symbol(VarRef::new("s", Some(ExprType::Text))), 1, 12, 2),
                 ts(Token::Eof, 1, 14, 0),
             ],
         );

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -33,6 +33,6 @@ mod reader;
 pub mod syms;
 #[cfg(test)]
 mod testutils;
-mod value;
+pub mod value;
 
 pub use reader::LineCol;

--- a/core/src/parser.rs
+++ b/core/src/parser.rs
@@ -1184,7 +1184,7 @@ impl<'a> Parser<'a> {
         let token_span = self.lexer.read()?;
         let iterator = match token_span.token {
             Token::Symbol(iterator) => match iterator.ref_type() {
-                None | Some(VarType::Double) | Some(VarType::Integer) => iterator,
+                None | Some(ExprType::Double) | Some(ExprType::Integer) => iterator,
                 _ => {
                     return Err(Error::Bad(
                         token_span.pos,
@@ -1732,7 +1732,7 @@ pub fn parse(input: &mut dyn io::Read) -> Result<Vec<Statement>> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::ast::VarType;
+    use crate::ast::ExprType;
 
     /// Syntactic sugar to instantiate a `LineCol` for testing.
     fn lc(line: usize, col: usize) -> LineCol {
@@ -1777,7 +1777,7 @@ mod tests {
             format!(
                 "{}",
                 &vref_to_unannotated_string(
-                    VarRef::new("print", Some(VarType::Text)),
+                    VarRef::new("print", Some(ExprType::Text)),
                     LineCol { line: 7, col: 6 }
                 )
                 .unwrap_err()
@@ -1869,7 +1869,7 @@ mod tests {
                     expr: expr_text("text", 2, 11),
                 }),
                 Statement::ArrayAssignment(ArrayAssignmentSpan {
-                    vref: VarRef::new("abc", Some(VarType::Text)),
+                    vref: VarRef::new("abc", Some(ExprType::Text)),
                     vref_pos: lc(3, 1),
                     subscripts: vec![
                         Expr::Add(Box::from(BinaryOpSpan {
@@ -1913,12 +1913,12 @@ mod tests {
                     expr: expr_integer(1, 1, 3),
                 }),
                 Statement::Assignment(AssignmentSpan {
-                    vref: VarRef::new("foo", Some(VarType::Text)),
+                    vref: VarRef::new("foo", Some(ExprType::Text)),
                     vref_pos: lc(2, 1),
                     expr: expr_text("bar", 2, 8),
                 }),
                 Statement::Assignment(AssignmentSpan {
-                    vref: VarRef::new("b", Some(VarType::Text)),
+                    vref: VarRef::new("b", Some(ExprType::Text)),
                     vref_pos: lc(3, 1),
                     expr: Expr::Add(Box::from(BinaryOpSpan {
                         lhs: expr_integer(3, 3, 6),
@@ -1964,7 +1964,7 @@ mod tests {
                             sep_pos: lc(2, 11),
                         },
                         ArgSpan {
-                            expr: Some(expr_symbol(VarRef::new("c", Some(VarType::Text)), 2, 13)),
+                            expr: Some(expr_symbol(VarRef::new("c", Some(ExprType::Text)), 2, 13)),
                             sep: ArgSep::End,
                             sep_pos: lc(2, 15),
                         },
@@ -2288,7 +2288,7 @@ mod tests {
                 dimensions: vec![
                     Add(Box::from(BinaryOpSpan {
                         lhs: Call(CallSpan {
-                            vref: VarRef::new("bar", Some(VarType::Text)),
+                            vref: VarRef::new("bar", Some(ExprType::Text)),
                             vref_pos: lc(1, 9),
                             args: vec![],
                         }),
@@ -2507,7 +2507,7 @@ mod tests {
     #[test]
     fn test_expr_symbols() {
         do_expr_ok_test("foo", expr_symbol(VarRef::new("foo", None), 1, 7));
-        do_expr_ok_test("bar$", expr_symbol(VarRef::new("bar", Some(VarType::Text)), 1, 7));
+        do_expr_ok_test("bar$", expr_symbol(VarRef::new("bar", Some(ExprType::Text)), 1, 7));
     }
 
     #[test]
@@ -2871,7 +2871,7 @@ mod tests {
         do_expr_ok_test(
             "one%(1)",
             Call(CallSpan {
-                vref: VarRef::new("one", Some(VarType::Integer)),
+                vref: VarRef::new("one", Some(ExprType::Integer)),
                 vref_pos: lc(1, 7),
                 args: vec![ArgSpan {
                     expr: Some(expr_integer(1, 1, 12)),
@@ -2883,7 +2883,7 @@ mod tests {
         do_expr_ok_test(
             "many$(3, \"x\", TRUE)",
             Call(CallSpan {
-                vref: VarRef::new("many", Some(VarType::Text)),
+                vref: VarRef::new("many", Some(ExprType::Text)),
                 vref_pos: lc(1, 7),
                 args: vec![
                     ArgSpan {
@@ -2928,7 +2928,7 @@ mod tests {
         do_expr_ok_test(
             "outer?(1, inner1(2, 3), 4, inner2(), 5)",
             Call(CallSpan {
-                vref: VarRef::new("outer", Some(VarType::Boolean)),
+                vref: VarRef::new("outer", Some(ExprType::Boolean)),
                 vref_pos: lc(1, 7),
                 args: vec![
                     ArgSpan {
@@ -2988,7 +2988,7 @@ mod tests {
             And(Box::from(BinaryOpSpan {
                 lhs: expr_symbol(VarRef::new("b".to_owned(), None), 1, 7),
                 rhs: Call(CallSpan {
-                    vref: VarRef::new("ask", Some(VarType::Boolean)),
+                    vref: VarRef::new("ask", Some(ExprType::Boolean)),
                     vref_pos: lc(1, 13),
                     args: vec![
                         ArgSpan {
@@ -3654,7 +3654,7 @@ mod tests {
             })],
         );
 
-        let typed_iter = VarRef::new("d", Some(VarType::Double));
+        let typed_iter = VarRef::new("d", Some(ExprType::Double));
         do_ok_test(
             "FOR d# = 1.0 TO 10.2\nREM Nothing to do\nNEXT",
             &[Statement::For(ForSpan {

--- a/core/src/parser.rs
+++ b/core/src/parser.rs
@@ -471,18 +471,18 @@ impl<'a> Parser<'a> {
 
     /// Parses the `AS typename` clause of a `DIM` statement.  The caller has already consumed the
     /// `AS` token.
-    fn parse_dim_as(&mut self) -> Result<(VarType, LineCol)> {
+    fn parse_dim_as(&mut self) -> Result<(ExprType, LineCol)> {
         let peeked = self.lexer.peek()?;
         let (vtype, vtype_pos) = match peeked.token {
-            Token::Eof | Token::Eol => (VarType::Integer, peeked.pos),
+            Token::Eof | Token::Eol => (ExprType::Integer, peeked.pos),
             Token::As => {
                 self.lexer.consume_peeked();
                 let token_span = self.lexer.read()?;
                 match token_span.token {
-                    Token::BooleanName => (VarType::Boolean, token_span.pos),
-                    Token::DoubleName => (VarType::Double, token_span.pos),
-                    Token::IntegerName => (VarType::Integer, token_span.pos),
-                    Token::TextName => (VarType::Text, token_span.pos),
+                    Token::BooleanName => (ExprType::Boolean, token_span.pos),
+                    Token::DoubleName => (ExprType::Double, token_span.pos),
+                    Token::IntegerName => (ExprType::Integer, token_span.pos),
+                    Token::TextName => (ExprType::Text, token_span.pos),
                     t => {
                         return Err(Error::Bad(
                             token_span.pos,
@@ -2181,7 +2181,7 @@ mod tests {
             &[Statement::Dim(DimSpan {
                 name: "i".to_owned(),
                 name_pos: lc(1, 5),
-                vtype: VarType::Integer,
+                vtype: ExprType::Integer,
                 vtype_pos: lc(1, 6),
             })],
         );
@@ -2194,7 +2194,7 @@ mod tests {
             &[Statement::Dim(DimSpan {
                 name: "i".to_owned(),
                 name_pos: lc(1, 5),
-                vtype: VarType::Boolean,
+                vtype: ExprType::Boolean,
                 vtype_pos: lc(1, 10),
             })],
         );
@@ -2203,7 +2203,7 @@ mod tests {
             &[Statement::Dim(DimSpan {
                 name: "i".to_owned(),
                 name_pos: lc(1, 5),
-                vtype: VarType::Double,
+                vtype: ExprType::Double,
                 vtype_pos: lc(1, 10),
             })],
         );
@@ -2212,7 +2212,7 @@ mod tests {
             &[Statement::Dim(DimSpan {
                 name: "i".to_owned(),
                 name_pos: lc(1, 5),
-                vtype: VarType::Integer,
+                vtype: ExprType::Integer,
                 vtype_pos: lc(1, 10),
             })],
         );
@@ -2221,7 +2221,7 @@ mod tests {
             &[Statement::Dim(DimSpan {
                 name: "i".to_owned(),
                 name_pos: lc(1, 5),
-                vtype: VarType::Text,
+                vtype: ExprType::Text,
                 vtype_pos: lc(1, 10),
             })],
         );
@@ -2235,19 +2235,19 @@ mod tests {
                 Statement::Dim(DimSpan {
                     name: "i".to_owned(),
                     name_pos: lc(1, 5),
-                    vtype: VarType::Integer,
+                    vtype: ExprType::Integer,
                     vtype_pos: lc(1, 6),
                 }),
                 Statement::Dim(DimSpan {
                     name: "j".to_owned(),
                     name_pos: lc(2, 5),
-                    vtype: VarType::Boolean,
+                    vtype: ExprType::Boolean,
                     vtype_pos: lc(2, 10),
                 }),
                 Statement::Dim(DimSpan {
                     name: "k".to_owned(),
                     name_pos: lc(3, 5),
-                    vtype: VarType::Integer,
+                    vtype: ExprType::Integer,
                     vtype_pos: lc(3, 6),
                 }),
             ],
@@ -2264,7 +2264,7 @@ mod tests {
                 name: "i".to_owned(),
                 name_pos: lc(1, 5),
                 dimensions: vec![expr_integer(10, 1, 7)],
-                subtype: VarType::Integer,
+                subtype: ExprType::Integer,
                 subtype_pos: lc(1, 10),
             })],
         );
@@ -2278,7 +2278,7 @@ mod tests {
                     Negate(Box::from(UnaryOpSpan { expr: expr_integer(5, 1, 10), pos: lc(1, 9) })),
                     expr_integer(0, 1, 13),
                 ],
-                subtype: VarType::Text,
+                subtype: ExprType::Text,
                 subtype_pos: lc(1, 19),
             })],
         );
@@ -2301,7 +2301,7 @@ mod tests {
                     expr_integer(8, 1, 21),
                     Negate(Box::from(UnaryOpSpan { expr: expr_integer(1, 1, 25), pos: lc(1, 24) })),
                 ],
-                subtype: VarType::Integer,
+                subtype: ExprType::Integer,
                 subtype_pos: lc(1, 27),
             })],
         );

--- a/core/src/parser.rs
+++ b/core/src/parser.rs
@@ -362,7 +362,7 @@ impl<'a> Parser<'a> {
                 }
             }
         }
-        Ok(Statement::Call(CallSpan { vref: VarRef::new(name, VarType::Void), vref_pos, args }))
+        Ok(Statement::Call(CallSpan { vref: VarRef::new(name, VarType::Auto), vref_pos, args }))
     }
 
     /// Starts processing either an array reference or a builtin call and disambiguates between the
@@ -1948,7 +1948,7 @@ mod tests {
             "PRINT a\nPRINT ; 3 , c$\nNOARGS\nNAME 3 AS 4",
             &[
                 Statement::Call(CallSpan {
-                    vref: VarRef::new("PRINT", VarType::Void),
+                    vref: VarRef::new("PRINT", VarType::Auto),
                     vref_pos: lc(1, 1),
                     args: vec![ArgSpan {
                         expr: Some(expr_symbol(VarRef::new("a", VarType::Auto), 1, 7)),
@@ -1957,7 +1957,7 @@ mod tests {
                     }],
                 }),
                 Statement::Call(CallSpan {
-                    vref: VarRef::new("PRINT", VarType::Void),
+                    vref: VarRef::new("PRINT", VarType::Auto),
                     vref_pos: lc(2, 1),
                     args: vec![
                         ArgSpan { expr: None, sep: ArgSep::Short, sep_pos: lc(2, 7) },
@@ -1974,12 +1974,12 @@ mod tests {
                     ],
                 }),
                 Statement::Call(CallSpan {
-                    vref: VarRef::new("NOARGS", VarType::Void),
+                    vref: VarRef::new("NOARGS", VarType::Auto),
                     vref_pos: lc(3, 1),
                     args: vec![],
                 }),
                 Statement::Call(CallSpan {
-                    vref: VarRef::new("NAME", VarType::Void),
+                    vref: VarRef::new("NAME", VarType::Auto),
                     vref_pos: lc(4, 1),
                     args: vec![
                         ArgSpan {
@@ -2005,7 +2005,7 @@ mod tests {
         do_ok_test(
             "PRINT(1)",
             &[Statement::Call(CallSpan {
-                vref: VarRef::new("PRINT", VarType::Void),
+                vref: VarRef::new("PRINT", VarType::Auto),
                 vref_pos: lc(1, 1),
                 args: vec![ArgSpan {
                     expr: Some(expr_integer(1, 1, 7)),
@@ -2018,7 +2018,7 @@ mod tests {
         do_ok_test(
             "PRINT(1), 2",
             &[Statement::Call(CallSpan {
-                vref: VarRef::new("PRINT", VarType::Void),
+                vref: VarRef::new("PRINT", VarType::Auto),
                 vref_pos: lc(1, 1),
                 args: vec![
                     ArgSpan {
@@ -2038,7 +2038,7 @@ mod tests {
         do_ok_test(
             "PRINT(1); 2",
             &[Statement::Call(CallSpan {
-                vref: VarRef::new("PRINT", VarType::Void),
+                vref: VarRef::new("PRINT", VarType::Auto),
                 vref_pos: lc(1, 1),
                 args: vec![
                     ArgSpan {
@@ -2058,7 +2058,7 @@ mod tests {
         do_ok_test(
             "PRINT(1);",
             &[Statement::Call(CallSpan {
-                vref: VarRef::new("PRINT", VarType::Void),
+                vref: VarRef::new("PRINT", VarType::Auto),
                 vref_pos: lc(1, 1),
                 args: vec![
                     ArgSpan {
@@ -2074,7 +2074,7 @@ mod tests {
         do_ok_test(
             "PRINT(1) + 2; 3",
             &[Statement::Call(CallSpan {
-                vref: VarRef::new("PRINT", VarType::Void),
+                vref: VarRef::new("PRINT", VarType::Auto),
                 vref_pos: lc(1, 1),
                 args: vec![
                     ArgSpan {
@@ -2474,7 +2474,7 @@ mod tests {
         do_ok_test(
             &format!("PRINT {}, 1", input),
             &[Statement::Call(CallSpan {
-                vref: VarRef::new("PRINT", VarType::Void),
+                vref: VarRef::new("PRINT", VarType::Auto),
                 vref_pos: lc(1, 1),
                 args: vec![
                     ArgSpan {
@@ -3176,7 +3176,7 @@ mod tests {
     /// Helper to instantiate a trivial `Statement::BuiltinCall` that has no arguments.
     fn make_bare_builtin_call(name: &str, line: usize, col: usize) -> Statement {
         Statement::Call(CallSpan {
-            vref: VarRef::new(name, VarType::Void),
+            vref: VarRef::new(name, VarType::Auto),
             vref_pos: LineCol { line, col },
             args: vec![],
         })
@@ -3616,7 +3616,7 @@ mod tests {
         do_if_uniline_allowed_test(
             "a 0",
             Statement::Call(CallSpan {
-                vref: VarRef::new("A", VarType::Void),
+                vref: VarRef::new("A", VarType::Auto),
                 vref_pos: lc(1, 11),
                 args: vec![ArgSpan {
                     expr: Some(expr_integer(0, 1, 13)),

--- a/core/src/syms.rs
+++ b/core/src/syms.rs
@@ -288,8 +288,8 @@ impl Symbols {
     }
 
     /// Defines a new variable `key` of type `vartype`.  The variable must not yet exist.
-    pub fn dim(&mut self, key: SymbolKey, vartype: VarType) {
-        let previous = self.by_name.insert(key.0, Symbol::Variable(vartype.default_value()));
+    pub fn dim(&mut self, key: SymbolKey, etype: ExprType) {
+        let previous = self.by_name.insert(key.0, Symbol::Variable(etype.default_value()));
         debug_assert!(
             previous.is_none(),
             "Pre-existence of variables is checked at compilation time"
@@ -802,7 +802,7 @@ mod tests {
     fn test_symbols_dim_ok() {
         let mut syms = Symbols::default();
 
-        syms.dim(SymbolKey::from("A_Boolean"), VarType::Boolean);
+        syms.dim(SymbolKey::from("A_Boolean"), ExprType::Boolean);
         match syms.get(&VarRef::new("a_boolean", VarType::Auto)).unwrap().unwrap() {
             Symbol::Variable(value) => assert_eq!(&Value::Boolean(false), value),
             _ => panic!("Got something that is not the variable we asked for"),

--- a/core/src/syms.rs
+++ b/core/src/syms.rs
@@ -69,7 +69,7 @@ impl From<compiler::Error> for CallError {
 }
 
 /// Result for callable execution return values.
-pub type CallResult = std::result::Result<Value, CallError>;
+pub type CallResult = std::result::Result<(), CallError>;
 
 /// The key of a symbol in the symbols table.
 #[derive(Clone, Debug, Hash, Eq, Ord, PartialEq, PartialOrd)]
@@ -209,7 +209,7 @@ impl Symbol {
         match self {
             Symbol::Array(array) => Some(array.subtype()),
             Symbol::Callable(callable) => callable.metadata().return_type(),
-            Symbol::Variable(value) => value.as_exprtype(),
+            Symbol::Variable(value) => Some(value.as_exprtype()),
         }
     }
 

--- a/core/src/testutils.rs
+++ b/core/src/testutils.rs
@@ -491,13 +491,13 @@ impl Callable for SumFunction {
     }
 
     async fn exec(&self, mut scope: Scope<'_>, _machine: &mut Machine) -> CallResult {
-        let mut result = Value::Integer(0);
+        let mut result = 0;
         while scope.nargs() > 0 {
             let (i, pos) = scope.pop_integer_with_pos();
-            result = value::add_integer(result, Value::Integer(i))
-                .map_err(|e| CallError::EvalError(pos, e.message))?;
+            result =
+                value::add_integer(result, i).map_err(|e| CallError::EvalError(pos, e.message))?;
         }
-        scope.return_any(result)
+        scope.return_integer(result)
     }
 }
 

--- a/core/src/testutils.rs
+++ b/core/src/testutils.rs
@@ -507,7 +507,7 @@ pub struct SymbolsBuilder {
 impl SymbolsBuilder {
     /// Adds the array named `name` of type `subtype` to the list of symbols.  The dimensions
     /// and contents of the array are unspecified.
-    pub fn add_array<S: Into<String>>(mut self, name: S, subtype: VarType) -> Self {
+    pub fn add_array<S: Into<String>>(mut self, name: S, subtype: ExprType) -> Self {
         let name = name.into();
         assert!(name == name.to_ascii_uppercase());
         let array = Array::new(subtype, vec![10]);

--- a/core/src/testutils.rs
+++ b/core/src/testutils.rs
@@ -238,7 +238,7 @@ impl Callable for GetHiddenFunction {
     async fn exec(&self, mut scope: Scope<'_>, machine: &mut Machine) -> CallResult {
         assert_eq!(1, scope.nargs());
         let name = scope.pop_string();
-        match machine.get_var(&VarRef::new(name, VarType::Text)) {
+        match machine.get_var(&VarRef::new(name, Some(VarType::Text))) {
             Ok(t) => scope.return_any(t.clone()),
             Err(_) => panic!("Invalid argument"),
         }

--- a/core/src/testutils.rs
+++ b/core/src/testutils.rs
@@ -40,12 +40,11 @@ pub struct ArglessFunction {
 
 impl ArglessFunction {
     pub fn new(value: Value) -> Rc<Self> {
-        Rc::from(Self {
-            metadata: CallableMetadataBuilder::new("ARGLESS", value.as_vartype())
-                .with_syntax(&[(&[], None)])
-                .test_build(),
-            value,
-        })
+        let mut builder = CallableMetadataBuilder::new("ARGLESS").with_syntax(&[(&[], None)]);
+        if let Some(etype) = value.as_exprtype() {
+            builder = builder.with_return_type(etype);
+        };
+        Rc::from(Self { metadata: builder.test_build(), value })
     }
 }
 
@@ -69,7 +68,7 @@ pub(crate) struct ClearCommand {
 impl ClearCommand {
     pub(crate) fn new() -> Rc<Self> {
         Rc::from(Self {
-            metadata: CallableMetadataBuilder::new("CLEAR", VarType::Void)
+            metadata: CallableMetadataBuilder::new("CLEAR")
                 .with_syntax(&[(&[], None)])
                 .test_build(),
         })
@@ -98,7 +97,8 @@ pub(crate) struct CountFunction {
 impl CountFunction {
     pub(crate) fn new() -> Rc<Self> {
         Rc::from(Self {
-            metadata: CallableMetadataBuilder::new("COUNT", VarType::Integer)
+            metadata: CallableMetadataBuilder::new("COUNT")
+                .with_return_type(ExprType::Integer)
                 .with_syntax(&[(&[], None)])
                 .test_build(),
             counter: Rc::from(RefCell::from(0)),
@@ -129,7 +129,8 @@ pub struct RaisefFunction {
 impl RaisefFunction {
     pub fn new() -> Rc<Self> {
         Rc::from(Self {
-            metadata: CallableMetadataBuilder::new("RAISEF", VarType::Boolean)
+            metadata: CallableMetadataBuilder::new("RAISEF")
+                .with_return_type(ExprType::Boolean)
                 .with_syntax(&[(
                     &[SingularArgSyntax::RequiredValue(
                         RequiredValueSyntax { name: "arg", vtype: ExprType::Text },
@@ -170,7 +171,7 @@ pub struct RaiseCommand {
 impl RaiseCommand {
     pub fn new() -> Rc<Self> {
         Rc::from(Self {
-            metadata: CallableMetadataBuilder::new("RAISE", VarType::Void)
+            metadata: CallableMetadataBuilder::new("RAISE")
                 .with_syntax(&[(
                     &[SingularArgSyntax::RequiredValue(
                         RequiredValueSyntax { name: "arg", vtype: ExprType::Text },
@@ -212,7 +213,8 @@ impl GetHiddenFunction {
     /// Creates a new command that sets aside all data values.
     pub(crate) fn new() -> Rc<Self> {
         Rc::from(Self {
-            metadata: CallableMetadataBuilder::new("GETHIDDEN", VarType::Text)
+            metadata: CallableMetadataBuilder::new("GETHIDDEN")
+                .with_return_type(ExprType::Text)
                 .with_syntax(&[(
                     &[SingularArgSyntax::RequiredValue(
                         RequiredValueSyntax { name: "varname", vtype: ExprType::Text },
@@ -251,7 +253,7 @@ impl GetDataCommand {
     /// Creates a new command that sets aside all data values.
     pub(crate) fn new(data: Rc<RefCell<Vec<Option<Value>>>>) -> Rc<Self> {
         Rc::from(Self {
-            metadata: CallableMetadataBuilder::new("GETDATA", VarType::Void)
+            metadata: CallableMetadataBuilder::new("GETDATA")
                 .with_syntax(&[(&[], None)])
                 .test_build(),
             data,
@@ -285,7 +287,7 @@ impl InCommand {
     /// Creates a new command with the golden `data`.
     pub fn new(data: Box<RefCell<dyn Iterator<Item = &'static &'static str>>>) -> Rc<Self> {
         Rc::from(Self {
-            metadata: CallableMetadataBuilder::new("IN", VarType::Void)
+            metadata: CallableMetadataBuilder::new("IN")
                 .with_syntax(&[(
                     &[SingularArgSyntax::RequiredRef(
                         RequiredRefSyntax {
@@ -335,7 +337,7 @@ impl OutCommand {
     /// Creates a new command that captures all calls into `data`.
     pub fn new(data: Rc<RefCell<Vec<String>>>) -> Rc<Self> {
         Rc::from(Self {
-            metadata: CallableMetadataBuilder::new("OUT", VarType::Void)
+            metadata: CallableMetadataBuilder::new("OUT")
                 .with_syntax(&[(
                     &[],
                     Some(&RepeatedSyntax {
@@ -409,7 +411,8 @@ impl OutfFunction {
     /// Creates a new function that captures all calls into `data`.
     pub fn new(data: Rc<RefCell<Vec<String>>>) -> Rc<Self> {
         Rc::from(Self {
-            metadata: CallableMetadataBuilder::new("OUTF", VarType::Integer)
+            metadata: CallableMetadataBuilder::new("OUTF")
+                .with_return_type(ExprType::Integer)
                 .with_syntax(&[(
                     &[],
                     Some(&RepeatedSyntax {
@@ -462,7 +465,8 @@ pub struct SumFunction {
 impl SumFunction {
     pub fn new() -> Rc<Self> {
         Rc::from(Self {
-            metadata: CallableMetadataBuilder::new("SUM", VarType::Integer)
+            metadata: CallableMetadataBuilder::new("SUM")
+                .with_return_type(ExprType::Integer)
                 .with_syntax(&[(
                     &[],
                     Some(&RepeatedSyntax {
@@ -546,7 +550,8 @@ pub struct TypeCheckFunction {
 impl TypeCheckFunction {
     pub fn new(value: Value) -> Rc<Self> {
         Rc::from(Self {
-            metadata: CallableMetadataBuilder::new("TYPE_CHECK", VarType::Boolean)
+            metadata: CallableMetadataBuilder::new("TYPE_CHECK")
+                .with_return_type(ExprType::Boolean)
                 .with_syntax(&[(&[], None)])
                 .test_build(),
             value,

--- a/core/src/testutils.rs
+++ b/core/src/testutils.rs
@@ -23,7 +23,7 @@ use crate::compiler::{
 use crate::exec::{Machine, Scope, ValueTag};
 use crate::syms::{
     Array, CallError, CallResult, Callable, CallableMetadata, CallableMetadataBuilder, Symbol,
-    Symbols,
+    SymbolKey, Symbols,
 };
 use crate::value;
 use async_trait::async_trait;
@@ -511,33 +511,30 @@ impl Callable for SumFunction {
 // in the real Symbols).
 #[derive(Default)]
 pub struct SymbolsBuilder {
-    by_name: HashMap<String, Symbol>,
+    by_name: HashMap<SymbolKey, Symbol>,
 }
 
 impl SymbolsBuilder {
     /// Adds the array named `name` of type `subtype` to the list of symbols.  The dimensions
     /// and contents of the array are unspecified.
-    pub fn add_array<S: Into<String>>(mut self, name: S, subtype: ExprType) -> Self {
-        let name = name.into();
-        assert!(name == name.to_ascii_uppercase());
+    pub fn add_array<S: AsRef<str>>(mut self, name: S, subtype: ExprType) -> Self {
+        let key = SymbolKey::from(name);
         let array = Array::new(subtype, vec![10]);
-        self.by_name.insert(name, Symbol::Array(array));
+        self.by_name.insert(key, Symbol::Array(array));
         self
     }
 
     /// Adds the `callable` to the list of symbols.
     pub fn add_callable(mut self, callable: Rc<dyn Callable>) -> Self {
         let name = callable.metadata().name();
-        assert!(name == name.to_ascii_uppercase());
-        self.by_name.insert(name.to_owned(), Symbol::Callable(callable));
+        self.by_name.insert(SymbolKey::from(name), Symbol::Callable(callable));
         self
     }
 
     /// Adds the variable named `name` with an initial `value` to the list of symbols.
-    pub fn add_var<S: Into<String>>(mut self, name: S, value: Value) -> Self {
-        let name = name.into();
-        assert!(name == name.to_ascii_uppercase());
-        self.by_name.insert(name, Symbol::Variable(value));
+    pub fn add_var<S: AsRef<str>>(mut self, name: S, value: Value) -> Self {
+        let key = SymbolKey::from(name);
+        self.by_name.insert(key, Symbol::Variable(value));
         self
     }
 

--- a/core/src/testutils.rs
+++ b/core/src/testutils.rs
@@ -23,7 +23,7 @@ use crate::compiler::{
 use crate::exec::{Machine, Scope, ValueTag};
 use crate::syms::{
     Array, CallError, CallResult, Callable, CallableMetadata, CallableMetadataBuilder, Symbol,
-    SymbolKey, Symbols,
+    Symbols,
 };
 use crate::value;
 use async_trait::async_trait;
@@ -315,13 +315,13 @@ impl Callable for InCommand {
 
     async fn exec(&self, mut scope: Scope<'_>, machine: &mut Machine) -> CallResult {
         debug_assert_eq!(1, scope.nargs());
-        let (vref, pos) = scope.pop_varref_with_pos();
+        let (vname, vtype, pos) = scope.pop_varref_with_pos();
 
         let mut data = self.data.borrow_mut();
         let raw_value = data.next().unwrap().to_owned();
-        let value = Value::parse_as(vref.ref_type(), raw_value)
+        let value = Value::parse_as(vtype.into(), raw_value)
             .map_err(|e| CallError::EvalError(pos, e.message))?;
-        machine.get_mut_symbols().assign(&SymbolKey::from(vref.name()), value);
+        machine.get_mut_symbols().assign(&vname, value);
         Ok(())
     }
 }

--- a/core/src/testutils.rs
+++ b/core/src/testutils.rs
@@ -15,10 +15,10 @@
 
 //! Test utilities.
 
-use crate::ast::{ArgSep, Value, VarRef, VarType};
+use crate::ast::{ArgSep, ExprType, Value, VarRef, VarType};
 use crate::compiler::{
-    ArgSepSyntax, ExprType, RepeatedSyntax, RepeatedTypeSyntax, RequiredRefSyntax,
-    RequiredValueSyntax, SingularArgSyntax,
+    ArgSepSyntax, RepeatedSyntax, RepeatedTypeSyntax, RequiredRefSyntax, RequiredValueSyntax,
+    SingularArgSyntax,
 };
 use crate::exec::{Machine, Scope, ValueTag};
 use crate::syms::{

--- a/core/src/testutils.rs
+++ b/core/src/testutils.rs
@@ -15,7 +15,7 @@
 
 //! Test utilities.
 
-use crate::ast::{ArgSep, ExprType, Value, VarRef, VarType};
+use crate::ast::{ArgSep, ExprType, Value, VarRef};
 use crate::compiler::{
     ArgSepSyntax, RepeatedSyntax, RepeatedTypeSyntax, RequiredRefSyntax, RequiredValueSyntax,
     SingularArgSyntax,
@@ -238,7 +238,7 @@ impl Callable for GetHiddenFunction {
     async fn exec(&self, mut scope: Scope<'_>, machine: &mut Machine) -> CallResult {
         assert_eq!(1, scope.nargs());
         let name = scope.pop_string();
-        match machine.get_var(&VarRef::new(name, Some(VarType::Text))) {
+        match machine.get_var(&VarRef::new(name, Some(ExprType::Text))) {
             Ok(t) => scope.return_any(t.clone()),
             Err(_) => panic!("Invalid argument"),
         }
@@ -319,8 +319,8 @@ impl Callable for InCommand {
 
         let mut data = self.data.borrow_mut();
         let raw_value = data.next().unwrap().to_owned();
-        let value = Value::parse_as(vtype.into(), raw_value)
-            .map_err(|e| CallError::EvalError(pos, e.message))?;
+        let value =
+            Value::parse_as(vtype, raw_value).map_err(|e| CallError::EvalError(pos, e.message))?;
         machine.get_mut_symbols().assign(&vname, value);
         Ok(())
     }

--- a/core/src/value.rs
+++ b/core/src/value.rs
@@ -189,8 +189,6 @@ mod tests {
 
     #[test]
     fn test_value_maybe_cast() {
-        use std::i32;
-
         let all_types = [ExprType::Boolean, ExprType::Double, ExprType::Integer, ExprType::Text];
         for target in all_types {
             assert_eq!(Boolean(true), Boolean(true).maybe_cast(Some(target)).unwrap());
@@ -271,31 +269,31 @@ mod tests {
     #[test]
     fn test_value_add_integer() {
         assert_eq!(5, add_integer(2, 3).unwrap());
-        assert_eq!(std::i32::MAX, add_integer(std::i32::MAX, 0).unwrap());
-        assert_eq!("Integer overflow", format!("{}", add_integer(std::i32::MAX, 1).unwrap_err()));
+        assert_eq!(i32::MAX, add_integer(i32::MAX, 0).unwrap());
+        assert_eq!("Integer overflow", format!("{}", add_integer(i32::MAX, 1).unwrap_err()));
     }
 
     #[test]
     fn test_value_sub_integer() {
         assert_eq!(-1, sub_integer(2, 3).unwrap());
-        assert_eq!(std::i32::MIN, sub_integer(std::i32::MIN, 0).unwrap());
-        assert_eq!("Integer underflow", format!("{}", sub_integer(std::i32::MIN, 1).unwrap_err()));
+        assert_eq!(i32::MIN, sub_integer(i32::MIN, 0).unwrap());
+        assert_eq!("Integer underflow", format!("{}", sub_integer(i32::MIN, 1).unwrap_err()));
     }
 
     #[test]
     fn test_value_mul_integer() {
         assert_eq!(6, mul_integer(2, 3).unwrap());
-        assert_eq!(std::i32::MAX, mul_integer(std::i32::MAX, 1).unwrap());
-        assert_eq!("Integer overflow", format!("{}", mul_integer(std::i32::MAX, 2).unwrap_err()));
+        assert_eq!(i32::MAX, mul_integer(i32::MAX, 1).unwrap());
+        assert_eq!("Integer overflow", format!("{}", mul_integer(i32::MAX, 2).unwrap_err()));
     }
 
     #[test]
     fn test_value_div_integer() {
         assert_eq!(2, div_integer(10, 5).unwrap());
         assert_eq!(6, div_integer(20, 3).unwrap());
-        assert_eq!(std::i32::MIN, div_integer(std::i32::MIN, 1).unwrap());
+        assert_eq!(i32::MIN, div_integer(i32::MIN, 1).unwrap());
         assert_eq!("Division by zero", format!("{}", div_integer(4, 0).unwrap_err()));
-        assert_eq!("Integer underflow", format!("{}", div_integer(std::i32::MIN, -1).unwrap_err()));
+        assert_eq!("Integer underflow", format!("{}", div_integer(i32::MIN, -1).unwrap_err()));
     }
 
     #[test]
@@ -303,18 +301,15 @@ mod tests {
         assert_eq!(0, modulo_integer(10, 5).unwrap());
         assert_eq!(2, modulo_integer(20, 3).unwrap());
         assert_eq!("Modulo by zero", format!("{}", modulo_integer(4, 0).unwrap_err()));
-        assert_eq!(
-            "Integer underflow",
-            format!("{}", modulo_integer(std::i32::MIN, -1).unwrap_err())
-        );
+        assert_eq!("Integer underflow", format!("{}", modulo_integer(i32::MIN, -1).unwrap_err()));
     }
 
     #[test]
     fn test_value_pow_integer() {
         assert_eq!(1, pow_integer(0, 0).unwrap());
         assert_eq!(9, pow_integer(3, 2).unwrap());
-        assert_eq!(std::i32::MAX, pow_integer(std::i32::MAX, 1).unwrap());
-        assert_eq!("Integer overflow", format!("{}", pow_integer(std::i32::MAX, 2).unwrap_err()));
+        assert_eq!(i32::MAX, pow_integer(i32::MAX, 1).unwrap());
+        assert_eq!("Integer overflow", format!("{}", pow_integer(i32::MAX, 2).unwrap_err()));
         assert_eq!(
             "Exponent -3 cannot be negative",
             format!("{}", pow_integer(1, -3).unwrap_err())

--- a/core/src/value.rs
+++ b/core/src/value.rs
@@ -16,7 +16,6 @@
 //! Operations on EndBASIC values.
 
 use crate::ast::*;
-use paste::paste;
 use std::convert::TryFrom;
 
 /// Evaluation errors.
@@ -105,77 +104,8 @@ pub(crate) fn integer_to_double(i: i32) -> f64 {
     i as f64
 }
 
-/// Performs a logical "and" operation.
-pub(crate) fn logical_and(lhs: Value, rhs: Value) -> Value {
-    match (lhs, rhs) {
-        (Value::Boolean(lhs), Value::Boolean(rhs)) => Value::Boolean(lhs && rhs),
-        (_, _) => unreachable!("Types validated during compilation"),
-    }
-}
-
-/// Performs a logical "or" operation.
-pub(crate) fn logical_or(lhs: Value, rhs: Value) -> Value {
-    match (lhs, rhs) {
-        (Value::Boolean(lhs), Value::Boolean(rhs)) => Value::Boolean(lhs || rhs),
-        (_, _) => unreachable!("Types validated during compilation"),
-    }
-}
-
-/// Performs a logical "xor" operation.
-pub(crate) fn logical_xor(lhs: Value, rhs: Value) -> Value {
-    match (lhs, rhs) {
-        (Value::Boolean(lhs), Value::Boolean(rhs)) => Value::Boolean(lhs ^ rhs),
-        (_, _) => unreachable!("Types validated during compilation"),
-    }
-}
-
-/// Performs a logical "not" operation.
-pub(crate) fn logical_not(value: Value) -> Value {
-    match value {
-        Value::Boolean(b) => Value::Boolean(!b),
-        _ => unreachable!("Types validated during compilation"),
-    }
-}
-
-/// Performs a bitwise "and" operation.
-pub(crate) fn bitwise_and(lhs: Value, rhs: Value) -> Value {
-    match (lhs, rhs) {
-        (Value::Integer(lhs), Value::Integer(rhs)) => Value::Integer(lhs & rhs),
-        (_, _) => unreachable!("Types validated during compilation"),
-    }
-}
-
-/// Performs a bitwise "or" operation.
-pub(crate) fn bitwise_or(lhs: Value, rhs: Value) -> Value {
-    match (lhs, rhs) {
-        (Value::Integer(lhs), Value::Integer(rhs)) => Value::Integer(lhs | rhs),
-        (_, _) => unreachable!("Types validated during compilation"),
-    }
-}
-
-/// Performs a bitwise "xor" operation.
-pub(crate) fn bitwise_xor(lhs: Value, rhs: Value) -> Value {
-    match (lhs, rhs) {
-        (Value::Integer(lhs), Value::Integer(rhs)) => Value::Integer(lhs ^ rhs),
-        (_, _) => unreachable!("Types validated during compilation"),
-    }
-}
-
-/// Performs a bitwise "not" operation.
-pub(crate) fn bitwise_not(value: Value) -> Value {
-    match value {
-        Value::Integer(b) => Value::Integer(!b),
-        _ => unreachable!("Types validated during compilation"),
-    }
-}
-
 /// Performs a left shift.
-pub(crate) fn bitwise_shl(lhs: Value, rhs: Value) -> Result<Value> {
-    let (lhs, rhs) = match (lhs, rhs) {
-        (Value::Integer(lhs), Value::Integer(rhs)) => (lhs, rhs),
-        (_, _) => unreachable!("Types validated during compilation"),
-    };
-
+pub(crate) fn bitwise_shl(lhs: i32, rhs: i32) -> Result<i32> {
     let bits = match u32::try_from(rhs) {
         Ok(n) => n,
         Err(_) => {
@@ -184,18 +114,13 @@ pub(crate) fn bitwise_shl(lhs: Value, rhs: Value) -> Result<Value> {
     };
 
     match lhs.checked_shl(bits) {
-        Some(i) => Ok(Value::Integer(i)),
-        None => Ok(Value::Integer(0)),
+        Some(i) => Ok(i),
+        None => Ok(0),
     }
 }
 
 /// Performs a right shift.
-pub(crate) fn bitwise_shr(lhs: Value, rhs: Value) -> Result<Value> {
-    let (lhs, rhs) = match (lhs, rhs) {
-        (Value::Integer(lhs), Value::Integer(rhs)) => (lhs, rhs),
-        (_, _) => unreachable!("Types validated during compilation"),
-    };
-
+pub(crate) fn bitwise_shr(lhs: i32, rhs: i32) -> Result<i32> {
     let bits = match u32::try_from(rhs) {
         Ok(n) => n,
         Err(_) => {
@@ -204,237 +129,77 @@ pub(crate) fn bitwise_shr(lhs: Value, rhs: Value) -> Result<Value> {
     };
 
     match lhs.checked_shr(bits) {
-        Some(i) => Ok(Value::Integer(i)),
-        None if lhs < 0 => Ok(Value::Integer(-1)),
-        None => Ok(Value::Integer(0)),
-    }
-}
-
-macro_rules! equality_ops {
-    ( $name:ident, $vtype:expr ) => {
-        paste! {
-            /// Performs an equality check.
-            pub(crate) fn [< eq_ $name >](lhs: Value, rhs: Value) -> Value {
-                match (lhs, rhs) {
-                    ($vtype(lhs), $vtype(rhs)) => Value::Boolean(lhs == rhs),
-                    (_, _) => unreachable!("Types validated during compilation"),
-                }
-            }
-
-            /// Performs an inequality check.
-            pub(crate) fn [< ne_ $name >](lhs: Value, rhs: Value) -> Value {
-                match (lhs, rhs) {
-                    ($vtype(lhs), $vtype(rhs)) => Value::Boolean(lhs != rhs),
-                    (_, _) => unreachable!("Types validated during compilation"),
-                }
-            }
-        }
-    };
-}
-
-equality_ops!(boolean, Value::Boolean);
-equality_ops!(double, Value::Double);
-equality_ops!(integer, Value::Integer);
-equality_ops!(text, Value::Text);
-
-macro_rules! relational_ops {
-    ( $name:ident, $vtype:expr ) => {
-        paste! {
-            /// Performs an equality check.
-            pub(crate) fn [< lt_ $name >](lhs: Value, rhs: Value) -> Value {
-                match (lhs, rhs) {
-                    ($vtype(lhs), $vtype(rhs)) => Value::Boolean(lhs < rhs),
-                    (_, _) => unreachable!("Types validated during compilation"),
-                }
-            }
-
-            /// Performs an equality check.
-            pub(crate) fn [< le_ $name >](lhs: Value, rhs: Value) -> Value {
-                match (lhs, rhs) {
-                    ($vtype(lhs), $vtype(rhs)) => Value::Boolean(lhs <= rhs),
-                    (_, _) => unreachable!("Types validated during compilation"),
-                }
-            }
-
-            /// Performs an equality check.
-            pub(crate) fn [< gt_ $name >](lhs: Value, rhs: Value) -> Value {
-                match (lhs, rhs) {
-                    ($vtype(lhs), $vtype(rhs)) => Value::Boolean(lhs > rhs),
-                    (_, _) => unreachable!("Types validated during compilation"),
-                }
-            }
-
-            /// Performs an equality check.
-            pub(crate) fn [< ge_ $name >](lhs: Value, rhs: Value) -> Value {
-                match (lhs, rhs) {
-                    ($vtype(lhs), $vtype(rhs)) => Value::Boolean(lhs >= rhs),
-                    (_, _) => unreachable!("Types validated during compilation"),
-                }
-            }
-        }
-    };
-}
-
-relational_ops!(double, Value::Double);
-relational_ops!(integer, Value::Integer);
-relational_ops!(text, Value::Text);
-
-/// Performs an arithmetic addition of doubles.
-pub fn add_double(lhs: Value, rhs: Value) -> Value {
-    match (lhs, rhs) {
-        (Value::Double(lhs), Value::Double(rhs)) => Value::Double(lhs + rhs),
-        (_, _) => unreachable!("Types validated during compilation"),
-    }
-}
-
-/// Performs an arithmetic subtraction of doubles.
-pub fn sub_double(lhs: Value, rhs: Value) -> Value {
-    match (lhs, rhs) {
-        (Value::Double(lhs), Value::Double(rhs)) => Value::Double(lhs - rhs),
-        (_, _) => unreachable!("Types validated during compilation"),
-    }
-}
-
-/// Performs a multiplication of doubles.
-pub fn mul_double(lhs: Value, rhs: Value) -> Value {
-    match (lhs, rhs) {
-        (Value::Double(lhs), Value::Double(rhs)) => Value::Double(lhs * rhs),
-        (_, _) => unreachable!("Types validated during compilation"),
-    }
-}
-
-/// Performs an arithmetic division of doubles.
-pub fn div_double(lhs: Value, rhs: Value) -> Value {
-    match (lhs, rhs) {
-        (Value::Double(lhs), Value::Double(rhs)) => Value::Double(lhs / rhs),
-        (_, _) => unreachable!("Types validated during compilation"),
-    }
-}
-
-/// Performs a modulo operation of doubles.
-pub fn modulo_double(lhs: Value, rhs: Value) -> Value {
-    match (lhs, rhs) {
-        (Value::Double(lhs), Value::Double(rhs)) => Value::Double(lhs % rhs),
-        (_, _) => unreachable!("Types validated during compilation"),
-    }
-}
-
-/// Performs a power operation of doubles.
-pub fn pow_double(lhs: Value, rhs: Value) -> Value {
-    match (lhs, rhs) {
-        (Value::Double(lhs), Value::Double(rhs)) => Value::Double(lhs.powf(rhs)),
-        (_, _) => unreachable!("Types validated during compilation"),
-    }
-}
-
-/// Performs an arithmetic negation of a double.
-pub fn neg_double(value: Value) -> Value {
-    match value {
-        Value::Double(d) => Value::Double(-d),
-        _ => unreachable!("Types validated during compilation"),
+        Some(i) => Ok(i),
+        None if lhs < 0 => Ok(-1),
+        None => Ok(0),
     }
 }
 
 /// Performs an arithmetic addition of integers.
-pub fn add_integer(lhs: Value, rhs: Value) -> Result<Value> {
-    match (lhs, rhs) {
-        (Value::Integer(lhs), Value::Integer(rhs)) => match lhs.checked_add(rhs) {
-            Some(i) => Ok(Value::Integer(i)),
-            None => Err(Error::new("Integer overflow".to_owned())),
-        },
-        (_, _) => unreachable!("Types validated during compilation"),
+pub fn add_integer(lhs: i32, rhs: i32) -> Result<i32> {
+    match lhs.checked_add(rhs) {
+        Some(i) => Ok(i),
+        None => Err(Error::new("Integer overflow".to_owned())),
     }
 }
 
 /// Performs an arithmetic subtraction of integers.
-pub fn sub_integer(lhs: Value, rhs: Value) -> Result<Value> {
-    match (lhs, rhs) {
-        (Value::Integer(lhs), Value::Integer(rhs)) => match lhs.checked_sub(rhs) {
-            Some(i) => Ok(Value::Integer(i)),
-            None => Err(Error::new("Integer underflow".to_owned())),
-        },
-        (_, _) => unreachable!("Types validated during compilation"),
+pub fn sub_integer(lhs: i32, rhs: i32) -> Result<i32> {
+    match lhs.checked_sub(rhs) {
+        Some(i) => Ok(i),
+        None => Err(Error::new("Integer underflow".to_owned())),
     }
 }
 
 /// Performs a multiplication of integers.
-pub fn mul_integer(lhs: Value, rhs: Value) -> Result<Value> {
-    match (lhs, rhs) {
-        (Value::Integer(lhs), Value::Integer(rhs)) => match lhs.checked_mul(rhs) {
-            Some(i) => Ok(Value::Integer(i)),
-            None => Err(Error::new("Integer overflow".to_owned())),
-        },
-        (_, _) => unreachable!("Types validated during compilation"),
+pub fn mul_integer(lhs: i32, rhs: i32) -> Result<i32> {
+    match lhs.checked_mul(rhs) {
+        Some(i) => Ok(i),
+        None => Err(Error::new("Integer overflow".to_owned())),
     }
 }
 
 /// Performs an arithmetic division of integers.
-pub fn div_integer(lhs: Value, rhs: Value) -> Result<Value> {
-    match (lhs, rhs) {
-        (Value::Integer(lhs), Value::Integer(rhs)) => {
-            if rhs == 0 {
-                return Err(Error::new("Division by zero"));
-            }
-            match lhs.checked_div(rhs) {
-                Some(i) => Ok(Value::Integer(i)),
-                None => Err(Error::new("Integer underflow".to_owned())),
-            }
-        }
-        (_, _) => unreachable!("Types validated during compilation"),
+pub fn div_integer(lhs: i32, rhs: i32) -> Result<i32> {
+    if rhs == 0 {
+        return Err(Error::new("Division by zero"));
+    }
+    match lhs.checked_div(rhs) {
+        Some(i) => Ok(i),
+        None => Err(Error::new("Integer underflow".to_owned())),
     }
 }
 
 /// Performs a modulo operation of integers.
-pub fn modulo_integer(lhs: Value, rhs: Value) -> Result<Value> {
-    match (lhs, rhs) {
-        (Value::Integer(lhs), Value::Integer(rhs)) => {
-            if rhs == 0 {
-                return Err(Error::new("Modulo by zero"));
-            }
-            match lhs.checked_rem(rhs) {
-                Some(i) => Ok(Value::Integer(i)),
-                None => Err(Error::new("Integer underflow".to_owned())),
-            }
-        }
-        (_, _) => unreachable!("Types validated during compilation"),
+pub fn modulo_integer(lhs: i32, rhs: i32) -> Result<i32> {
+    if rhs == 0 {
+        return Err(Error::new("Modulo by zero"));
+    }
+    match lhs.checked_rem(rhs) {
+        Some(i) => Ok(i),
+        None => Err(Error::new("Integer underflow".to_owned())),
     }
 }
 
 /// Performs a power operation of integers.
-pub fn pow_integer(lhs: Value, rhs: Value) -> Result<Value> {
-    match (lhs, rhs) {
-        (Value::Integer(lhs), Value::Integer(rhs)) => {
-            let exp = match u32::try_from(rhs) {
-                Ok(exp) => exp,
-                Err(_) => {
-                    return Err(Error::new(format!("Exponent {} cannot be negative", rhs)));
-                }
-            };
-            match lhs.checked_pow(exp) {
-                Some(i) => Ok(Value::Integer(i)),
-                None => Err(Error::new("Integer overflow".to_owned())),
-            }
+pub fn pow_integer(lhs: i32, rhs: i32) -> Result<i32> {
+    let exp = match u32::try_from(rhs) {
+        Ok(exp) => exp,
+        Err(_) => {
+            return Err(Error::new(format!("Exponent {} cannot be negative", rhs)));
         }
-        (_, _) => unreachable!("Types validated during compilation"),
+    };
+    match lhs.checked_pow(exp) {
+        Some(i) => Ok(i),
+        None => Err(Error::new("Integer overflow".to_owned())),
     }
 }
 
 /// Performs an arithmetic negation of an integer.
-pub fn neg_integer(value: Value) -> Result<Value> {
-    match value {
-        Value::Integer(i) => match i.checked_neg() {
-            Some(i) => Ok(Value::Integer(i)),
-            None => Err(Error::new("Integer underflow".to_owned())),
-        },
-        _ => unreachable!("Types validated during compilation"),
-    }
-}
-
-/// Performs the concatenation of strings.
-pub fn add_text(lhs: Value, rhs: Value) -> Value {
-    match (lhs, rhs) {
-        (Value::Text(lhs), Value::Text(rhs)) => Value::Text(format!("{}{}", lhs, rhs)),
-        (_, _) => unreachable!("Types validated during compilation"),
+pub fn neg_integer(i: i32) -> Result<i32> {
+    match i.checked_neg() {
+        Some(i) => Ok(i),
+        None => Err(Error::new("Integer underflow".to_owned())),
     }
 }
 
@@ -599,384 +364,101 @@ mod tests {
     }
 
     #[test]
-    fn test_value_logical_and() {
-        assert_eq!(Boolean(false), logical_and(Boolean(false), Boolean(false)));
-        assert_eq!(Boolean(false), logical_and(Boolean(false), Boolean(true)));
-        assert_eq!(Boolean(false), logical_and(Boolean(true), Boolean(false)));
-        assert_eq!(Boolean(true), logical_and(Boolean(true), Boolean(true)));
-    }
-
-    #[test]
-    fn test_value_logical_or() {
-        assert_eq!(Boolean(false), logical_or(Boolean(false), Boolean(false)));
-        assert_eq!(Boolean(true), logical_or(Boolean(false), Boolean(true)));
-        assert_eq!(Boolean(true), logical_or(Boolean(true), Boolean(false)));
-        assert_eq!(Boolean(true), logical_or(Boolean(true), Boolean(true)));
-    }
-
-    #[test]
-    fn test_value_logical_xor() {
-        assert_eq!(Boolean(false), logical_xor(Boolean(false), Boolean(false)));
-        assert_eq!(Boolean(true), logical_xor(Boolean(false), Boolean(true)));
-        assert_eq!(Boolean(true), logical_xor(Boolean(true), Boolean(false)));
-        assert_eq!(Boolean(false), logical_xor(Boolean(true), Boolean(true)));
-    }
-
-    #[test]
-    fn test_value_logical_not() {
-        assert_eq!(Boolean(true), logical_not(Boolean(false)));
-        assert_eq!(Boolean(false), logical_not(Boolean(true)));
-    }
-
-    #[test]
-    fn test_value_bitwise_and() {
-        assert_eq!(Integer(5), bitwise_and(Integer(7), Integer(5)));
-        assert_eq!(Integer(0), bitwise_and(Integer(2), Integer(4)));
-        assert_eq!(Integer(1234), bitwise_and(Integer(-1), Integer(1234)));
-    }
-
-    #[test]
-    fn test_value_bitwise_or() {
-        assert_eq!(Integer(7), bitwise_or(Integer(7), Integer(5)));
-        assert_eq!(Integer(6), bitwise_or(Integer(2), Integer(4)));
-        assert_eq!(Integer(-1), bitwise_or(Integer(-1), Integer(1234)));
-    }
-
-    #[test]
-    fn test_value_bitwise_xor() {
-        assert_eq!(Integer(2), bitwise_xor(Integer(7), Integer(5)));
-        assert_eq!(Integer(6), bitwise_xor(Integer(2), Integer(4)));
-        assert_eq!(Integer(-1235), bitwise_xor(Integer(-1), Integer(1234)));
-    }
-
-    #[test]
-    fn test_value_bitwise_not() {
-        assert_eq!(Integer(-1), bitwise_not(Integer(0)));
-    }
-
-    #[test]
     fn test_value_shl() {
-        assert_eq!(Integer(12), bitwise_shl(Integer(3), Integer(2)).unwrap());
-        assert_eq!(
-            Integer(0xf0000000u32 as i32),
-            bitwise_shl(Integer(0xf0000000u32 as i32), Integer(0)).unwrap()
-        );
-        assert_eq!(Integer(0x80000000u32 as i32), bitwise_shl(Integer(1), Integer(31)).unwrap());
-        assert_eq!(Integer(0), bitwise_shl(Integer(0xf0000000u32 as i32), Integer(31)).unwrap());
+        assert_eq!(12, bitwise_shl(3, 2).unwrap());
+        assert_eq!(0xf0000000u32 as i32, bitwise_shl(0xf0000000u32 as i32, 0).unwrap());
+        assert_eq!(0x80000000u32 as i32, bitwise_shl(1, 31).unwrap());
+        assert_eq!(0, bitwise_shl(0xf0000000u32 as i32, 31).unwrap());
 
-        assert_eq!(
-            Integer(0xe0000000u32 as i32),
-            bitwise_shl(Integer(0xf0000000u32 as i32), Integer(1)).unwrap()
-        );
-        assert_eq!(Integer(0), bitwise_shl(Integer(0x80000000u32 as i32), Integer(1)).unwrap());
-        assert_eq!(Integer(0), bitwise_shl(Integer(1), Integer(32)).unwrap());
-        assert_eq!(Integer(0), bitwise_shl(Integer(1), Integer(64)).unwrap());
+        assert_eq!(0xe0000000u32 as i32, bitwise_shl(0xf0000000u32 as i32, 1).unwrap());
+        assert_eq!(0, bitwise_shl(0x80000000u32 as i32, 1).unwrap());
+        assert_eq!(0, bitwise_shl(1, 32).unwrap());
+        assert_eq!(0, bitwise_shl(1, 64).unwrap());
 
         assert_eq!(
             "Number of bits to << (-1) must be positive",
-            format!("{}", bitwise_shl(Integer(3), Integer(-1)).unwrap_err())
+            format!("{}", bitwise_shl(3, -1).unwrap_err())
         );
     }
 
     #[test]
     fn test_value_shr() {
-        assert_eq!(Integer(3), bitwise_shr(Integer(12), Integer(2)).unwrap());
-        assert_eq!(
-            Integer(0xf0000000u32 as i32),
-            bitwise_shr(Integer(0xf0000000u32 as i32), Integer(0)).unwrap()
-        );
-        assert_eq!(Integer(-1), bitwise_shr(Integer(0xf0000000u32 as i32), Integer(31)).unwrap());
-        assert_eq!(Integer(1), bitwise_shr(Integer(0x70000000u32 as i32), Integer(30)).unwrap());
-        assert_eq!(Integer(-2), bitwise_shr(Integer(-8), Integer(2)).unwrap());
+        assert_eq!(3, bitwise_shr(12, 2).unwrap());
+        assert_eq!(0xf0000000u32 as i32, bitwise_shr(0xf0000000u32 as i32, 0).unwrap());
+        assert_eq!(-1, bitwise_shr(0xf0000000u32 as i32, 31).unwrap());
+        assert_eq!(1, bitwise_shr(0x70000000u32 as i32, 30).unwrap());
+        assert_eq!(-2, bitwise_shr(-8, 2).unwrap());
 
-        assert_eq!(
-            Integer(0xf0000000u32 as i32),
-            bitwise_shr(Integer(0xe0000000u32 as i32), Integer(1)).unwrap()
-        );
-        assert_eq!(
-            Integer(0xc0000000u32 as i32),
-            bitwise_shr(Integer(0x80000000u32 as i32), Integer(1)).unwrap()
-        );
-        assert_eq!(Integer(0x38000000), bitwise_shr(Integer(0x70000000), Integer(1)).unwrap());
-        assert_eq!(Integer(0), bitwise_shr(Integer(0x70000000u32 as i32), Integer(32)).unwrap());
-        assert_eq!(Integer(0), bitwise_shr(Integer(0x70000000u32 as i32), Integer(32)).unwrap());
-        assert_eq!(Integer(-1), bitwise_shr(Integer(0x80000000u32 as i32), Integer(32)).unwrap());
-        assert_eq!(Integer(-1), bitwise_shr(Integer(0x80000000u32 as i32), Integer(64)).unwrap());
+        assert_eq!(0xf0000000u32 as i32, bitwise_shr(0xe0000000u32 as i32, 1).unwrap());
+        assert_eq!(0xc0000000u32 as i32, bitwise_shr(0x80000000u32 as i32, 1).unwrap());
+        assert_eq!(0x38000000, bitwise_shr(0x70000000, 1).unwrap());
+        assert_eq!(0, bitwise_shr(0x70000000u32 as i32, 32).unwrap());
+        assert_eq!(0, bitwise_shr(0x70000000u32 as i32, 32).unwrap());
+        assert_eq!(-1, bitwise_shr(0x80000000u32 as i32, 32).unwrap());
+        assert_eq!(-1, bitwise_shr(0x80000000u32 as i32, 64).unwrap());
 
         assert_eq!(
             "Number of bits to >> (-1) must be positive",
-            format!("{}", bitwise_shr(Integer(3), Integer(-1)).unwrap_err())
+            format!("{}", bitwise_shr(3, -1).unwrap_err())
         );
-    }
-
-    #[test]
-    fn test_value_eq_boolean() {
-        assert_eq!(Boolean(true), eq_boolean(Boolean(false), Boolean(false)));
-        assert_eq!(Boolean(false), eq_boolean(Boolean(true), Boolean(false)));
-    }
-
-    #[test]
-    fn test_value_eq_double() {
-        assert_eq!(Boolean(true), eq_double(Double(2.5), Double(2.5)));
-        assert_eq!(Boolean(false), eq_double(Double(3.5), Double(3.6)));
-    }
-
-    #[test]
-    fn test_value_eq_integer() {
-        assert_eq!(Boolean(true), eq_integer(Integer(2), Integer(2)));
-        assert_eq!(Boolean(false), eq_integer(Integer(3), Integer(4)));
-    }
-
-    #[test]
-    fn test_value_eq_text() {
-        assert_eq!(Boolean(true), eq_text(Text("a".to_owned()), Text("a".to_owned())));
-        assert_eq!(Boolean(false), eq_text(Text("b".to_owned()), Text("c".to_owned())));
-    }
-
-    #[test]
-    fn test_value_ne_boolean() {
-        assert_eq!(Boolean(false), ne_boolean(Boolean(false), Boolean(false)));
-        assert_eq!(Boolean(true), ne_boolean(Boolean(true), Boolean(false)));
-    }
-
-    #[test]
-    fn test_value_ne_double() {
-        assert_eq!(Boolean(false), ne_double(Double(2.5), Double(2.5)));
-        assert_eq!(Boolean(true), ne_double(Double(3.5), Double(3.6)));
-    }
-
-    #[test]
-    fn test_value_ne_integer() {
-        assert_eq!(Boolean(false), ne_integer(Integer(2), Integer(2)));
-        assert_eq!(Boolean(true), ne_integer(Integer(3), Integer(4)));
-    }
-
-    #[test]
-    fn test_value_ne_text() {
-        assert_eq!(Boolean(false), ne_text(Text("a".to_owned()), Text("a".to_owned())));
-        assert_eq!(Boolean(true), ne_text(Text("b".to_owned()), Text("c".to_owned())));
-    }
-
-    #[test]
-    fn test_value_lt_double() {
-        assert_eq!(Boolean(false), lt_double(Double(2.5), Double(2.5)));
-        assert_eq!(Boolean(true), lt_double(Double(3.5), Double(3.6)));
-    }
-
-    #[test]
-    fn test_value_lt_integer() {
-        assert_eq!(Boolean(false), lt_integer(Integer(2), Integer(2)));
-        assert_eq!(Boolean(true), lt_integer(Integer(3), Integer(4)));
-    }
-
-    #[test]
-    fn test_value_lt_text() {
-        assert_eq!(Boolean(false), lt_text(Text("a".to_owned()), Text("a".to_owned())));
-        assert_eq!(Boolean(true), lt_text(Text("a".to_owned()), Text("c".to_owned())));
-    }
-
-    #[test]
-    fn test_value_le_double() {
-        assert_eq!(Boolean(false), le_double(Double(2.1), Double(2.0)));
-        assert_eq!(Boolean(true), le_double(Double(2.1), Double(2.1)));
-        assert_eq!(Boolean(true), le_double(Double(2.1), Double(2.2)));
-    }
-
-    #[test]
-    fn test_value_le_integer() {
-        assert_eq!(Boolean(false), le_integer(Integer(2), Integer(1)));
-        assert_eq!(Boolean(true), le_integer(Integer(2), Integer(2)));
-        assert_eq!(Boolean(true), le_integer(Integer(2), Integer(3)));
-    }
-
-    #[test]
-    fn test_value_le_text() {
-        assert_eq!(Boolean(false), le_text(Text("b".to_owned()), Text("a".to_owned())));
-        assert_eq!(Boolean(true), le_text(Text("a".to_owned()), Text("a".to_owned())));
-        assert_eq!(Boolean(true), le_text(Text("a".to_owned()), Text("c".to_owned())));
-    }
-
-    #[test]
-    fn test_value_gt_double() {
-        assert_eq!(Boolean(false), gt_double(Double(2.1), Double(2.1)));
-        assert_eq!(Boolean(true), gt_double(Double(4.1), Double(4.0)));
-    }
-
-    #[test]
-    fn test_value_gt_integer() {
-        assert_eq!(Boolean(false), gt_integer(Integer(2), Integer(2)));
-        assert_eq!(Boolean(true), gt_integer(Integer(4), Integer(3)));
-    }
-
-    #[test]
-    fn test_value_gt_text() {
-        assert_eq!(Boolean(false), gt_text(Text("a".to_owned()), Text("a".to_owned())));
-        assert_eq!(Boolean(true), gt_text(Text("c".to_owned()), Text("a".to_owned())));
-    }
-
-    #[test]
-    fn test_value_ge_double() {
-        assert_eq!(Boolean(false), ge_double(Double(2.0), Double(2.1)));
-        assert_eq!(Boolean(true), ge_double(Double(2.1), Double(2.1)));
-        assert_eq!(Boolean(true), ge_double(Double(2.2), Double(2.1)));
-    }
-
-    #[test]
-    fn test_value_ge_integer() {
-        assert_eq!(Boolean(false), ge_integer(Integer(1), Integer(2)));
-        assert_eq!(Boolean(true), ge_integer(Integer(2), Integer(2)));
-        assert_eq!(Boolean(true), ge_integer(Integer(4), Integer(3)));
-    }
-
-    #[test]
-    fn test_value_ge_text() {
-        assert_eq!(Boolean(false), ge_text(Text("".to_owned()), Text("b".to_owned())));
-        assert_eq!(Boolean(true), ge_text(Text("a".to_owned()), Text("a".to_owned())));
-        assert_eq!(Boolean(true), ge_text(Text("c".to_owned()), Text("a".to_owned())));
-    }
-
-    #[test]
-    fn test_value_add_double() {
-        assert_eq!(Double(7.1), add_double(Double(2.1), Double(5.0)));
-    }
-
-    #[test]
-    fn test_value_sub_double() {
-        assert_eq!(Double(-1.0), sub_double(Double(2.5), Double(3.5)));
-    }
-
-    #[test]
-    fn test_value_mul_double() {
-        assert_eq!(Double(40.0), mul_double(Double(4.0), Double(10.0)));
-    }
-
-    #[test]
-    fn test_value_div_double() {
-        assert_eq!(Double(4.0), div_double(Double(10.0), Double(2.5)));
-        assert_eq!(Double(f64::INFINITY), div_double(Double(1.0), Double(0.0)));
-    }
-
-    #[test]
-    fn test_value_modulo_double() {
-        assert_eq!(Double(0.0), modulo_double(Double(10.0), Double(2.5)));
-        match modulo_double(Double(1.0), Double(0.0)) {
-            Double(d) => assert!(d.is_nan()),
-            _ => panic!("Did not get a double"),
-        };
-    }
-
-    #[test]
-    fn test_value_pow_double() {
-        assert_eq!(Double(1.0), pow_double(Double(0.0), Double(0.0)));
-        assert_eq!(Double(2.0f64.powf(3.1)), pow_double(Double(2.0), Double(3.1)));
-    }
-
-    #[test]
-    fn test_value_neg_double() {
-        assert_eq!(Double(-6.12), neg_double(Double(6.12)));
-        assert_eq!(Double(5.53), neg_double(Double(-5.53)));
     }
 
     #[test]
     fn test_value_add_integer() {
-        assert_eq!(Integer(5), add_integer(Integer(2), Integer(3)).unwrap());
-        assert_eq!(
-            Integer(std::i32::MAX),
-            add_integer(Integer(std::i32::MAX), Integer(0)).unwrap()
-        );
-        assert_eq!(
-            "Integer overflow",
-            format!("{}", add_integer(Integer(std::i32::MAX), Integer(1)).unwrap_err())
-        );
+        assert_eq!(5, add_integer(2, 3).unwrap());
+        assert_eq!(std::i32::MAX, add_integer(std::i32::MAX, 0).unwrap());
+        assert_eq!("Integer overflow", format!("{}", add_integer(std::i32::MAX, 1).unwrap_err()));
     }
 
     #[test]
     fn test_value_sub_integer() {
-        assert_eq!(Integer(-1), sub_integer(Integer(2), Integer(3)).unwrap());
-        assert_eq!(
-            Integer(std::i32::MIN),
-            sub_integer(Integer(std::i32::MIN), Integer(0)).unwrap()
-        );
-        assert_eq!(
-            "Integer underflow",
-            format!("{}", sub_integer(Integer(std::i32::MIN), Integer(1)).unwrap_err())
-        );
+        assert_eq!(-1, sub_integer(2, 3).unwrap());
+        assert_eq!(std::i32::MIN, sub_integer(std::i32::MIN, 0).unwrap());
+        assert_eq!("Integer underflow", format!("{}", sub_integer(std::i32::MIN, 1).unwrap_err()));
     }
 
     #[test]
     fn test_value_mul_integer() {
-        assert_eq!(Integer(6), mul_integer(Integer(2), Integer(3)).unwrap());
-        assert_eq!(
-            Integer(std::i32::MAX),
-            mul_integer(Integer(std::i32::MAX), Integer(1)).unwrap()
-        );
-        assert_eq!(
-            "Integer overflow",
-            format!("{}", mul_integer(Integer(std::i32::MAX), Integer(2)).unwrap_err())
-        );
+        assert_eq!(6, mul_integer(2, 3).unwrap());
+        assert_eq!(std::i32::MAX, mul_integer(std::i32::MAX, 1).unwrap());
+        assert_eq!("Integer overflow", format!("{}", mul_integer(std::i32::MAX, 2).unwrap_err()));
     }
 
     #[test]
     fn test_value_div_integer() {
-        assert_eq!(Integer(2), div_integer(Integer(10), Integer(5)).unwrap());
-        assert_eq!(Integer(6), div_integer(Integer(20), Integer(3)).unwrap());
-        assert_eq!(
-            Integer(std::i32::MIN),
-            div_integer(Integer(std::i32::MIN), Integer(1)).unwrap()
-        );
-        assert_eq!(
-            "Division by zero",
-            format!("{}", div_integer(Integer(4), Integer(0)).unwrap_err())
-        );
-        assert_eq!(
-            "Integer underflow",
-            format!("{}", div_integer(Integer(std::i32::MIN), Integer(-1)).unwrap_err())
-        );
+        assert_eq!(2, div_integer(10, 5).unwrap());
+        assert_eq!(6, div_integer(20, 3).unwrap());
+        assert_eq!(std::i32::MIN, div_integer(std::i32::MIN, 1).unwrap());
+        assert_eq!("Division by zero", format!("{}", div_integer(4, 0).unwrap_err()));
+        assert_eq!("Integer underflow", format!("{}", div_integer(std::i32::MIN, -1).unwrap_err()));
     }
 
     #[test]
     fn test_value_modulo_integer() {
-        assert_eq!(Integer(0), modulo_integer(Integer(10), Integer(5)).unwrap());
-        assert_eq!(Integer(2), modulo_integer(Integer(20), Integer(3)).unwrap());
-        assert_eq!(
-            "Modulo by zero",
-            format!("{}", modulo_integer(Integer(4), Integer(0)).unwrap_err())
-        );
+        assert_eq!(0, modulo_integer(10, 5).unwrap());
+        assert_eq!(2, modulo_integer(20, 3).unwrap());
+        assert_eq!("Modulo by zero", format!("{}", modulo_integer(4, 0).unwrap_err()));
         assert_eq!(
             "Integer underflow",
-            format!("{}", modulo_integer(Integer(std::i32::MIN), Integer(-1)).unwrap_err())
+            format!("{}", modulo_integer(std::i32::MIN, -1).unwrap_err())
         );
     }
 
     #[test]
     fn test_value_pow_integer() {
-        assert_eq!(Integer(1), pow_integer(Integer(0), Integer(0)).unwrap());
-        assert_eq!(Integer(9), pow_integer(Integer(3), Integer(2)).unwrap());
-        assert_eq!(
-            Integer(std::i32::MAX),
-            pow_integer(Integer(std::i32::MAX), Integer(1)).unwrap()
-        );
-        assert_eq!(
-            "Integer overflow",
-            format!("{}", pow_integer(Integer(std::i32::MAX), Integer(2)).unwrap_err())
-        );
+        assert_eq!(1, pow_integer(0, 0).unwrap());
+        assert_eq!(9, pow_integer(3, 2).unwrap());
+        assert_eq!(std::i32::MAX, pow_integer(std::i32::MAX, 1).unwrap());
+        assert_eq!("Integer overflow", format!("{}", pow_integer(std::i32::MAX, 2).unwrap_err()));
         assert_eq!(
             "Exponent -3 cannot be negative",
-            format!("{}", pow_integer(Integer(1), Integer(-3)).unwrap_err())
+            format!("{}", pow_integer(1, -3).unwrap_err())
         );
     }
 
     #[test]
     fn test_value_neg_integer() {
-        assert_eq!(Integer(-6), neg_integer(Integer(6)).unwrap());
-        assert_eq!(Integer(5), neg_integer(Integer(-5)).unwrap());
-    }
-
-    #[test]
-    fn test_value_add_text() {
-        assert_eq!(
-            Text("foobar".to_owned()),
-            add_text(Text("foo".to_owned()), Text("bar".to_owned()))
-        );
+        assert_eq!(-6, neg_integer(6).unwrap());
+        assert_eq!(5, neg_integer(-5).unwrap());
     }
 }

--- a/core/src/value.rs
+++ b/core/src/value.rs
@@ -76,44 +76,33 @@ impl Value {
         }
     }
 
-    /// Reinterprets this value as an `i32` and fails if the conversion is not possible.
-    pub fn as_i32(&self) -> Result<i32> {
-        match self {
-            Value::Double(d) => {
-                let d = d.round();
-                if d.is_finite() && d >= (std::i32::MIN as f64) && (d <= std::i32::MAX as f64) {
-                    Ok(d as i32)
-                } else {
-                    Err(Error::new(format!("Cannot cast {} to integer due to overflow", d)))
-                }
-            }
-            Value::Integer(i) => Ok(*i),
-            Value::VarRef(_) => panic!("Should never get unevaluated varrefs"),
-            _ => Err(Error::new(format!("{} is not a number", self))),
-        }
-    }
-
-    /// Reinterprets this value as an `f64` and fails if the conversion is not possible.
-    pub fn as_f64(&self) -> Result<f64> {
-        match self {
-            Value::Double(d) => Ok(*d),
-            Value::Integer(i) => Ok(*i as f64),
-            _ => Err(Error::new(format!("{} is not a number", self))),
-        }
-    }
-
     /// Given a `target` variable type, tries to convert the value to that type if they are
     /// compatible or otherwise returns self.
     ///
     /// Can return an error when the conversion is feasible but it is not possible, such as trying
     /// to cast a NaN to an integer.
-    pub fn maybe_cast(self, target: VarType) -> Result<Value> {
+    pub(crate) fn maybe_cast(self, target: VarType) -> Result<Value> {
         match (target, self) {
-            (VarType::Integer, d @ Value::Double(_)) => Ok(Value::Integer(d.as_i32()?)),
-            (VarType::Double, i @ Value::Integer(_)) => Ok(Value::Double(i.as_f64()?)),
+            (VarType::Integer, Value::Double(d)) => Ok(Value::Integer(double_to_integer(d)?)),
+            (VarType::Double, Value::Integer(i)) => Ok(Value::Double(integer_to_double(i))),
             (_, v) => Ok(v),
         }
     }
+}
+
+/// Converts the double `d` to an integer and fails if the conversion is not possible.
+pub fn double_to_integer(d: f64) -> Result<i32> {
+    let d = d.round();
+    if d.is_finite() && d >= (i32::MIN as f64) && (d <= i32::MAX as f64) {
+        Ok(d as i32)
+    } else {
+        Err(Error::new(format!("Cannot cast {} to integer due to overflow", d)))
+    }
+}
+
+/// Converts the integer `i` to a double.
+pub(crate) fn integer_to_double(i: i32) -> f64 {
+    i as f64
 }
 
 /// Performs a logical "and" operation.
@@ -546,27 +535,19 @@ mod tests {
     }
 
     #[test]
-    fn test_value_as_i32() {
-        assert_eq!(8, Double(8.4).as_i32().unwrap());
-        assert_eq!(9, Double(8.5).as_i32().unwrap());
-        assert_eq!(9, Double(8.6).as_i32().unwrap());
-        assert_eq!(7, Integer(7).as_i32().unwrap());
+    fn test_double_to_integer() {
+        assert_eq!(8, double_to_integer(8.4).unwrap());
+        assert_eq!(9, double_to_integer(8.5).unwrap());
+        assert_eq!(9, double_to_integer(8.6).unwrap());
 
-        Double(f64::NAN).as_i32().unwrap_err();
-        Double(i32::MAX as f64 + 1.0).as_i32().unwrap_err();
-        Double(i32::MIN as f64 - 1.0).as_i32().unwrap_err();
-
-        Boolean(false).as_i32().unwrap_err();
-        Text("a".to_owned()).as_i32().unwrap_err();
+        double_to_integer(f64::NAN).unwrap_err();
+        double_to_integer(i32::MAX as f64 + 1.0).unwrap_err();
+        double_to_integer(i32::MIN as f64 - 1.0).unwrap_err();
     }
 
     #[test]
-    fn test_value_as_f64() {
-        assert_eq!(8.4, Double(8.4).as_f64().unwrap());
-        assert_eq!(7.0, Integer(7).as_f64().unwrap());
-
-        Boolean(false).as_f64().unwrap_err();
-        Text("a".to_owned()).as_f64().unwrap_err();
+    fn test_integer_to_double() {
+        assert_eq!(7.0, integer_to_double(7));
     }
 
     #[test]

--- a/core/src/value.rs
+++ b/core/src/value.rs
@@ -72,7 +72,6 @@ impl Value {
             VarType::Double => parse_f64(&s),
             VarType::Integer => parse_i32(&s),
             VarType::Text => Ok(Value::Text(s)),
-            VarType::Void => panic!("Void values are not supported"),
         }
     }
 
@@ -554,14 +553,8 @@ mod tests {
     fn test_value_maybe_cast() {
         use std::i32;
 
-        let all_types = [
-            VarType::Auto,
-            VarType::Boolean,
-            VarType::Double,
-            VarType::Integer,
-            VarType::Text,
-            VarType::Void,
-        ];
+        let all_types =
+            [VarType::Auto, VarType::Boolean, VarType::Double, VarType::Integer, VarType::Text];
         for target in all_types {
             assert_eq!(Boolean(true), Boolean(true).maybe_cast(target).unwrap());
             if target != VarType::Integer {

--- a/repl/src/demos.rs
+++ b/repl/src/demos.rs
@@ -106,7 +106,7 @@ impl Drive for DemosDrive {
         }
         let files = self.demos.len();
 
-        let disk_quota = if bytes <= std::u64::MAX as usize && files <= std::u64::MAX as usize {
+        let disk_quota = if bytes <= u64::MAX as usize && files <= u64::MAX as usize {
             Some(DiskSpace::new(bytes as u64, files as u64))
         } else {
             // Cannot represent the amount of disk within a DiskSpace.

--- a/std/src/arrays.rs
+++ b/std/src/arrays.rs
@@ -16,7 +16,7 @@
 //! Array-related functions for EndBASIC.
 
 use async_trait::async_trait;
-use endbasic_core::ast::{ArgSep, ExprType};
+use endbasic_core::ast::{ArgSep, ExprType, VarRef};
 use endbasic_core::compiler::{
     ArgSepSyntax, RequiredRefSyntax, RequiredValueSyntax, SingularArgSyntax,
 };
@@ -37,8 +37,9 @@ fn parse_bound_args<'a>(
     scope: &mut Scope<'_>,
     symbols: &'a Symbols,
 ) -> Result<(&'a Array, usize), CallError> {
-    let (arrayref, arraypos) = scope.pop_varref_with_pos();
+    let (arrayname, arraytype, arraypos) = scope.pop_varref_with_pos();
 
+    let arrayref = VarRef::new(arrayname.to_string(), arraytype.into());
     let array = match symbols
         .get(&arrayref)
         .map_err(|e| CallError::ArgumentError(arraypos, format!("{}", e)))?
@@ -60,7 +61,7 @@ fn parse_bound_args<'a>(
                 pos,
                 format!(
                     "Array {} has only {} dimensions but asked for {}",
-                    arrayref,
+                    arrayname,
                     array.dimensions().len(),
                     i,
                 ),
@@ -305,7 +306,7 @@ mod tests {
         Tester::default()
             .run(&format!("DIM x(2, 3, 4): result = {}(x, 5)", func))
             .expect_err(format!(
-                "1:26: In call to {}: 1:36: Array x has only 3 dimensions but asked for 5",
+                "1:26: In call to {}: 1:36: Array X has only 3 dimensions but asked for 5",
                 func
             ))
             .expect_array("x", ExprType::Integer, &[2, 3, 4], vec![])

--- a/std/src/arrays.rs
+++ b/std/src/arrays.rs
@@ -219,8 +219,8 @@ pub fn add_all(machine: &mut Machine) {
 
 #[cfg(test)]
 mod tests {
+    use super::*;
     use crate::testutils::*;
-    use endbasic_core::ast::VarType;
 
     /// Validates error handling of `LBOUND` and `UBOUND` as given in `func`.
     fn do_bound_errors_test(func: &str) {
@@ -243,7 +243,7 @@ mod tests {
         Tester::default()
             .run(&format!("DIM x(2): result = {}(x, -1)", func))
             .expect_err(format!("1:20: In call to {}: 1:30: Dimension -1 must be positive", func))
-            .expect_array("x", VarType::Integer, &[2], vec![])
+            .expect_array("x", ExprType::Integer, &[2], vec![])
             .check();
 
         Tester::default()
@@ -297,7 +297,7 @@ mod tests {
                 "1:26: In call to {}: 1:33: Requires a dimension for multidimensional arrays",
                 func
             ))
-            .expect_array("x", VarType::Integer, &[2, 3, 4], vec![])
+            .expect_array("x", ExprType::Integer, &[2, 3, 4], vec![])
             .check();
 
         Tester::default()
@@ -306,7 +306,7 @@ mod tests {
                 "1:26: In call to {}: 1:36: Array x has only 3 dimensions but asked for 5",
                 func
             ))
-            .expect_array("x", VarType::Integer, &[2, 3, 4], vec![])
+            .expect_array("x", ExprType::Integer, &[2, 3, 4], vec![])
             .check();
     }
 
@@ -315,19 +315,19 @@ mod tests {
         Tester::default()
             .run("DIM x(10): result = LBOUND(x)")
             .expect_var("result", 0i32)
-            .expect_array("x", VarType::Integer, &[10], vec![])
+            .expect_array("x", ExprType::Integer, &[10], vec![])
             .check();
 
         Tester::default()
             .run("DIM x(10, 20): result = LBOUND(x, 1)")
             .expect_var("result", 0i32)
-            .expect_array("x", VarType::Integer, &[10, 20], vec![])
+            .expect_array("x", ExprType::Integer, &[10, 20], vec![])
             .check();
 
         Tester::default()
             .run("DIM x(10, 20): result = LBOUND(x, 2.1)")
             .expect_var("result", 0i32)
-            .expect_array("x", VarType::Integer, &[10, 20], vec![])
+            .expect_array("x", ExprType::Integer, &[10, 20], vec![])
             .check();
     }
 
@@ -341,19 +341,19 @@ mod tests {
         Tester::default()
             .run("DIM x(10): result = UBOUND(x)")
             .expect_var("result", 9i32)
-            .expect_array("x", VarType::Integer, &[10], vec![])
+            .expect_array("x", ExprType::Integer, &[10], vec![])
             .check();
 
         Tester::default()
             .run("DIM x(10, 20): result = UBOUND(x, 1)")
             .expect_var("result", 9i32)
-            .expect_array("x", VarType::Integer, &[10, 20], vec![])
+            .expect_array("x", ExprType::Integer, &[10, 20], vec![])
             .check();
 
         Tester::default()
             .run("DIM x(10, 20): result = UBOUND(x, 2.1)")
             .expect_var("result", 19i32)
-            .expect_array("x", VarType::Integer, &[10, 20], vec![])
+            .expect_array("x", ExprType::Integer, &[10, 20], vec![])
             .check();
     }
 
@@ -369,7 +369,7 @@ mod tests {
             .expect_var("i", 5i32)
             .expect_array_simple(
                 "x",
-                VarType::Integer,
+                ExprType::Integer,
                 vec![0i32.into(), 2i32.into(), 4i32.into(), 6i32.into(), 8i32.into()],
             )
             .check();

--- a/std/src/arrays.rs
+++ b/std/src/arrays.rs
@@ -16,7 +16,7 @@
 //! Array-related functions for EndBASIC.
 
 use async_trait::async_trait;
-use endbasic_core::ast::{ArgSep, ExprType, Value};
+use endbasic_core::ast::{ArgSep, ExprType};
 use endbasic_core::compiler::{
     ArgSepSyntax, RequiredRefSyntax, RequiredValueSyntax, SingularArgSyntax,
 };
@@ -34,7 +34,7 @@ const CATEGORY: &str = "Array functions";
 /// either `LBOUND` or `UBOUND`.
 #[allow(clippy::needless_lifetimes)]
 fn parse_bound_args<'a>(
-    mut scope: Scope<'_>,
+    scope: &mut Scope<'_>,
     symbols: &'a Symbols,
 ) -> Result<(&'a Array, usize), CallError> {
     let (arrayref, arraypos) = scope.pop_varref_with_pos();
@@ -141,9 +141,9 @@ impl Callable for LboundFunction {
         &self.metadata
     }
 
-    async fn exec(&self, scope: Scope<'_>, machine: &mut Machine) -> CallResult {
-        let (_array, _dim) = parse_bound_args(scope, machine.get_symbols())?;
-        Ok(Value::Integer(0))
+    async fn exec(&self, mut scope: Scope<'_>, machine: &mut Machine) -> CallResult {
+        let (_array, _dim) = parse_bound_args(&mut scope, machine.get_symbols())?;
+        scope.return_integer(0)
     }
 }
 
@@ -207,9 +207,9 @@ impl Callable for UboundFunction {
         &self.metadata
     }
 
-    async fn exec(&self, scope: Scope<'_>, machine: &mut Machine) -> CallResult {
-        let (array, dim) = parse_bound_args(scope, machine.get_symbols())?;
-        Ok(Value::Integer((array.dimensions()[dim - 1] - 1) as i32))
+    async fn exec(&self, mut scope: Scope<'_>, machine: &mut Machine) -> CallResult {
+        let (array, dim) = parse_bound_args(&mut scope, machine.get_symbols())?;
+        scope.return_integer((array.dimensions()[dim - 1] - 1) as i32)
     }
 }
 

--- a/std/src/arrays.rs
+++ b/std/src/arrays.rs
@@ -39,7 +39,7 @@ fn parse_bound_args<'a>(
 ) -> Result<(&'a Array, usize), CallError> {
     let (arrayname, arraytype, arraypos) = scope.pop_varref_with_pos();
 
-    let arrayref = VarRef::new(arrayname.to_string(), Some(arraytype.into()));
+    let arrayref = VarRef::new(arrayname.to_string(), Some(arraytype));
     let array = match symbols
         .get(&arrayref)
         .map_err(|e| CallError::ArgumentError(arraypos, format!("{}", e)))?

--- a/std/src/arrays.rs
+++ b/std/src/arrays.rs
@@ -39,7 +39,7 @@ fn parse_bound_args<'a>(
 ) -> Result<(&'a Array, usize), CallError> {
     let (arrayname, arraytype, arraypos) = scope.pop_varref_with_pos();
 
-    let arrayref = VarRef::new(arrayname.to_string(), arraytype.into());
+    let arrayref = VarRef::new(arrayname.to_string(), Some(arraytype.into()));
     let array = match symbols
         .get(&arrayref)
         .map_err(|e| CallError::ArgumentError(arraypos, format!("{}", e)))?

--- a/std/src/arrays.rs
+++ b/std/src/arrays.rs
@@ -16,9 +16,9 @@
 //! Array-related functions for EndBASIC.
 
 use async_trait::async_trait;
-use endbasic_core::ast::{ArgSep, Value, VarType};
+use endbasic_core::ast::{ArgSep, ExprType, Value, VarType};
 use endbasic_core::compiler::{
-    ArgSepSyntax, ExprType, RequiredRefSyntax, RequiredValueSyntax, SingularArgSyntax,
+    ArgSepSyntax, RequiredRefSyntax, RequiredValueSyntax, SingularArgSyntax,
 };
 use endbasic_core::exec::{Machine, Scope};
 use endbasic_core::syms::{

--- a/std/src/arrays.rs
+++ b/std/src/arrays.rs
@@ -16,7 +16,7 @@
 //! Array-related functions for EndBASIC.
 
 use async_trait::async_trait;
-use endbasic_core::ast::{ArgSep, ExprType, Value, VarType};
+use endbasic_core::ast::{ArgSep, ExprType, Value};
 use endbasic_core::compiler::{
     ArgSepSyntax, RequiredRefSyntax, RequiredValueSyntax, SingularArgSyntax,
 };
@@ -90,7 +90,8 @@ impl LboundFunction {
     /// Creates a new instance of the function.
     pub fn new() -> Rc<Self> {
         Rc::from(Self {
-            metadata: CallableMetadataBuilder::new("LBOUND", VarType::Integer)
+            metadata: CallableMetadataBuilder::new("LBOUND")
+                .with_return_type(ExprType::Integer)
                 .with_syntax(&[
                     (
                         &[SingularArgSyntax::RequiredRef(
@@ -155,7 +156,8 @@ impl UboundFunction {
     /// Creates a new instance of the function.
     pub fn new() -> Rc<Self> {
         Rc::from(Self {
-            metadata: CallableMetadataBuilder::new("UBOUND", VarType::Integer)
+            metadata: CallableMetadataBuilder::new("UBOUND")
+                .with_return_type(ExprType::Integer)
                 .with_syntax(&[
                     (
                         &[SingularArgSyntax::RequiredRef(

--- a/std/src/console/cmds.rs
+++ b/std/src/console/cmds.rs
@@ -19,10 +19,10 @@ use crate::console::readline::read_line;
 use crate::console::{CharsXY, ClearType, Console, ConsoleClearable, Key};
 use crate::strings::{format_boolean, format_double, format_integer};
 use async_trait::async_trait;
-use endbasic_core::ast::{ArgSep, Value, VarType};
+use endbasic_core::ast::{ArgSep, ExprType, Value, VarType};
 use endbasic_core::compiler::{
-    ArgSepSyntax, ExprType, OptionalValueSyntax, RepeatedSyntax, RepeatedTypeSyntax,
-    RequiredRefSyntax, RequiredValueSyntax, SingularArgSyntax,
+    ArgSepSyntax, OptionalValueSyntax, RepeatedSyntax, RepeatedTypeSyntax, RequiredRefSyntax,
+    RequiredValueSyntax, SingularArgSyntax,
 };
 use endbasic_core::exec::{Machine, Scope, ValueTag};
 use endbasic_core::syms::{

--- a/std/src/console/cmds.rs
+++ b/std/src/console/cmds.rs
@@ -19,7 +19,7 @@ use crate::console::readline::read_line;
 use crate::console::{CharsXY, ClearType, Console, ConsoleClearable, Key};
 use crate::strings::{format_boolean, format_double, format_integer};
 use async_trait::async_trait;
-use endbasic_core::ast::{ArgSep, ExprType, Value, VarType};
+use endbasic_core::ast::{ArgSep, ExprType, Value};
 use endbasic_core::compiler::{
     ArgSepSyntax, OptionalValueSyntax, RepeatedSyntax, RepeatedTypeSyntax, RequiredRefSyntax,
     RequiredValueSyntax, SingularArgSyntax,
@@ -62,7 +62,7 @@ impl ClsCommand {
     /// Creates a new `CLS` command that clears the `console`.
     pub fn new(console: Rc<RefCell<dyn Console>>) -> Rc<Self> {
         Rc::from(Self {
-            metadata: CallableMetadataBuilder::new("CLS", VarType::Void)
+            metadata: CallableMetadataBuilder::new("CLS")
                 .with_syntax(&[(&[], None)])
                 .with_category(CATEGORY)
                 .with_description("Clears the screen.")
@@ -98,7 +98,7 @@ impl ColorCommand {
     /// Creates a new `COLOR` command that changes the color of the `console`.
     pub fn new(console: Rc<RefCell<dyn Console>>) -> Rc<Self> {
         Rc::from(Self {
-            metadata: CallableMetadataBuilder::new("COLOR", VarType::Void)
+            metadata: CallableMetadataBuilder::new("COLOR")
                 .with_syntax(&[
                     (&[], None),
                     (
@@ -191,7 +191,8 @@ impl InKeyFunction {
     /// Creates a new `INKEY` function that waits for a key press.
     pub fn new(console: Rc<RefCell<dyn Console>>) -> Rc<Self> {
         Rc::from(Self {
-            metadata: CallableMetadataBuilder::new("INKEY", VarType::Text)
+            metadata: CallableMetadataBuilder::new("INKEY")
+                .with_return_type(ExprType::Text)
                 .with_syntax(&[(&[], None)])
                 .with_category(CATEGORY)
                 .with_description(
@@ -259,7 +260,7 @@ impl InputCommand {
     /// Creates a new `INPUT` command that uses `console` to gather user input.
     pub fn new(console: Rc<RefCell<dyn Console>>) -> Rc<Self> {
         Rc::from(Self {
-            metadata: CallableMetadataBuilder::new("INPUT", VarType::Void)
+            metadata: CallableMetadataBuilder::new("INPUT")
                 .with_syntax(&[
                     (
                         &[SingularArgSyntax::RequiredRef(
@@ -382,7 +383,7 @@ impl LocateCommand {
     /// Creates a new `LOCATE` command that moves the cursor of the `console`.
     pub fn new(console: Rc<RefCell<dyn Console>>) -> Rc<Self> {
         Rc::from(Self {
-            metadata: CallableMetadataBuilder::new("LOCATE", VarType::Void)
+            metadata: CallableMetadataBuilder::new("LOCATE")
                 .with_syntax(&[(
                     &[
                         SingularArgSyntax::RequiredValue(
@@ -453,7 +454,7 @@ impl PrintCommand {
     /// Creates a new `PRINT` command that writes to `console`.
     pub fn new(console: Rc<RefCell<dyn Console>>) -> Rc<Self> {
         Rc::from(Self {
-            metadata: CallableMetadataBuilder::new("PRINT", VarType::Void)
+            metadata: CallableMetadataBuilder::new("PRINT")
                 .with_syntax(&[(
                     &[],
                     Some(&RepeatedSyntax {
@@ -561,7 +562,8 @@ impl ScrColsFunction {
     /// Creates a new instance of the function.
     pub fn new(console: Rc<RefCell<dyn Console>>) -> Rc<Self> {
         Rc::from(Self {
-            metadata: CallableMetadataBuilder::new("SCRCOLS", VarType::Integer)
+            metadata: CallableMetadataBuilder::new("SCRCOLS")
+                .with_return_type(ExprType::Integer)
                 .with_syntax(&[(&[], None)])
                 .with_category(CATEGORY)
                 .with_description(
@@ -597,7 +599,8 @@ impl ScrRowsFunction {
     /// Creates a new instance of the function.
     pub fn new(console: Rc<RefCell<dyn Console>>) -> Rc<Self> {
         Rc::from(Self {
-            metadata: CallableMetadataBuilder::new("SCRROWS", VarType::Integer)
+            metadata: CallableMetadataBuilder::new("SCRROWS")
+                .with_return_type(ExprType::Integer)
                 .with_syntax(&[(&[], None)])
                 .with_category(CATEGORY)
                 .with_description(

--- a/std/src/console/cmds.rs
+++ b/std/src/console/cmds.rs
@@ -81,7 +81,7 @@ impl Callable for ClsCommand {
     async fn exec(&self, scope: Scope<'_>, _machine: &mut Machine) -> CallResult {
         debug_assert_eq!(0, scope.nargs());
         self.console.borrow_mut().clear(ClearType::All)?;
-        Ok(Value::Void)
+        Ok(())
     }
 }
 
@@ -177,7 +177,7 @@ impl Callable for ColorCommand {
         };
 
         self.console.borrow_mut().set_color(fg, bg)?;
-        Ok(Value::Void)
+        Ok(())
     }
 }
 
@@ -225,28 +225,29 @@ impl Callable for InKeyFunction {
         debug_assert_eq!(0, scope.nargs());
 
         let key = self.console.borrow_mut().poll_key().await?;
-        Ok(match key {
-            Some(Key::ArrowDown) => Value::Text("DOWN".to_owned()),
-            Some(Key::ArrowLeft) => Value::Text("LEFT".to_owned()),
-            Some(Key::ArrowRight) => Value::Text("RIGHT".to_owned()),
-            Some(Key::ArrowUp) => Value::Text("UP".to_owned()),
+        let key_name = match key {
+            Some(Key::ArrowDown) => "DOWN".to_owned(),
+            Some(Key::ArrowLeft) => "LEFT".to_owned(),
+            Some(Key::ArrowRight) => "RIGHT".to_owned(),
+            Some(Key::ArrowUp) => "UP".to_owned(),
 
-            Some(Key::Backspace) => Value::Text("BS".to_owned()),
-            Some(Key::CarriageReturn) => Value::Text("ENTER".to_owned()),
-            Some(Key::Char(x)) => Value::Text(format!("{}", x)),
-            Some(Key::End) => Value::Text("END".to_owned()),
-            Some(Key::Eof) => Value::Text("EOF".to_owned()),
-            Some(Key::Escape) => Value::Text("ESC".to_owned()),
-            Some(Key::Home) => Value::Text("HOME".to_owned()),
-            Some(Key::Interrupt) => Value::Text("INT".to_owned()),
-            Some(Key::NewLine) => Value::Text("ENTER".to_owned()),
-            Some(Key::PageDown) => Value::Text("PGDOWN".to_owned()),
-            Some(Key::PageUp) => Value::Text("PGUP".to_owned()),
-            Some(Key::Tab) => Value::Text("TAB".to_owned()),
-            Some(Key::Unknown(_)) => Value::Text("".to_owned()),
+            Some(Key::Backspace) => "BS".to_owned(),
+            Some(Key::CarriageReturn) => "ENTER".to_owned(),
+            Some(Key::Char(x)) => format!("{}", x),
+            Some(Key::End) => "END".to_owned(),
+            Some(Key::Eof) => "EOF".to_owned(),
+            Some(Key::Escape) => "ESC".to_owned(),
+            Some(Key::Home) => "HOME".to_owned(),
+            Some(Key::Interrupt) => "INT".to_owned(),
+            Some(Key::NewLine) => "ENTER".to_owned(),
+            Some(Key::PageDown) => "PGDOWN".to_owned(),
+            Some(Key::PageUp) => "PGUP".to_owned(),
+            Some(Key::Tab) => "TAB".to_owned(),
+            Some(Key::Unknown(_)) => "".to_owned(),
 
-            None => Value::Text("".to_owned()),
-        })
+            None => "".to_owned(),
+        };
+        scope.return_string(key_name)
     }
 }
 
@@ -357,7 +358,7 @@ impl Callable for InputCommand {
                             .get_mut_symbols()
                             .set_var(&vref, value)
                             .map_err(|e| CallError::EvalError(pos, format!("{}", e)))?;
-                        return Ok(Value::Void);
+                        return Ok(());
                     }
                     Err(e) => {
                         console.print(&format!("Retry input: {}", e))?;
@@ -440,7 +441,7 @@ impl Callable for LocateCommand {
         }
 
         console.locate(CharsXY::new(column, row))?;
-        Ok(Value::Void)
+        Ok(())
     }
 }
 
@@ -548,7 +549,7 @@ impl Callable for PrintCommand {
         } else {
             self.console.borrow_mut().write(&text)?;
         }
-        Ok(Value::Void)
+        Ok(())
     }
 }
 
@@ -585,7 +586,7 @@ impl Callable for ScrColsFunction {
     async fn exec(&self, scope: Scope<'_>, _machine: &mut Machine) -> CallResult {
         debug_assert_eq!(0, scope.nargs());
         let size = self.console.borrow().size_chars()?;
-        Ok(Value::Integer(i32::from(size.x)))
+        scope.return_integer(i32::from(size.x))
     }
 }
 
@@ -622,7 +623,7 @@ impl Callable for ScrRowsFunction {
     async fn exec(&self, scope: Scope<'_>, _machine: &mut Machine) -> CallResult {
         debug_assert_eq!(0, scope.nargs());
         let size = self.console.borrow().size_chars()?;
-        Ok(Value::Integer(i32::from(size.y)))
+        scope.return_integer(i32::from(size.y))
     }
 }
 

--- a/std/src/console/cmds.rs
+++ b/std/src/console/cmds.rs
@@ -834,14 +834,20 @@ mod tests {
             "1:1: In call to INPUT: expected <vref> | <[prompt$] <,|;> vref>",
             "INPUT \"foo\" AS bar",
         );
-        check_stmt_uncatchable_err("1:7: Undefined variable a", "INPUT a + 1 ; b");
+        check_stmt_uncatchable_err(
+            "1:1: In call to INPUT: 1:7: Undefined variable a",
+            "INPUT a + 1 ; b",
+        );
         Tester::default()
             .run("a = 3: INPUT ; a + 1")
             .expect_compilation_err(
                 "1:8: In call to INPUT: 1:16: Requires a variable reference, not a value",
             )
             .check();
-        check_stmt_uncatchable_err("1:11: Cannot + STRING and BOOLEAN", "INPUT \"a\" + TRUE; b?");
+        check_stmt_uncatchable_err(
+            "1:1: In call to INPUT: 1:11: Cannot + STRING and BOOLEAN",
+            "INPUT \"a\" + TRUE; b?",
+        );
     }
 
     #[test]

--- a/std/src/console/cmds.rs
+++ b/std/src/console/cmds.rs
@@ -345,7 +345,7 @@ impl Callable for InputCommand {
 
         let mut console = self.console.borrow_mut();
         let mut previous_answer = String::new();
-        let vref = VarRef::new(vname.to_string(), vtype.into());
+        let vref = VarRef::new(vname.to_string(), Some(vtype.into()));
         loop {
             match read_line(&mut *console, &prompt, &previous_answer, None).await {
                 Ok(answer) => match Value::parse_as(vtype.into(), answer.trim_end()) {

--- a/std/src/console/cmds.rs
+++ b/std/src/console/cmds.rs
@@ -345,10 +345,10 @@ impl Callable for InputCommand {
 
         let mut console = self.console.borrow_mut();
         let mut previous_answer = String::new();
-        let vref = VarRef::new(vname.to_string(), Some(vtype.into()));
+        let vref = VarRef::new(vname.to_string(), Some(vtype));
         loop {
             match read_line(&mut *console, &prompt, &previous_answer, None).await {
-                Ok(answer) => match Value::parse_as(vtype.into(), answer.trim_end()) {
+                Ok(answer) => match Value::parse_as(vtype, answer.trim_end()) {
                     Ok(value) => {
                         machine
                             .get_mut_symbols()

--- a/std/src/console/cmds.rs
+++ b/std/src/console/cmds.rs
@@ -155,7 +155,7 @@ impl Callable for ColorCommand {
 
     async fn exec(&self, mut scope: Scope<'_>, _machine: &mut Machine) -> CallResult {
         fn get_color((i, pos): (i32, LineCol)) -> Result<Option<u8>, CallError> {
-            if i >= 0 && i <= std::u8::MAX as i32 {
+            if i >= 0 && i <= u8::MAX as i32 {
                 Ok(Some(i as u8))
             } else {
                 Err(CallError::ArgumentError(pos, "Color out of range".to_owned()))

--- a/std/src/data.rs
+++ b/std/src/data.rs
@@ -46,7 +46,7 @@ impl ReadCommand {
     /// Creates a new `READ` command.
     pub fn new(index: Rc<RefCell<usize>>) -> Rc<Self> {
         Rc::from(Self {
-            metadata: CallableMetadataBuilder::new("READ", VarType::Void)
+            metadata: CallableMetadataBuilder::new("READ")
                 .with_syntax(&[(
                     &[],
                     Some(&RepeatedSyntax {
@@ -146,7 +146,7 @@ impl RestoreCommand {
     /// Creates a new `RESTORE` command.
     pub fn new(index: Rc<RefCell<usize>>) -> Rc<Self> {
         Rc::from(Self {
-            metadata: CallableMetadataBuilder::new("RESTORE", VarType::Void)
+            metadata: CallableMetadataBuilder::new("RESTORE")
                 .with_syntax(&[(&[], None)])
                 .with_category(CATEGORY)
                 .with_description(

--- a/std/src/data.rs
+++ b/std/src/data.rs
@@ -114,7 +114,7 @@ impl Callable for ReadCommand {
             };
             *index += 1;
 
-            let vref = VarRef::new(vname.to_string(), Some(vtype.into()));
+            let vref = VarRef::new(vname.to_string(), Some(vtype));
             machine
                 .get_mut_symbols()
                 .set_var(&vref, datum)

--- a/std/src/data.rs
+++ b/std/src/data.rs
@@ -114,7 +114,7 @@ impl Callable for ReadCommand {
             };
             *index += 1;
 
-            let vref = VarRef::new(vname.to_string(), vtype.into());
+            let vref = VarRef::new(vname.to_string(), Some(vtype.into()));
             machine
                 .get_mut_symbols()
                 .set_var(&vref, datum)

--- a/std/src/data.rs
+++ b/std/src/data.rs
@@ -132,7 +132,7 @@ impl Callable for ReadCommand {
                 .map_err(|e| CallError::ArgumentError(pos, format!("{}", e)))?;
         }
 
-        Ok(Value::Void)
+        Ok(())
     }
 }
 
@@ -169,7 +169,7 @@ impl Callable for RestoreCommand {
     async fn exec(&self, scope: Scope<'_>, _machine: &mut Machine) -> CallResult {
         debug_assert_eq!(0, scope.nargs());
         *self.index.borrow_mut() = 0;
-        Ok(Value::Void)
+        Ok(())
     }
 }
 

--- a/std/src/exec.rs
+++ b/std/src/exec.rs
@@ -16,8 +16,8 @@
 //! Commands that manipulate the machine's state or the program's execution.
 
 use async_trait::async_trait;
-use endbasic_core::ast::{Value, VarType};
-use endbasic_core::compiler::{ArgSepSyntax, ExprType, RequiredValueSyntax, SingularArgSyntax};
+use endbasic_core::ast::{ExprType, Value, VarType};
+use endbasic_core::compiler::{ArgSepSyntax, RequiredValueSyntax, SingularArgSyntax};
 use endbasic_core::exec::{Machine, Scope};
 use endbasic_core::syms::{
     CallError, CallResult, Callable, CallableMetadata, CallableMetadataBuilder, Symbol,

--- a/std/src/exec.rs
+++ b/std/src/exec.rs
@@ -16,7 +16,7 @@
 //! Commands that manipulate the machine's state or the program's execution.
 
 use async_trait::async_trait;
-use endbasic_core::ast::{ExprType, Value, VarType};
+use endbasic_core::ast::{ExprType, Value};
 use endbasic_core::compiler::{ArgSepSyntax, RequiredValueSyntax, SingularArgSyntax};
 use endbasic_core::exec::{Machine, Scope};
 use endbasic_core::syms::{
@@ -40,7 +40,7 @@ impl ClearCommand {
     /// Creates a new `CLEAR` command that resets the state of the machine.
     pub fn new() -> Rc<Self> {
         Rc::from(Self {
-            metadata: CallableMetadataBuilder::new("CLEAR", VarType::Void)
+            metadata: CallableMetadataBuilder::new("CLEAR")
                 .with_syntax(&[(&[], None)])
                 .with_category(CATEGORY)
                 .with_description(
@@ -79,7 +79,8 @@ impl ErrmsgFunction {
     /// Creates a new instance of the function.
     pub fn new() -> Rc<Self> {
         Rc::from(Self {
-            metadata: CallableMetadataBuilder::new("ERRMSG", VarType::Text)
+            metadata: CallableMetadataBuilder::new("ERRMSG")
+                .with_return_type(ExprType::Text)
                 .with_syntax(&[(&[], None)])
                 .with_category(CATEGORY)
                 .with_description(
@@ -136,7 +137,7 @@ impl SleepCommand {
     /// Creates a new instance of the command.
     pub fn new(sleep_fn: SleepFn) -> Rc<Self> {
         Rc::from(Self {
-            metadata: CallableMetadataBuilder::new("SLEEP", VarType::Void)
+            metadata: CallableMetadataBuilder::new("SLEEP")
                 .with_syntax(&[(
                     &[SingularArgSyntax::RequiredValue(
                         RequiredValueSyntax { name: "seconds", vtype: ExprType::Double },

--- a/std/src/exec.rs
+++ b/std/src/exec.rs
@@ -66,7 +66,7 @@ impl Callable for ClearCommand {
     async fn exec(&self, scope: Scope<'_>, machine: &mut Machine) -> CallResult {
         debug_assert_eq!(0, scope.nargs());
         machine.clear();
-        Ok(Value::Void)
+        Ok(())
     }
 }
 
@@ -108,9 +108,9 @@ impl Callable for ErrmsgFunction {
         // a method, but this is difficult (from a refactoring perspective) because a function's
         // exec() does not have access to the Machine.
         match machine.get_symbols().get_auto("0errmsg") {
-            Some(Symbol::Variable(v @ Value::Text(_))) => Ok(v.clone()),
+            Some(Symbol::Variable(Value::Text(t))) => scope.return_string(t),
             Some(_) => panic!("Internal symbol must be of a specific type"),
-            None => Ok(Value::Text("".to_owned())),
+            None => scope.return_string("".to_owned()),
         }
     }
 }
@@ -122,7 +122,7 @@ pub type SleepFn = Box<dyn Fn(Duration, LineCol) -> BoxedLocal<CallResult>>;
 fn system_sleep(d: Duration, _pos: LineCol) -> BoxedLocal<CallResult> {
     async move {
         thread::sleep(d);
-        Ok(Value::Void)
+        Ok(())
     }
     .boxed_local()
 }

--- a/std/src/gfx.rs
+++ b/std/src/gfx.rs
@@ -17,7 +17,7 @@
 
 use crate::console::{Console, PixelsXY};
 use async_trait::async_trait;
-use endbasic_core::ast::{ArgSep, ExprType, Value, VarType};
+use endbasic_core::ast::{ArgSep, ExprType, Value};
 use endbasic_core::compiler::{ArgSepSyntax, RequiredValueSyntax, SingularArgSyntax};
 use endbasic_core::exec::{Machine, Scope};
 use endbasic_core::syms::{
@@ -74,7 +74,7 @@ impl GfxCircleCommand {
     /// Creates a new `GFX_CIRCLE` command that draws an empty circle on `console`.
     pub fn new(console: Rc<RefCell<dyn Console>>) -> Rc<Self> {
         Rc::from(Self {
-            metadata: CallableMetadataBuilder::new("GFX_CIRCLE", VarType::Void)
+            metadata: CallableMetadataBuilder::new("GFX_CIRCLE")
                 .with_syntax(&[(
                     &[
                         SingularArgSyntax::RequiredValue(
@@ -134,7 +134,7 @@ impl GfxCirclefCommand {
     /// Creates a new `GFX_CIRCLEF` command that draws a filled circle on `console`.
     pub fn new(console: Rc<RefCell<dyn Console>>) -> Rc<Self> {
         Rc::from(Self {
-            metadata: CallableMetadataBuilder::new("GFX_CIRCLEF", VarType::Void)
+            metadata: CallableMetadataBuilder::new("GFX_CIRCLEF")
                 .with_syntax(&[(
                     &[
                         SingularArgSyntax::RequiredValue(
@@ -193,7 +193,8 @@ impl GfxHeightFunction {
     /// Creates a new instance of the function.
     pub fn new(console: Rc<RefCell<dyn Console>>) -> Rc<Self> {
         Rc::from(Self {
-            metadata: CallableMetadataBuilder::new("GFX_HEIGHT", VarType::Integer)
+            metadata: CallableMetadataBuilder::new("GFX_HEIGHT")
+                .with_return_type(ExprType::Integer)
                 .with_syntax(&[(&[], None)])
                 .with_category(CATEGORY)
                 .with_description(
@@ -229,7 +230,7 @@ impl GfxLineCommand {
     /// Creates a new `GFX_LINE` command that draws a line on `console`.
     pub fn new(console: Rc<RefCell<dyn Console>>) -> Rc<Self> {
         Rc::from(Self {
-            metadata: CallableMetadataBuilder::new("GFX_LINE", VarType::Void)
+            metadata: CallableMetadataBuilder::new("GFX_LINE")
                 .with_syntax(&[(
                     &[
                         SingularArgSyntax::RequiredValue(
@@ -293,7 +294,7 @@ impl GfxPixelCommand {
     /// Creates a new `GFX_PIXEL` command that draws a single pixel on `console`.
     pub fn new(console: Rc<RefCell<dyn Console>>) -> Rc<Self> {
         Rc::from(Self {
-            metadata: CallableMetadataBuilder::new("GFX_PIXEL", VarType::Void)
+            metadata: CallableMetadataBuilder::new("GFX_PIXEL")
                 .with_syntax(&[(
                     &[
                         SingularArgSyntax::RequiredValue(
@@ -346,7 +347,7 @@ impl GfxRectCommand {
     /// Creates a new `GFX_RECT` command that draws an empty rectangle on `console`.
     pub fn new(console: Rc<RefCell<dyn Console>>) -> Rc<Self> {
         Rc::from(Self {
-            metadata: CallableMetadataBuilder::new("GFX_RECT", VarType::Void)
+            metadata: CallableMetadataBuilder::new("GFX_RECT")
                 .with_syntax(&[(
                     &[
                         SingularArgSyntax::RequiredValue(
@@ -411,7 +412,7 @@ impl GfxRectfCommand {
     /// Creates a new `GFX_RECTF` command that draws a filled rectangle on `console`.
     pub fn new(console: Rc<RefCell<dyn Console>>) -> Rc<Self> {
         Rc::from(Self {
-            metadata: CallableMetadataBuilder::new("GFX_RECTF", VarType::Void)
+            metadata: CallableMetadataBuilder::new("GFX_RECTF")
                 .with_syntax(&[(
                     &[
                         SingularArgSyntax::RequiredValue(
@@ -475,7 +476,7 @@ impl GfxSyncCommand {
     /// Creates a new `GFX_SYNC` command that controls video syncing on `console`.
     pub fn new(console: Rc<RefCell<dyn Console>>) -> Rc<Self> {
         Rc::from(Self {
-            metadata: CallableMetadataBuilder::new("GFX_SYNC", VarType::Void)
+            metadata: CallableMetadataBuilder::new("GFX_SYNC")
                 .with_syntax(&[
                     (&[], None),
                     (
@@ -545,7 +546,8 @@ impl GfxWidthFunction {
     /// Creates a new instance of the function.
     pub fn new(console: Rc<RefCell<dyn Console>>) -> Rc<Self> {
         Rc::from(Self {
-            metadata: CallableMetadataBuilder::new("GFX_WIDTH", VarType::Integer)
+            metadata: CallableMetadataBuilder::new("GFX_WIDTH")
+                .with_return_type(ExprType::Integer)
                 .with_syntax(&[(&[], None)])
                 .with_category(CATEGORY)
                 .with_description(

--- a/std/src/gfx.rs
+++ b/std/src/gfx.rs
@@ -17,7 +17,7 @@
 
 use crate::console::{Console, PixelsXY};
 use async_trait::async_trait;
-use endbasic_core::ast::{ArgSep, ExprType, Value};
+use endbasic_core::ast::{ArgSep, ExprType};
 use endbasic_core::compiler::{ArgSepSyntax, RequiredValueSyntax, SingularArgSyntax};
 use endbasic_core::exec::{Machine, Scope};
 use endbasic_core::syms::{
@@ -120,7 +120,7 @@ impl Callable for GfxCircleCommand {
         let r = parse_radius(rvalue, rpos)?;
 
         self.console.borrow_mut().draw_circle(xy, r)?;
-        Ok(Value::Void)
+        Ok(())
     }
 }
 
@@ -179,7 +179,7 @@ impl Callable for GfxCirclefCommand {
         let r = parse_radius(rvalue, rpos)?;
 
         self.console.borrow_mut().draw_circle_filled(xy, r)?;
-        Ok(Value::Void)
+        Ok(())
     }
 }
 
@@ -216,7 +216,7 @@ impl Callable for GfxHeightFunction {
     async fn exec(&self, scope: Scope<'_>, _machine: &mut Machine) -> CallResult {
         debug_assert_eq!(0, scope.nargs());
         let size = self.console.borrow().size_pixels()?;
-        Ok(Value::Integer(i32::from(size.height)))
+        scope.return_integer(i32::from(size.height))
     }
 }
 
@@ -280,7 +280,7 @@ impl Callable for GfxLineCommand {
         let x2y2 = parse_coordinates(x2value, x2pos, y2value, y2pos)?;
 
         self.console.borrow_mut().draw_line(x1y1, x2y2)?;
-        Ok(Value::Void)
+        Ok(())
     }
 }
 
@@ -333,7 +333,7 @@ impl Callable for GfxPixelCommand {
         let xy = parse_coordinates(xvalue, xpos, yvalue, ypos)?;
 
         self.console.borrow_mut().draw_pixel(xy)?;
-        Ok(Value::Void)
+        Ok(())
     }
 }
 
@@ -398,7 +398,7 @@ impl Callable for GfxRectCommand {
         let x2y2 = parse_coordinates(x2value, x2pos, y2value, y2pos)?;
 
         self.console.borrow_mut().draw_rect(x1y1, x2y2)?;
-        Ok(Value::Void)
+        Ok(())
     }
 }
 
@@ -462,7 +462,7 @@ impl Callable for GfxRectfCommand {
         let x2y2 = parse_coordinates(x2value, x2pos, y2value, y2pos)?;
 
         self.console.borrow_mut().draw_rect_filled(x1y1, x2y2)?;
-        Ok(Value::Void)
+        Ok(())
     }
 }
 
@@ -519,7 +519,7 @@ impl Callable for GfxSyncCommand {
     async fn exec(&self, mut scope: Scope<'_>, _machine: &mut Machine) -> CallResult {
         if scope.nargs() == 0 {
             self.console.borrow_mut().sync_now()?;
-            Ok(Value::Void)
+            Ok(())
         } else {
             debug_assert_eq!(1, scope.nargs());
             let enabled = scope.pop_boolean();
@@ -531,7 +531,7 @@ impl Callable for GfxSyncCommand {
                 console.hide_cursor()?;
             }
             console.set_sync(enabled)?;
-            Ok(Value::Void)
+            Ok(())
         }
     }
 }
@@ -569,7 +569,7 @@ impl Callable for GfxWidthFunction {
     async fn exec(&self, scope: Scope<'_>, _machine: &mut Machine) -> CallResult {
         debug_assert_eq!(0, scope.nargs());
         let size = self.console.borrow().size_pixels()?;
-        Ok(Value::Integer(i32::from(size.width)))
+        scope.return_integer(i32::from(size.width))
     }
 }
 

--- a/std/src/gfx.rs
+++ b/std/src/gfx.rs
@@ -17,8 +17,8 @@
 
 use crate::console::{Console, PixelsXY};
 use async_trait::async_trait;
-use endbasic_core::ast::{ArgSep, Value, VarType};
-use endbasic_core::compiler::{ArgSepSyntax, ExprType, RequiredValueSyntax, SingularArgSyntax};
+use endbasic_core::ast::{ArgSep, ExprType, Value, VarType};
+use endbasic_core::compiler::{ArgSepSyntax, RequiredValueSyntax, SingularArgSyntax};
 use endbasic_core::exec::{Machine, Scope};
 use endbasic_core::syms::{
     CallError, CallResult, Callable, CallableMetadata, CallableMetadataBuilder,

--- a/std/src/gpio/fakes.rs
+++ b/std/src/gpio/fakes.rs
@@ -111,7 +111,7 @@ impl MockOp {
             ));
         }
         let pin = datum / 100;
-        if pin > std::u8::MAX as i32 {
+        if pin > u8::MAX as i32 {
             return Err(io::Error::new(
                 io::ErrorKind::InvalidData,
                 format!("Pin number too large at __GPIO_MOCK_DATA({})", pos),

--- a/std/src/gpio/fakes.rs
+++ b/std/src/gpio/fakes.rs
@@ -16,7 +16,7 @@
 //! Fake implementations of GPIO pins that work on all platforms.
 
 use crate::gpio::{Pin, PinMode, Pins};
-use endbasic_core::ast::{Value, VarRef, VarType};
+use endbasic_core::ast::{ExprType, Value, VarRef};
 use endbasic_core::syms::{Array, Symbol, Symbols};
 use std::io;
 
@@ -145,7 +145,7 @@ impl<'a> MockPins<'a> {
 
     /// Obtains the value of `__GPIO_MOCK_LAST` if present.
     fn get_last(symbols: &Symbols) -> Option<i32> {
-        match symbols.get(&VarRef::new("__GPIO_MOCK_LAST", Some(VarType::Integer))) {
+        match symbols.get(&VarRef::new("__GPIO_MOCK_LAST", Some(ExprType::Integer))) {
             Ok(Some(Symbol::Variable(Value::Integer(i)))) => Some(*i),
             _ => None,
         }
@@ -153,7 +153,7 @@ impl<'a> MockPins<'a> {
 
     /// Obtains a mutable reference to `__GPIO_MOCK_DATA` if present.
     fn get_mut_data(symbols: &mut Symbols) -> Option<&mut Array> {
-        match symbols.get_mut(&VarRef::new("__GPIO_MOCK_DATA", Some(VarType::Integer))) {
+        match symbols.get_mut(&VarRef::new("__GPIO_MOCK_DATA", Some(ExprType::Integer))) {
             Ok(Some(Symbol::Array(data))) if data.dimensions().len() == 1 => Some(data),
             _ => None,
         }
@@ -174,7 +174,7 @@ impl<'a> MockPins<'a> {
         let new_last = Value::Integer(last + 1);
         match self
             .symbols
-            .set_var(&VarRef::new("__GPIO_MOCK_LAST", Some(VarType::Integer)), new_last)
+            .set_var(&VarRef::new("__GPIO_MOCK_LAST", Some(ExprType::Integer)), new_last)
         {
             Ok(()) => Ok(()),
             Err(e) => Err(io::Error::new(io::ErrorKind::InvalidData, e.to_string())),

--- a/std/src/gpio/fakes.rs
+++ b/std/src/gpio/fakes.rs
@@ -145,7 +145,7 @@ impl<'a> MockPins<'a> {
 
     /// Obtains the value of `__GPIO_MOCK_LAST` if present.
     fn get_last(symbols: &Symbols) -> Option<i32> {
-        match symbols.get(&VarRef::new("__GPIO_MOCK_LAST", VarType::Integer)) {
+        match symbols.get(&VarRef::new("__GPIO_MOCK_LAST", Some(VarType::Integer))) {
             Ok(Some(Symbol::Variable(Value::Integer(i)))) => Some(*i),
             _ => None,
         }
@@ -153,7 +153,7 @@ impl<'a> MockPins<'a> {
 
     /// Obtains a mutable reference to `__GPIO_MOCK_DATA` if present.
     fn get_mut_data(symbols: &mut Symbols) -> Option<&mut Array> {
-        match symbols.get_mut(&VarRef::new("__GPIO_MOCK_DATA", VarType::Integer)) {
+        match symbols.get_mut(&VarRef::new("__GPIO_MOCK_DATA", Some(VarType::Integer))) {
             Ok(Some(Symbol::Array(data))) if data.dimensions().len() == 1 => Some(data),
             _ => None,
         }
@@ -172,7 +172,10 @@ impl<'a> MockPins<'a> {
     fn increment_last(&mut self) -> io::Result<()> {
         let last = MockPins::get_last(self.symbols).expect("Validated at construction time");
         let new_last = Value::Integer(last + 1);
-        match self.symbols.set_var(&VarRef::new("__GPIO_MOCK_LAST", VarType::Integer), new_last) {
+        match self
+            .symbols
+            .set_var(&VarRef::new("__GPIO_MOCK_LAST", Some(VarType::Integer)), new_last)
+        {
             Ok(()) => Ok(()),
             Err(e) => Err(io::Error::new(io::ErrorKind::InvalidData, e.to_string())),
         }

--- a/std/src/gpio/mod.rs
+++ b/std/src/gpio/mod.rs
@@ -16,7 +16,7 @@
 //! GPIO access functions and commands for EndBASIC.
 
 use async_trait::async_trait;
-use endbasic_core::ast::{ArgSep, ExprType, Value, VarType};
+use endbasic_core::ast::{ArgSep, ExprType, Value};
 use endbasic_core::compiler::{ArgSepSyntax, RequiredValueSyntax, SingularArgSyntax};
 use endbasic_core::exec::{Clearable, Machine, Scope};
 use endbasic_core::syms::{
@@ -139,7 +139,7 @@ impl GpioSetupCommand {
     /// Creates a new instance of the command.
     pub fn new(pins: Rc<RefCell<dyn Pins>>) -> Rc<Self> {
         Rc::from(Self {
-            metadata: CallableMetadataBuilder::new("GPIO_SETUP", VarType::Void)
+            metadata: CallableMetadataBuilder::new("GPIO_SETUP")
                 .with_syntax(&[(
                     &[
                         SingularArgSyntax::RequiredValue(
@@ -205,7 +205,7 @@ impl GpioClearCommand {
     /// Creates a new instance of the command.
     pub fn new(pins: Rc<RefCell<dyn Pins>>) -> Rc<Self> {
         Rc::from(Self {
-            metadata: CallableMetadataBuilder::new("GPIO_CLEAR", VarType::Void)
+            metadata: CallableMetadataBuilder::new("GPIO_CLEAR")
                 .with_syntax(&[
                     (&[], None),
                     (
@@ -268,7 +268,8 @@ impl GpioReadFunction {
     /// Creates a new instance of the function.
     pub fn new(pins: Rc<RefCell<dyn Pins>>) -> Rc<Self> {
         Rc::from(Self {
-            metadata: CallableMetadataBuilder::new("GPIO_READ", VarType::Boolean)
+            metadata: CallableMetadataBuilder::new("GPIO_READ")
+                .with_return_type(ExprType::Boolean)
                 .with_syntax(&[(
                     &[SingularArgSyntax::RequiredValue(
                         RequiredValueSyntax { name: "pin", vtype: ExprType::Integer },
@@ -318,7 +319,7 @@ impl GpioWriteCommand {
     /// Creates a new instance of the command.
     pub fn new(pins: Rc<RefCell<dyn Pins>>) -> Rc<Self> {
         Rc::from(Self {
-            metadata: CallableMetadataBuilder::new("GPIO_WRITE", VarType::Void)
+            metadata: CallableMetadataBuilder::new("GPIO_WRITE")
                 .with_syntax(&[(
                     &[
                         SingularArgSyntax::RequiredValue(

--- a/std/src/gpio/mod.rs
+++ b/std/src/gpio/mod.rs
@@ -427,7 +427,7 @@ mod tests {
             c = c.expect_var(var.0, var.1.clone());
         }
         c.expect_var("__GPIO_MOCK_LAST", Value::Integer(trace.len() as i32))
-            .expect_array_simple("__GPIO_MOCK_DATA", VarType::Integer, exp_data)
+            .expect_array_simple("__GPIO_MOCK_DATA", ExprType::Integer, exp_data)
             .check();
     }
 

--- a/std/src/gpio/mod.rs
+++ b/std/src/gpio/mod.rs
@@ -16,7 +16,7 @@
 //! GPIO access functions and commands for EndBASIC.
 
 use async_trait::async_trait;
-use endbasic_core::ast::{ArgSep, ExprType, Value};
+use endbasic_core::ast::{ArgSep, ExprType};
 use endbasic_core::compiler::{ArgSepSyntax, RequiredValueSyntax, SingularArgSyntax};
 use endbasic_core::exec::{Clearable, Machine, Scope};
 use endbasic_core::syms::{
@@ -191,7 +191,7 @@ impl Callable for GpioSetupCommand {
             Some(mut pins) => pins.setup(pin, mode)?,
             None => self.pins.borrow_mut().setup(pin, mode)?,
         };
-        Ok(Value::Void)
+        Ok(())
     }
 }
 
@@ -254,7 +254,7 @@ impl Callable for GpioClearCommand {
             };
         }
 
-        Ok(Value::Void)
+        Ok(())
     }
 }
 
@@ -305,7 +305,7 @@ impl Callable for GpioReadFunction {
             Some(mut pins) => pins.read(pin)?,
             None => self.pins.borrow_mut().read(pin)?,
         };
-        Ok(value.into())
+        scope.return_boolean(value)
     }
 }
 
@@ -362,7 +362,7 @@ impl Callable for GpioWriteCommand {
             Some(mut pins) => pins.write(pin, value)?,
             None => self.pins.borrow_mut().write(pin, value)?,
         };
-        Ok(Value::Void)
+        Ok(())
     }
 }
 
@@ -379,6 +379,7 @@ pub fn add_all(machine: &mut Machine, pins: Rc<RefCell<dyn Pins>>) {
 mod tests {
     use super::*;
     use crate::testutils::*;
+    use endbasic_core::ast::Value;
 
     /// Common checks for pin number validation.
     ///

--- a/std/src/gpio/mod.rs
+++ b/std/src/gpio/mod.rs
@@ -16,8 +16,8 @@
 //! GPIO access functions and commands for EndBASIC.
 
 use async_trait::async_trait;
-use endbasic_core::ast::{ArgSep, Value, VarType};
-use endbasic_core::compiler::{ArgSepSyntax, ExprType, RequiredValueSyntax, SingularArgSyntax};
+use endbasic_core::ast::{ArgSep, ExprType, Value, VarType};
+use endbasic_core::compiler::{ArgSepSyntax, RequiredValueSyntax, SingularArgSyntax};
 use endbasic_core::exec::{Clearable, Machine, Scope};
 use endbasic_core::syms::{
     CallError, CallResult, Callable, CallableMetadata, CallableMetadataBuilder, Symbols,

--- a/std/src/gpio/mod.rs
+++ b/std/src/gpio/mod.rs
@@ -50,7 +50,7 @@ impl Pin {
                 format!("Pin number {} must be positive", i),
             ));
         }
-        if i > std::u8::MAX as i32 {
+        if i > u8::MAX as i32 {
             return Err(CallError::ArgumentError(pos, format!("Pin number {} is too large", i)));
         }
         Ok(Self(i as u8))

--- a/std/src/help.rs
+++ b/std/src/help.rs
@@ -18,7 +18,7 @@
 use crate::console::{refill_and_print, AnsiColor, Console};
 use crate::exec::CATEGORY;
 use async_trait::async_trait;
-use endbasic_core::ast::{ExprType, Value};
+use endbasic_core::ast::ExprType;
 use endbasic_core::compiler::{ArgSepSyntax, RequiredValueSyntax, SingularArgSyntax};
 use endbasic_core::exec::{Machine, Scope};
 use endbasic_core::syms::{
@@ -510,7 +510,7 @@ impl Callable for HelpCommand {
             result?;
         }
 
-        Ok(Value::Void)
+        Ok(())
     }
 }
 
@@ -522,7 +522,6 @@ pub fn add_all(machine: &mut Machine, console: Rc<RefCell<dyn Console>>) {
 #[cfg(test)]
 pub(crate) mod testutils {
     use super::*;
-    use endbasic_core::ast::Value;
     use endbasic_core::syms::{CallResult, Callable, CallableMetadata, CallableMetadataBuilder};
 
     /// A command that does nothing.
@@ -568,7 +567,7 @@ Second paragraph of the extended description.",
         }
 
         async fn exec(&self, _scope: Scope<'_>, _machine: &mut Machine) -> CallResult {
-            Ok(Value::Void)
+            Ok(())
         }
     }
 
@@ -615,8 +614,8 @@ Second paragraph of the extended description.",
             &self.metadata
         }
 
-        async fn exec(&self, _scope: Scope<'_>, _machine: &mut Machine) -> CallResult {
-            Ok(Value::Text("irrelevant".to_owned()))
+        async fn exec(&self, scope: Scope<'_>, _machine: &mut Machine) -> CallResult {
+            scope.return_string("irrelevant".to_owned())
         }
     }
 }

--- a/std/src/help.rs
+++ b/std/src/help.rs
@@ -18,8 +18,8 @@
 use crate::console::{refill_and_print, AnsiColor, Console};
 use crate::exec::CATEGORY;
 use async_trait::async_trait;
-use endbasic_core::ast::{Value, VarType};
-use endbasic_core::compiler::{ArgSepSyntax, ExprType, RequiredValueSyntax, SingularArgSyntax};
+use endbasic_core::ast::{ExprType, Value, VarType};
+use endbasic_core::compiler::{ArgSepSyntax, RequiredValueSyntax, SingularArgSyntax};
 use endbasic_core::exec::{Machine, Scope};
 use endbasic_core::syms::{
     CallError, CallResult, Callable, CallableMetadata, CallableMetadataBuilder, Symbols,

--- a/std/src/help.rs
+++ b/std/src/help.rs
@@ -941,7 +941,9 @@ This is the first and only topic with just one line.
         t.run(r#"HELP foo bar"#)
             .expect_uncatchable_err("1:10: Unexpected value in expression")
             .check();
-        t.run(r#"HELP foo"#).expect_compilation_err("1:6: Undefined variable foo").check();
+        t.run(r#"HELP foo"#)
+            .expect_compilation_err("1:1: In call to HELP: 1:6: Undefined variable foo")
+            .check();
 
         t.run(r#"HELP "foo", 3"#)
             .expect_compilation_err("1:1: In call to HELP: expected <> | <topic$>")

--- a/std/src/help.rs
+++ b/std/src/help.rs
@@ -990,7 +990,7 @@ This is the first and only topic with just one line.
             .check();
         t.run(r#"DIM undoc(3): HELP "undoc""#)
             .expect_err("1:15: In call to HELP: 1:20: Unknown help topic undoc")
-            .expect_array("undoc", VarType::Integer, &[3], vec![])
+            .expect_array("undoc", ExprType::Integer, &[3], vec![])
             .check();
     }
 }

--- a/std/src/numerics.rs
+++ b/std/src/numerics.rs
@@ -25,6 +25,7 @@ use endbasic_core::exec::{Clearable, Machine, Scope};
 use endbasic_core::syms::{
     CallError, CallResult, Callable, CallableMetadata, CallableMetadataBuilder, Symbols,
 };
+use endbasic_core::value::double_to_integer;
 use rand::rngs::SmallRng;
 use rand::{RngCore, SeedableRng};
 use std::cell::RefCell;
@@ -185,11 +186,9 @@ impl Callable for CintFunction {
         debug_assert_eq!(1, scope.nargs());
         let (value, pos) = scope.pop_double_with_pos();
 
-        Ok(Value::Integer(
-            Value::Double(value)
-                .as_i32()
-                .map_err(|e| CallError::ArgumentError(pos, e.to_string()))?,
-        ))
+        let i =
+            double_to_integer(value).map_err(|e| CallError::ArgumentError(pos, e.to_string()))?;
+        Ok(Value::Integer(i))
     }
 }
 
@@ -310,9 +309,9 @@ impl Callable for IntFunction {
         debug_assert_eq!(1, scope.nargs());
         let (value, pos) = scope.pop_double_with_pos();
 
-        Ok(Value::Double(value.floor())
-            .maybe_cast(VarType::Integer)
-            .map_err(|e| CallError::ArgumentError(pos, e.to_string()))?)
+        let i = double_to_integer(value.floor())
+            .map_err(|e| CallError::ArgumentError(pos, e.to_string()))?;
+        Ok(Value::Integer(i))
     }
 }
 

--- a/std/src/numerics.rs
+++ b/std/src/numerics.rs
@@ -90,7 +90,7 @@ impl Prng {
 
     /// Returns the previously returned random number.
     fn last(&self) -> f64 {
-        (self.last as f64) / (std::u32::MAX as f64)
+        (self.last as f64) / (u32::MAX as f64)
     }
 
     /// Computes the next random number and returns it.

--- a/std/src/numerics.rs
+++ b/std/src/numerics.rs
@@ -16,7 +16,7 @@
 //! Numerical functions for EndBASIC.
 
 use async_trait::async_trait;
-use endbasic_core::ast::{ArgSep, ExprType, Value, VarType};
+use endbasic_core::ast::{ArgSep, ExprType, Value};
 use endbasic_core::compiler::{
     ArgSepSyntax, RepeatedSyntax, RepeatedTypeSyntax, RequiredValueSyntax, SingularArgSyntax,
 };
@@ -110,7 +110,8 @@ impl AtnFunction {
     /// Creates a new instance of the function.
     pub fn new(angle_mode: Rc<RefCell<AngleMode>>) -> Rc<Self> {
         Rc::from(Self {
-            metadata: CallableMetadataBuilder::new("ATN", VarType::Double)
+            metadata: CallableMetadataBuilder::new("ATN")
+                .with_return_type(ExprType::Double)
                 .with_syntax(&[(
                     &[SingularArgSyntax::RequiredValue(
                         RequiredValueSyntax { name: "n", vtype: ExprType::Double },
@@ -156,7 +157,8 @@ impl CintFunction {
     /// Creates a new instance of the function.
     pub fn new() -> Rc<Self> {
         Rc::from(Self {
-            metadata: CallableMetadataBuilder::new("CINT", VarType::Integer)
+            metadata: CallableMetadataBuilder::new("CINT")
+                .with_return_type(ExprType::Integer)
                 .with_syntax(&[(
                     &[SingularArgSyntax::RequiredValue(
                         RequiredValueSyntax { name: "expr", vtype: ExprType::Double },
@@ -201,7 +203,8 @@ impl CosFunction {
     /// Creates a new instance of the function.
     pub fn new(angle_mode: Rc<RefCell<AngleMode>>) -> Rc<Self> {
         Rc::from(Self {
-            metadata: CallableMetadataBuilder::new("COS", VarType::Double)
+            metadata: CallableMetadataBuilder::new("COS")
+                .with_return_type(ExprType::Double)
                 .with_syntax(&[(
                     &[SingularArgSyntax::RequiredValue(
                         RequiredValueSyntax { name: "angle", vtype: ExprType::Double },
@@ -243,7 +246,7 @@ impl DegCommand {
     /// Creates a new instance of the command.
     pub fn new(angle_mode: Rc<RefCell<AngleMode>>) -> Rc<Self> {
         Rc::from(Self {
-            metadata: CallableMetadataBuilder::new("DEG", VarType::Void)
+            metadata: CallableMetadataBuilder::new("DEG")
                 .with_syntax(&[(&[], None)])
                 .with_category(CATEGORY)
                 .with_description(
@@ -279,7 +282,8 @@ impl IntFunction {
     /// Creates a new instance of the function.
     pub fn new() -> Rc<Self> {
         Rc::from(Self {
-            metadata: CallableMetadataBuilder::new("INT", VarType::Integer)
+            metadata: CallableMetadataBuilder::new("INT")
+                .with_return_type(ExprType::Integer)
                 .with_syntax(&[(
                     &[SingularArgSyntax::RequiredValue(
                         RequiredValueSyntax { name: "expr", vtype: ExprType::Double },
@@ -323,7 +327,8 @@ impl MaxFunction {
     /// Creates a new instance of the function.
     pub fn new() -> Rc<Self> {
         Rc::from(Self {
-            metadata: CallableMetadataBuilder::new("MAX", VarType::Double)
+            metadata: CallableMetadataBuilder::new("MAX")
+                .with_return_type(ExprType::Double)
                 .with_syntax(&[(
                     &[],
                     Some(&RepeatedSyntax {
@@ -368,7 +373,8 @@ impl MinFunction {
     /// Creates a new instance of the function.
     pub fn new() -> Rc<Self> {
         Rc::from(Self {
-            metadata: CallableMetadataBuilder::new("MIN", VarType::Double)
+            metadata: CallableMetadataBuilder::new("MIN")
+                .with_return_type(ExprType::Double)
                 .with_syntax(&[(
                     &[],
                     Some(&RepeatedSyntax {
@@ -413,7 +419,8 @@ impl PiFunction {
     /// Creates a new instance of the function.
     pub fn new() -> Rc<Self> {
         Rc::from(Self {
-            metadata: CallableMetadataBuilder::new("PI", VarType::Double)
+            metadata: CallableMetadataBuilder::new("PI")
+                .with_return_type(ExprType::Double)
                 .with_syntax(&[(&[], None)])
                 .with_category(CATEGORY)
                 .with_description("Returns the Archimedes' constant.")
@@ -444,7 +451,7 @@ impl RadCommand {
     /// Creates a new instance of the command.
     pub fn new(angle_mode: Rc<RefCell<AngleMode>>) -> Rc<Self> {
         Rc::from(Self {
-            metadata: CallableMetadataBuilder::new("RAD", VarType::Void)
+            metadata: CallableMetadataBuilder::new("RAD")
                 .with_syntax(&[(&[], None)])
                 .with_category(CATEGORY)
                 .with_description(
@@ -481,7 +488,7 @@ impl RandomizeCommand {
     /// Creates a new command that updates `code` with the exit code once called.
     pub fn new(prng: Rc<RefCell<Prng>>) -> Rc<Self> {
         Rc::from(Self {
-            metadata: CallableMetadataBuilder::new("RANDOMIZE", VarType::Void)
+            metadata: CallableMetadataBuilder::new("RANDOMIZE")
                 .with_syntax(&[
                     (&[], None),
                     (
@@ -532,7 +539,8 @@ impl RndFunction {
     /// Creates a new instance of the function.
     pub fn new(prng: Rc<RefCell<Prng>>) -> Rc<Self> {
         Rc::from(Self {
-            metadata: CallableMetadataBuilder::new("RND", VarType::Double)
+            metadata: CallableMetadataBuilder::new("RND")
+                .with_return_type(ExprType::Double)
                 .with_syntax(&[
                     (&[], None),
                     (
@@ -591,7 +599,8 @@ impl SinFunction {
     /// Creates a new instance of the function.
     pub fn new(angle_mode: Rc<RefCell<AngleMode>>) -> Rc<Self> {
         Rc::from(Self {
-            metadata: CallableMetadataBuilder::new("SIN", VarType::Double)
+            metadata: CallableMetadataBuilder::new("SIN")
+                .with_return_type(ExprType::Double)
                 .with_syntax(&[(
                     &[SingularArgSyntax::RequiredValue(
                         RequiredValueSyntax { name: "angle", vtype: ExprType::Double },
@@ -632,7 +641,8 @@ impl SqrFunction {
     /// Creates a new instance of the function.
     pub fn new() -> Rc<Self> {
         Rc::from(Self {
-            metadata: CallableMetadataBuilder::new("SQR", VarType::Double)
+            metadata: CallableMetadataBuilder::new("SQR")
+                .with_return_type(ExprType::Double)
                 .with_syntax(&[(
                     &[SingularArgSyntax::RequiredValue(
                         RequiredValueSyntax { name: "num", vtype: ExprType::Double },
@@ -677,7 +687,8 @@ impl TanFunction {
     /// Creates a new instance of the function.
     pub fn new(angle_mode: Rc<RefCell<AngleMode>>) -> Rc<Self> {
         Rc::from(Self {
-            metadata: CallableMetadataBuilder::new("TAN", VarType::Double)
+            metadata: CallableMetadataBuilder::new("TAN")
+                .with_return_type(ExprType::Double)
                 .with_syntax(&[(
                     &[SingularArgSyntax::RequiredValue(
                         RequiredValueSyntax { name: "angle", vtype: ExprType::Double },

--- a/std/src/numerics.rs
+++ b/std/src/numerics.rs
@@ -16,10 +16,9 @@
 //! Numerical functions for EndBASIC.
 
 use async_trait::async_trait;
-use endbasic_core::ast::{ArgSep, Value, VarType};
+use endbasic_core::ast::{ArgSep, ExprType, Value, VarType};
 use endbasic_core::compiler::{
-    ArgSepSyntax, ExprType, RepeatedSyntax, RepeatedTypeSyntax, RequiredValueSyntax,
-    SingularArgSyntax,
+    ArgSepSyntax, RepeatedSyntax, RepeatedTypeSyntax, RequiredValueSyntax, SingularArgSyntax,
 };
 use endbasic_core::exec::{Clearable, Machine, Scope};
 use endbasic_core::syms::{

--- a/std/src/program.rs
+++ b/std/src/program.rs
@@ -197,7 +197,7 @@ impl Callable for KillCommand {
         let name = add_extension(name)?;
         self.storage.borrow_mut().delete(&name).await?;
 
-        Ok(Value::Void)
+        Ok(())
     }
 }
 
@@ -235,7 +235,7 @@ impl Callable for EditCommand {
         let mut console = self.console.borrow_mut();
         let mut program = self.program.borrow_mut();
         program.edit(&mut *console).await?;
-        Ok(Value::Void)
+        Ok(())
     }
 }
 
@@ -274,7 +274,7 @@ impl Callable for ListCommand {
         for line in self.program.borrow().text().lines() {
             console.print(line)?;
         }
-        Ok(Value::Void)
+        Ok(())
     }
 }
 
@@ -341,7 +341,7 @@ impl Callable for LoadCommand {
                 .borrow_mut()
                 .print("LOAD aborted; use SAVE to save your current changes.")?;
         }
-        Ok(Value::Void)
+        Ok(())
     }
 }
 
@@ -393,7 +393,7 @@ impl Callable for NewCommand {
                 .borrow_mut()
                 .print("NEW aborted; use SAVE to save your current changes.")?;
         }
-        Ok(Value::Void)
+        Ok(())
     }
 }
 
@@ -451,7 +451,7 @@ impl Callable for RunCommand {
                 }
             }
         }
-        Ok(Value::Void)
+        Ok(())
     }
 }
 
@@ -529,7 +529,7 @@ impl Callable for SaveCommand {
 
         self.console.borrow_mut().print(&format!("Saved as {}", full_name))?;
 
-        Ok(Value::Void)
+        Ok(())
     }
 }
 

--- a/std/src/program.rs
+++ b/std/src/program.rs
@@ -163,7 +163,7 @@ impl KillCommand {
     /// Creates a new `KILL` command that deletes a file from `storage`.
     pub fn new(storage: Rc<RefCell<Storage>>) -> Rc<Self> {
         Rc::from(Self {
-            metadata: CallableMetadataBuilder::new("KILL", VarType::Void)
+            metadata: CallableMetadataBuilder::new("KILL")
                 .with_syntax(&[(
                     &[SingularArgSyntax::RequiredValue(
                         RequiredValueSyntax { name: "filename", vtype: ExprType::Text },
@@ -212,7 +212,7 @@ impl EditCommand {
     /// Creates a new `EDIT` command that edits the stored `program` in the `console`.
     pub fn new(console: Rc<RefCell<dyn Console>>, program: Rc<RefCell<dyn Program>>) -> Rc<Self> {
         Rc::from(Self {
-            metadata: CallableMetadataBuilder::new("EDIT", VarType::Void)
+            metadata: CallableMetadataBuilder::new("EDIT")
                 .with_syntax(&[(&[], None)])
                 .with_category(CATEGORY)
                 .with_description("Interactively edits the stored program.")
@@ -250,7 +250,7 @@ impl ListCommand {
     /// Creates a new `LIST` command that dumps the `program` to the `console`.
     pub fn new(console: Rc<RefCell<dyn Console>>, program: Rc<RefCell<dyn Program>>) -> Rc<Self> {
         Rc::from(Self {
-            metadata: CallableMetadataBuilder::new("LIST", VarType::Void)
+            metadata: CallableMetadataBuilder::new("LIST")
                 .with_syntax(&[(&[], None)])
                 .with_category(CATEGORY)
                 .with_description("Prints the currently-loaded program.")
@@ -295,7 +295,7 @@ impl LoadCommand {
         program: Rc<RefCell<dyn Program>>,
     ) -> Rc<Self> {
         Rc::from(Self {
-            metadata: CallableMetadataBuilder::new("LOAD", VarType::Void)
+            metadata: CallableMetadataBuilder::new("LOAD")
                 .with_syntax(&[(
                     &[SingularArgSyntax::RequiredValue(
                         RequiredValueSyntax { name: "filename", vtype: ExprType::Text },
@@ -357,7 +357,7 @@ impl NewCommand {
     /// to communicate unsaved changes.
     pub fn new(console: Rc<RefCell<dyn Console>>, program: Rc<RefCell<dyn Program>>) -> Rc<Self> {
         Rc::from(Self {
-            metadata: CallableMetadataBuilder::new("NEW", VarType::Void)
+            metadata: CallableMetadataBuilder::new("NEW")
                 .with_syntax(&[(&[], None)])
                 .with_category(CATEGORY)
                 .with_description(
@@ -410,7 +410,7 @@ impl RunCommand {
     /// Reports any non-successful return codes from the program to the console.
     pub fn new(console: Rc<RefCell<dyn Console>>, program: Rc<RefCell<dyn Program>>) -> Rc<Self> {
         Rc::from(Self {
-            metadata: CallableMetadataBuilder::new("RUN", VarType::Void)
+            metadata: CallableMetadataBuilder::new("RUN")
                 .with_syntax(&[(&[], None)])
                 .with_category(CATEGORY)
                 .with_description(
@@ -471,7 +471,7 @@ impl SaveCommand {
         program: Rc<RefCell<dyn Program>>,
     ) -> Rc<Self> {
         Rc::from(Self {
-            metadata: CallableMetadataBuilder::new("SAVE", VarType::Void)
+            metadata: CallableMetadataBuilder::new("SAVE")
                 .with_syntax(&[
                     (&[], None),
                     (

--- a/std/src/program.rs
+++ b/std/src/program.rs
@@ -18,7 +18,7 @@
 use crate::console::{read_line, Console};
 use crate::storage::Storage;
 use async_trait::async_trait;
-use endbasic_core::ast::{ExprType, Value, VarType};
+use endbasic_core::ast::{ExprType, Value};
 use endbasic_core::compiler::{ArgSepSyntax, RequiredValueSyntax, SingularArgSyntax};
 use endbasic_core::exec::{Machine, Scope, StopReason};
 use endbasic_core::syms::{
@@ -144,7 +144,7 @@ pub async fn continue_if_modified(
         None => console.print("Current program has unsaved changes and has never been saved!")?,
     }
     let answer = read_line(console, "Discard and continue (y/N)? ", "", None).await?;
-    match Value::parse_as(VarType::Boolean, answer) {
+    match Value::parse_as(ExprType::Boolean, answer) {
         Ok(Value::Boolean(b)) => Ok(b),
         _ => Ok(false),
     }

--- a/std/src/program.rs
+++ b/std/src/program.rs
@@ -17,8 +17,9 @@
 
 use crate::console::{read_line, Console};
 use crate::storage::Storage;
+use crate::strings::parse_boolean;
 use async_trait::async_trait;
-use endbasic_core::ast::{ExprType, Value};
+use endbasic_core::ast::ExprType;
 use endbasic_core::compiler::{ArgSepSyntax, RequiredValueSyntax, SingularArgSyntax};
 use endbasic_core::exec::{Machine, Scope, StopReason};
 use endbasic_core::syms::{
@@ -144,10 +145,7 @@ pub async fn continue_if_modified(
         None => console.print("Current program has unsaved changes and has never been saved!")?,
     }
     let answer = read_line(console, "Discard and continue (y/N)? ", "", None).await?;
-    match Value::parse_as(ExprType::Boolean, answer) {
-        Ok(Value::Boolean(b)) => Ok(b),
-        _ => Ok(false),
-    }
+    Ok(parse_boolean(&answer).unwrap_or(false))
 }
 
 /// The `KILL` command.

--- a/std/src/program.rs
+++ b/std/src/program.rs
@@ -859,12 +859,12 @@ mod tests {
         let program = "DIM a(1) AS INTEGER: a(0) = 123";
         let mut t = Tester::default().set_program(Some("untouched.bas"), program);
         t.run("DIM a(1) AS STRING: RUN")
-            .expect_array_simple("a", VarType::Integer, vec![123.into()])
+            .expect_array_simple("a", ExprType::Integer, vec![123.into()])
             .expect_clear()
             .expect_program(Some("untouched.bas"), program)
             .check();
         t.run("RUN")
-            .expect_array_simple("a", VarType::Integer, vec![123.into()])
+            .expect_array_simple("a", ExprType::Integer, vec![123.into()])
             .expect_clear()
             .expect_clear()
             .expect_program(Some("untouched.bas"), program)

--- a/std/src/program.rs
+++ b/std/src/program.rs
@@ -18,8 +18,8 @@
 use crate::console::{read_line, Console};
 use crate::storage::Storage;
 use async_trait::async_trait;
-use endbasic_core::ast::{Value, VarType};
-use endbasic_core::compiler::{ArgSepSyntax, ExprType, RequiredValueSyntax, SingularArgSyntax};
+use endbasic_core::ast::{ExprType, Value, VarType};
+use endbasic_core::compiler::{ArgSepSyntax, RequiredValueSyntax, SingularArgSyntax};
 use endbasic_core::exec::{Machine, Scope, StopReason};
 use endbasic_core::syms::{
     CallError, CallResult, Callable, CallableMetadata, CallableMetadataBuilder,

--- a/std/src/storage/cmds.rs
+++ b/std/src/storage/cmds.rs
@@ -18,8 +18,8 @@
 use crate::console::{is_narrow, Console};
 use crate::storage::Storage;
 use async_trait::async_trait;
-use endbasic_core::ast::{ArgSep, Value, VarType};
-use endbasic_core::compiler::{ArgSepSyntax, ExprType, RequiredValueSyntax, SingularArgSyntax};
+use endbasic_core::ast::{ArgSep, ExprType, Value, VarType};
+use endbasic_core::compiler::{ArgSepSyntax, RequiredValueSyntax, SingularArgSyntax};
 use endbasic_core::exec::{Machine, Scope};
 use endbasic_core::syms::{CallResult, Callable, CallableMetadata, CallableMetadataBuilder};
 use std::cell::RefCell;

--- a/std/src/storage/cmds.rs
+++ b/std/src/storage/cmds.rs
@@ -18,7 +18,7 @@
 use crate::console::{is_narrow, Console};
 use crate::storage::Storage;
 use async_trait::async_trait;
-use endbasic_core::ast::{ArgSep, ExprType, Value};
+use endbasic_core::ast::{ArgSep, ExprType};
 use endbasic_core::compiler::{ArgSepSyntax, RequiredValueSyntax, SingularArgSyntax};
 use endbasic_core::exec::{Machine, Scope};
 use endbasic_core::syms::{CallResult, Callable, CallableMetadata, CallableMetadataBuilder};
@@ -156,7 +156,7 @@ impl Callable for CdCommand {
 
         self.storage.borrow_mut().cd(&target)?;
 
-        Ok(Value::Void)
+        Ok(())
     }
 }
 
@@ -207,7 +207,7 @@ impl Callable for DirCommand {
 
         show_dir(&self.storage.borrow(), &mut *self.console.borrow_mut(), &path).await?;
 
-        Ok(Value::Void)
+        Ok(())
     }
 }
 
@@ -262,14 +262,14 @@ impl Callable for MountCommand {
     async fn exec(&self, mut scope: Scope<'_>, _machine: &mut Machine) -> CallResult {
         if scope.nargs() == 0 {
             show_drives(&self.storage.borrow_mut(), &mut *self.console.borrow_mut())?;
-            Ok(Value::Void)
+            Ok(())
         } else {
             debug_assert_eq!(2, scope.nargs());
             let target = scope.pop_string();
             let name = scope.pop_string();
 
             self.storage.borrow_mut().mount(&name, &target)?;
-            Ok(Value::Void)
+            Ok(())
         }
     }
 }
@@ -322,7 +322,7 @@ impl Callable for PwdCommand {
         }
         console.print("")?;
 
-        Ok(Value::Void)
+        Ok(())
     }
 }
 
@@ -367,7 +367,7 @@ impl Callable for UnmountCommand {
 
         self.storage.borrow_mut().unmount(&drive)?;
 
-        Ok(Value::Void)
+        Ok(())
     }
 }
 

--- a/std/src/storage/cmds.rs
+++ b/std/src/storage/cmds.rs
@@ -18,7 +18,7 @@
 use crate::console::{is_narrow, Console};
 use crate::storage::Storage;
 use async_trait::async_trait;
-use endbasic_core::ast::{ArgSep, ExprType, Value, VarType};
+use endbasic_core::ast::{ArgSep, ExprType, Value};
 use endbasic_core::compiler::{ArgSepSyntax, RequiredValueSyntax, SingularArgSyntax};
 use endbasic_core::exec::{Machine, Scope};
 use endbasic_core::syms::{CallResult, Callable, CallableMetadata, CallableMetadataBuilder};
@@ -128,7 +128,7 @@ impl CdCommand {
     /// Creates a new `CD` command that changes the current location in `storage`.
     pub fn new(storage: Rc<RefCell<Storage>>) -> Rc<Self> {
         Rc::from(Self {
-            metadata: CallableMetadataBuilder::new("CD", VarType::Void)
+            metadata: CallableMetadataBuilder::new("CD")
                 .with_syntax(&[(
                     &[SingularArgSyntax::RequiredValue(
                         RequiredValueSyntax { name: "path", vtype: ExprType::Text },
@@ -171,7 +171,7 @@ impl DirCommand {
     /// Creates a new `DIR` command that lists `storage` contents on the `console`.
     pub fn new(console: Rc<RefCell<dyn Console>>, storage: Rc<RefCell<Storage>>) -> Rc<Self> {
         Rc::from(Self {
-            metadata: CallableMetadataBuilder::new("DIR", VarType::Void)
+            metadata: CallableMetadataBuilder::new("DIR")
                 .with_syntax(&[
                     (&[], None),
                     (
@@ -222,7 +222,7 @@ impl MountCommand {
     /// Creates a new `MOUNT` command.
     pub fn new(console: Rc<RefCell<dyn Console>>, storage: Rc<RefCell<Storage>>) -> Rc<Self> {
         Rc::from(Self {
-            metadata: CallableMetadataBuilder::new("MOUNT", VarType::Void)
+            metadata: CallableMetadataBuilder::new("MOUNT")
                 .with_syntax(&[
                     (&[], None),
                     (
@@ -285,7 +285,7 @@ impl PwdCommand {
     /// Creates a new `PWD` command that prints the current directory of `storage` to the `console`.
     pub fn new(console: Rc<RefCell<dyn Console>>, storage: Rc<RefCell<Storage>>) -> Rc<Self> {
         Rc::from(Self {
-            metadata: CallableMetadataBuilder::new("PWD", VarType::Void)
+            metadata: CallableMetadataBuilder::new("PWD")
                 .with_syntax(&[(&[], None)])
                 .with_category(CATEGORY)
                 .with_description(
@@ -336,7 +336,7 @@ impl UnmountCommand {
     /// Creates a new `UNMOUNT` command.
     pub fn new(storage: Rc<RefCell<Storage>>) -> Rc<Self> {
         Rc::from(Self {
-            metadata: CallableMetadataBuilder::new("UNMOUNT", VarType::Void)
+            metadata: CallableMetadataBuilder::new("UNMOUNT")
                 .with_syntax(&[(
                     &[SingularArgSyntax::RequiredValue(
                         RequiredValueSyntax { name: "drive_name", vtype: ExprType::Text },

--- a/std/src/strings.rs
+++ b/std/src/strings.rs
@@ -16,9 +16,9 @@
 //! String functions for EndBASIC.
 
 use async_trait::async_trait;
-use endbasic_core::ast::{ArgSep, Value, VarType};
+use endbasic_core::ast::{ArgSep, ExprType, Value, VarType};
 use endbasic_core::compiler::{
-    AnyValueSyntax, ArgSepSyntax, ExprType, RequiredValueSyntax, SingularArgSyntax,
+    AnyValueSyntax, ArgSepSyntax, RequiredValueSyntax, SingularArgSyntax,
 };
 use endbasic_core::exec::{Machine, Scope, ValueTag};
 use endbasic_core::syms::{

--- a/std/src/strings.rs
+++ b/std/src/strings.rs
@@ -16,7 +16,7 @@
 //! String functions for EndBASIC.
 
 use async_trait::async_trait;
-use endbasic_core::ast::{ArgSep, ExprType, Value};
+use endbasic_core::ast::{ArgSep, ExprType};
 use endbasic_core::compiler::{
     AnyValueSyntax, ArgSepSyntax, RequiredValueSyntax, SingularArgSyntax,
 };
@@ -121,7 +121,7 @@ impl Callable for AscFunction {
             ch as i32
         };
 
-        Ok(Value::Integer(ch))
+        scope.return_integer(ch)
     }
 }
 
@@ -172,7 +172,7 @@ impl Callable for ChrFunction {
         let code = i as u32;
 
         match char::from_u32(code) {
-            Some(ch) => Ok(Value::Text(format!("{}", ch))),
+            Some(ch) => scope.return_string(format!("{}", ch)),
             None => Err(CallError::ArgumentError(ipos, format!("Invalid character code {}", code))),
         }
     }
@@ -228,7 +228,7 @@ impl Callable for LeftFunction {
             Err(CallError::ArgumentError(npos, "n% cannot be negative".to_owned()))
         } else {
             let n = min(s.len(), n as usize);
-            Ok(Value::Text(s[..n].to_owned()))
+            scope.return_string(s[..n].to_owned())
         }
     }
 }
@@ -271,7 +271,7 @@ impl Callable for LenFunction {
         if s.len() > std::i32::MAX as usize {
             Err(CallError::InternalError(spos, "String too long".to_owned()))
         } else {
-            Ok(Value::Integer(s.len() as i32))
+            scope.return_integer(s.len() as i32)
         }
     }
 }
@@ -311,7 +311,7 @@ impl Callable for LtrimFunction {
         debug_assert_eq!(1, scope.nargs());
         let s = scope.pop_string();
 
-        Ok(Value::Text(s.trim_start().to_owned()))
+        scope.return_string(s.trim_start().to_owned())
     }
 }
 
@@ -400,7 +400,7 @@ impl Callable for MidFunction {
             s.len()
         };
 
-        Ok(Value::Text(s[start..end].to_owned()))
+        scope.return_string(s[start..end].to_owned())
     }
 }
 
@@ -454,7 +454,7 @@ impl Callable for RightFunction {
             Err(CallError::ArgumentError(npos, "n% cannot be negative".to_owned()))
         } else {
             let n = min(s.len(), n as usize);
-            Ok(Value::Text(s[s.len() - n..].to_owned()))
+            scope.return_string(s[s.len() - n..].to_owned())
         }
     }
 }
@@ -494,7 +494,7 @@ impl Callable for RtrimFunction {
         debug_assert_eq!(1, scope.nargs());
         let s = scope.pop_string();
 
-        Ok(Value::Text(s.trim_end().to_owned()))
+        scope.return_string(s.trim_end().to_owned())
     }
 }
 
@@ -543,19 +543,19 @@ impl Callable for StrFunction {
         match scope.pop_value_tag() {
             ValueTag::Boolean => {
                 let b = scope.pop_boolean();
-                Ok(Value::Text(format_boolean(b).to_owned()))
+                scope.return_string(format_boolean(b).to_owned())
             }
             ValueTag::Double => {
                 let d = scope.pop_double();
-                Ok(Value::Text(format_double(d)))
+                scope.return_string(format_double(d))
             }
             ValueTag::Integer => {
                 let i = scope.pop_integer();
-                Ok(Value::Text(format_integer(i)))
+                scope.return_string(format_integer(i))
             }
             ValueTag::Text => {
                 let s = scope.pop_string();
-                Ok(Value::Text(s))
+                scope.return_string(s)
             }
             ValueTag::Missing => {
                 unreachable!("Missing expressions aren't allowed in function calls");

--- a/std/src/strings.rs
+++ b/std/src/strings.rs
@@ -16,7 +16,7 @@
 //! String functions for EndBASIC.
 
 use async_trait::async_trait;
-use endbasic_core::ast::{ArgSep, ExprType, Value, VarType};
+use endbasic_core::ast::{ArgSep, ExprType, Value};
 use endbasic_core::compiler::{
     AnyValueSyntax, ArgSepSyntax, RequiredValueSyntax, SingularArgSyntax,
 };
@@ -67,7 +67,8 @@ impl AscFunction {
     /// Creates a new instance of the function.
     pub fn new() -> Rc<Self> {
         Rc::from(Self {
-            metadata: CallableMetadataBuilder::new("ASC", VarType::Integer)
+            metadata: CallableMetadataBuilder::new("ASC")
+                .with_return_type(ExprType::Integer)
                 .with_syntax(&[(
                     &[SingularArgSyntax::RequiredValue(
                         RequiredValueSyntax { name: "char", vtype: ExprType::Text },
@@ -133,7 +134,8 @@ impl ChrFunction {
     /// Creates a new instance of the function.
     pub fn new() -> Rc<Self> {
         Rc::from(Self {
-            metadata: CallableMetadataBuilder::new("CHR", VarType::Text)
+            metadata: CallableMetadataBuilder::new("CHR")
+                .with_return_type(ExprType::Text)
                 .with_syntax(&[(
                     &[SingularArgSyntax::RequiredValue(
                         RequiredValueSyntax { name: "code", vtype: ExprType::Integer },
@@ -185,7 +187,8 @@ impl LeftFunction {
     /// Creates a new instance of the function.
     pub fn new() -> Rc<Self> {
         Rc::from(Self {
-            metadata: CallableMetadataBuilder::new("LEFT", VarType::Text)
+            metadata: CallableMetadataBuilder::new("LEFT")
+                .with_return_type(ExprType::Text)
                 .with_syntax(&[(
                     &[
                         SingularArgSyntax::RequiredValue(
@@ -239,7 +242,8 @@ impl LenFunction {
     /// Creates a new instance of the function.
     pub fn new() -> Rc<Self> {
         Rc::from(Self {
-            metadata: CallableMetadataBuilder::new("LEN", VarType::Integer)
+            metadata: CallableMetadataBuilder::new("LEN")
+                .with_return_type(ExprType::Integer)
                 .with_syntax(&[(
                     &[SingularArgSyntax::RequiredValue(
                         RequiredValueSyntax { name: "expr", vtype: ExprType::Text },
@@ -281,7 +285,8 @@ impl LtrimFunction {
     /// Creates a new instance of the function.
     pub fn new() -> Rc<Self> {
         Rc::from(Self {
-            metadata: CallableMetadataBuilder::new("LTRIM", VarType::Text)
+            metadata: CallableMetadataBuilder::new("LTRIM")
+                .with_return_type(ExprType::Text)
                 .with_syntax(&[(
                     &[SingularArgSyntax::RequiredValue(
                         RequiredValueSyntax { name: "expr", vtype: ExprType::Text },
@@ -319,7 +324,8 @@ impl MidFunction {
     /// Creates a new instance of the function.
     pub fn new() -> Rc<Self> {
         Rc::from(Self {
-            metadata: CallableMetadataBuilder::new("MID", VarType::Text)
+            metadata: CallableMetadataBuilder::new("MID")
+                .with_return_type(ExprType::Text)
                 .with_syntax(&[
                     (
                         &[
@@ -407,7 +413,8 @@ impl RightFunction {
     /// Creates a new instance of the function.
     pub fn new() -> Rc<Self> {
         Rc::from(Self {
-            metadata: CallableMetadataBuilder::new("RIGHT", VarType::Text)
+            metadata: CallableMetadataBuilder::new("RIGHT")
+                .with_return_type(ExprType::Text)
                 .with_syntax(&[(
                     &[
                         SingularArgSyntax::RequiredValue(
@@ -461,7 +468,8 @@ impl RtrimFunction {
     /// Creates a new instance of the function.
     pub fn new() -> Rc<Self> {
         Rc::from(Self {
-            metadata: CallableMetadataBuilder::new("RTRIM", VarType::Text)
+            metadata: CallableMetadataBuilder::new("RTRIM")
+                .with_return_type(ExprType::Text)
                 .with_syntax(&[(
                     &[SingularArgSyntax::RequiredValue(
                         RequiredValueSyntax { name: "expr", vtype: ExprType::Text },
@@ -499,7 +507,8 @@ impl StrFunction {
     /// Creates a new instance of the function.
     pub fn new() -> Rc<Self> {
         Rc::from(Self {
-            metadata: CallableMetadataBuilder::new("STR", VarType::Text)
+            metadata: CallableMetadataBuilder::new("STR")
+                .with_return_type(ExprType::Text)
                 .with_syntax(&[(
                     &[SingularArgSyntax::AnyValue(
                         AnyValueSyntax { name: "expr", allow_missing: false },

--- a/std/src/strings.rs
+++ b/std/src/strings.rs
@@ -296,7 +296,7 @@ impl Callable for LenFunction {
         debug_assert_eq!(1, scope.nargs());
         let (s, spos) = scope.pop_string_with_pos();
 
-        if s.len() > std::i32::MAX as usize {
+        if s.len() > i32::MAX as usize {
             Err(CallError::InternalError(spos, "String too long".to_owned()))
         } else {
             scope.return_integer(s.len() as i32)
@@ -613,17 +613,17 @@ mod tests {
     #[test]
     fn test_value_parse_boolean() {
         for s in &["true", "TrUe", "TRUE", "yes", "Yes", "y", "Y"] {
-            assert!(parse_boolean(*s).unwrap());
+            assert!(parse_boolean(s).unwrap());
         }
 
         for s in &["false", "FaLsE", "FALSE", "no", "No", "n", "N"] {
-            assert!(!parse_boolean(*s).unwrap());
+            assert!(!parse_boolean(s).unwrap());
         }
 
         for s in &["ye", "0", "1", " true"] {
             assert_eq!(
                 format!("Invalid boolean literal {}", s),
-                format!("{}", parse_boolean(*s).unwrap_err())
+                format!("{}", parse_boolean(s).unwrap_err())
             );
         }
     }

--- a/std/src/testutils.rs
+++ b/std/src/testutils.rs
@@ -22,7 +22,7 @@ use crate::gpio;
 use crate::program::Program;
 use crate::storage::Storage;
 use async_trait::async_trait;
-use endbasic_core::ast::{Value, VarRef, VarType};
+use endbasic_core::ast::{ExprType, Value, VarRef, VarType};
 use endbasic_core::exec::{self, Machine, StopReason};
 use endbasic_core::syms::{Array, Callable, Symbol};
 use futures_lite::future::block_on;
@@ -618,7 +618,7 @@ impl<'a> Checker<'a> {
     pub fn expect_array<S: Into<String>>(
         mut self,
         name: S,
-        subtype: VarType,
+        subtype: ExprType,
         dimensions: &[usize],
         contents: Vec<(&[i32], Value)>,
     ) -> Self {
@@ -637,7 +637,7 @@ impl<'a> Checker<'a> {
     pub fn expect_array_simple<S: Into<String>>(
         mut self,
         name: S,
-        subtype: VarType,
+        subtype: ExprType,
         contents: Vec<Value>,
     ) -> Self {
         let name = name.into().to_ascii_uppercase();

--- a/std/src/testutils.rs
+++ b/std/src/testutils.rs
@@ -22,7 +22,7 @@ use crate::gpio;
 use crate::program::Program;
 use crate::storage::Storage;
 use async_trait::async_trait;
-use endbasic_core::ast::{ExprType, Value, VarRef, VarType};
+use endbasic_core::ast::{ExprType, Value, VarRef};
 use endbasic_core::exec::{self, Machine, StopReason};
 use endbasic_core::syms::{Array, Callable, Symbol};
 use futures_lite::future::block_on;
@@ -482,7 +482,7 @@ impl Tester {
 
     /// Sets a variable to an initial value.
     pub fn set_var(mut self, name: &str, value: Value) -> Self {
-        self.machine.get_mut_symbols().set_var(&VarRef::new(name, VarType::Auto), value).unwrap();
+        self.machine.get_mut_symbols().set_var(&VarRef::new(name, None), value).unwrap();
         self
     }
 

--- a/web/src/lib.rs
+++ b/web/src/lib.rs
@@ -107,7 +107,7 @@ fn js_sleep(
     yielder: Rc<RefCell<Yielder>>,
 ) -> Pin<Box<dyn Future<Output = CallResult>>> {
     let ms = d.as_millis();
-    if ms > std::i32::MAX as u128 {
+    if ms > i32::MAX as u128 {
         // The JavaScript setTimeout function only takes i32s so ensure our value fits.  If it
         // doesn't, you can imagine chaining calls to setTimeout to achieve the desired delay...
         // but the numbers we are talking about are so big that this doesn't make sense.
@@ -389,7 +389,7 @@ mod tests {
     async fn test_js_sleep_too_big() {
         let yielder = Rc::from(RefCell::from(Yielder::new()));
         match js_sleep(
-            Duration::from_millis(std::i32::MAX as u64 + 1),
+            Duration::from_millis(i32::MAX as u64 + 1),
             LineCol { line: 1, col: 2 },
             yielder,
         )

--- a/web/src/lib.rs
+++ b/web/src/lib.rs
@@ -23,7 +23,6 @@
 #![warn(unsafe_code)]
 
 use async_channel::{Receiver, Sender};
-use endbasic_core::ast::Value;
 use endbasic_core::exec::{Signal, YieldNowFn};
 use endbasic_core::syms::{self, CallResult};
 use endbasic_core::LineCol;
@@ -119,7 +118,7 @@ fn js_sleep(
     let ms = ms as i32;
 
     yielder.borrow_mut().reset();
-    do_sleep(ms, Ok(Value::Void))
+    do_sleep(ms, Ok(()))
 }
 
 /// Supplier of a `YieldNowFn` that relies on a zero timeout to yield execution back to the


### PR DESCRIPTION
The main goal of these changes is to introduce a "typed stack" context for execution and special-casing all types so that type-checks at runtime are minimal.

The changes have gone off the rails a bit and the results are still not "complete", but this is good enough to be merged for now and unblocks implementing custom functions.

I'll have to get back to this to complete the "cleanups"... or maybe "revert" some of them. I wanted to remove the Value type completely, but I'm realizing that I still need some sort of generic type interface for some consumers. I will need to think about this some more.