### PR TITLE
Adjust Mac arch names in release artifacts

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -93,19 +93,6 @@ jobs:
                   draft: true
                   prerelease: false
                   token: ${{ secrets.GITHUB_TOKEN }}
-            - name: Upload tgz artifacts
-              id: upload_tgzs
-              uses: ncipollo/release-action@v1
-              with:
-                  allowUpdates: true
-                  omitBody: true
-                  omitName: true
-                  replacesArtifacts: false
-                  draft: true
-                  prerelease: false
-                  artifacts: "artifacts/*/*.tgz"
-                  artifactContentType: application/gzip
-                  token: ${{ secrets.GITHUB_TOKEN }}
             - name: Upload zip artifacts
               id: upload_zips
               uses: ncipollo/release-action@v1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,15 +50,15 @@ jobs:
                 path: endbasic-linux-x86_64-sdl/*
                 retention-days: 1
 
-    macos-x86_64-sdl:
+    macos-arm64-sdl:
         runs-on: macos-latest
         steps:
             - uses: actions/checkout@v2
-            - run: ./.github/workflows/release.sh macos-x86_64-sdl
+            - run: ./.github/workflows/release.sh macos-arm64-sdl
             - uses: actions/upload-artifact@v4
               with:
-                name: endbasic-macos-x86_64-sdl
-                path: endbasic-macos-x86_64-sdl/*
+                name: endbasic-macos-arm64-sdl
+                path: endbasic-macos-arm64-sdl/*
                 retention-days: 1
 
     windows-x86_64-sdl:
@@ -77,7 +77,7 @@ jobs:
 
     create-release:
         if: startsWith(github.ref, 'refs/tags/')
-        needs: [linux-armv7-rpi, linux-x86_64-sdl, macos-x86_64-sdl, windows-x86_64-sdl]
+        needs: [linux-armv7-rpi, linux-x86_64-sdl, macos-arm64-sdl, windows-x86_64-sdl]
         runs-on: ubuntu-latest
         steps:
             - uses: actions/checkout@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,11 +21,9 @@ jobs:
     linux-armv7-rpi:
         runs-on: ubuntu-latest
         steps:
-            - uses: actions-rs/toolchain@v1
+            - uses: actions-rust-lang/setup-rust-toolchain@v1
               with:
-                  profile: minimal
                   toolchain: stable
-                  default: true
                   target: armv7-unknown-linux-gnueabihf
             - uses: actions/checkout@v4
             - run: sudo apt update

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,7 +27,7 @@ jobs:
                   toolchain: stable
                   default: true
                   target: armv7-unknown-linux-gnueabihf
-            - uses: actions/checkout@v2
+            - uses: actions/checkout@v4
             - run: sudo apt update
             - run: sudo apt install gcc-arm-linux-gnueabihf
             - run: ./.github/workflows/release.sh linux-armv7-rpi
@@ -40,7 +40,7 @@ jobs:
     linux-x86_64-sdl:
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/checkout@v2
+            - uses: actions/checkout@v4
             - run: sudo apt update
             - run: sudo apt install libsdl2-dev libsdl2-ttf-dev
             - run: ./.github/workflows/release.sh linux-x86_64-sdl
@@ -53,7 +53,7 @@ jobs:
     macos-arm64-sdl:
         runs-on: macos-latest
         steps:
-            - uses: actions/checkout@v2
+            - uses: actions/checkout@v4
             - run: ./.github/workflows/release.sh macos-arm64-sdl
             - uses: actions/upload-artifact@v4
               with:
@@ -64,7 +64,7 @@ jobs:
     windows-x86_64-sdl:
         runs-on: windows-latest
         steps:
-            - uses: actions/checkout@v2
+            - uses: actions/checkout@v4
             - run: choco install unzip zip
             - run: ./.github/workflows/setup-sdl.ps1
             - run: ./.github/workflows/release.sh windows-x86_64-sdl
@@ -80,7 +80,7 @@ jobs:
         needs: [linux-armv7-rpi, linux-x86_64-sdl, macos-arm64-sdl, windows-x86_64-sdl]
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/checkout@v2
+            - uses: actions/checkout@v4
             - run: ./.github/workflows/notes.sh >notes.md || touch notes.md
             - name: Fetch binary artifacts
               uses: actions/download-artifact@v4

--- a/.github/workflows/deploy-release.yml
+++ b/.github/workflows/deploy-release.yml
@@ -24,7 +24,7 @@ jobs:
     publish:
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/checkout@v2
+            - uses: actions/checkout@v4
             - run: ./.github/workflows/publish.sh prod
             - uses: JamesIves/github-pages-deploy-action@4.1.4
               with:

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -27,7 +27,7 @@ jobs:
     publish:
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/checkout@v2
+            - uses: actions/checkout@v4
             - run: ./.github/workflows/publish.sh staging
             - uses: JamesIves/github-pages-deploy-action@4.1.4
               with:

--- a/.github/workflows/release.sh
+++ b/.github/workflows/release.sh
@@ -66,7 +66,6 @@ main() {
         echo
     done >"${distname}/NOTICE"
 
-    local ext=
     local target=
     case "${name}" in
         linux-armv7-rpi)
@@ -81,8 +80,6 @@ main() {
             rm -f .cargo/config
 
             cp ./target/armv7-unknown-linux-gnueabihf/release/endbasic "${distname}"
-
-            ext=tgz
             ;;
 
         macos*)
@@ -110,7 +107,6 @@ main() {
 
             brew uninstall --ignore-dependencies sdl2 sdl2_ttf freetype libpng
             sanity_check "${distname}/endbasic"
-            ext=tgz
             ;;
 
         windows*)
@@ -120,7 +116,6 @@ main() {
             cp dlls/* "${distname}"
 
             sanity_check "${distname}/endbasic.exe"
-            ext=zip
             ;;
 
         *)
@@ -129,17 +124,9 @@ main() {
             cp ./target/release/endbasic "${distname}"
 
             sanity_check "${distname}/endbasic"
-            ext=tgz
             ;;
     esac
-    case "${ext}" in
-        tgz)
-            tar czvf "${outdir}/${distname}.${ext}" "${distname}"
-            ;;
-        zip)
-            zip -r "${outdir}/${distname}.${ext}" "${distname}"
-            ;;
-    esac
+    zip -r "${outdir}/${distname}.zip" "${distname}"
     rm -rf "${distname}"
 }
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ jobs:
     cargo-package:
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/checkout@v2
+            - uses: actions/checkout@v4
             - run: sudo apt update
             - run: sudo apt install libsdl2-dev libsdl2-ttf-dev
             - run: ./.github/workflows/package.sh
@@ -33,7 +33,7 @@ jobs:
     cargo-install:
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/checkout@v2
+            - uses: actions/checkout@v4
             - run: sudo apt update
             - run: sudo apt install libsdl2-dev libsdl2-ttf-dev
             - run: ./.github/workflows/install.sh

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,7 +29,7 @@ jobs:
                   toolchain: stable
                   default: true
                   components: clippy, rustfmt
-            - uses: actions/checkout@v2
+            - uses: actions/checkout@v4
             - run: sudo apt update
             - run: sudo apt install libsdl2-dev libsdl2-ttf-dev
             - run: ./.github/workflows/lint.sh
@@ -43,7 +43,7 @@ jobs:
             TEST_ACCOUNT_2_USERNAME: ${{ secrets.TEST_ACCOUNT_2_USERNAME }}
             TEST_ACCOUNT_2_PASSWORD: ${{ secrets.TEST_ACCOUNT_2_PASSWORD }}
         steps:
-            - uses: actions/checkout@v2
+            - uses: actions/checkout@v4
             - run: sudo apt update
             - run: sudo apt install libsdl2-dev libsdl2-ttf-dev
             - run: cargo test --package='*' --features=sdl
@@ -58,7 +58,7 @@ jobs:
             TEST_ACCOUNT_2_USERNAME: ${{ secrets.TEST_ACCOUNT_2_USERNAME }}
             TEST_ACCOUNT_2_PASSWORD: ${{ secrets.TEST_ACCOUNT_2_PASSWORD }}
         steps:
-            - uses: actions/checkout@v2
+            - uses: actions/checkout@v4
             - run: brew install sdl2 sdl2_ttf
             - run: cargo test --package=endbasic-client -- --include-ignored
             - run: cargo test --package=endbasic-core -- --include-ignored
@@ -82,7 +82,7 @@ jobs:
             TEST_ACCOUNT_2_USERNAME: ${{ secrets.TEST_ACCOUNT_2_USERNAME }}
             TEST_ACCOUNT_2_PASSWORD: ${{ secrets.TEST_ACCOUNT_2_PASSWORD }}
         steps:
-            - uses: actions/checkout@v2
+            - uses: actions/checkout@v4
             - run: choco install unzip
             - run: ./.github/workflows/setup-sdl.ps1
             - run: cargo test --package=endbasic-client -- --include-ignored
@@ -99,5 +99,5 @@ jobs:
     linux-test-no-features:
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/checkout@v2
+            - uses: actions/checkout@v4
             - run: cd std && cargo build --no-default-features

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,13 +21,11 @@ jobs:
     lint:
         runs-on: ubuntu-latest
         steps:
-            - uses: actions-rs/toolchain@v1
+            - uses: actions-rust-lang/setup-rust-toolchain@v1
               with:
-                  profile: minimal
                   # Use the latest stable Rust version for lint checks to
                   # verify any new Clippy warnings that may appear.
                   toolchain: stable
-                  default: true
                   components: clippy, rustfmt
             - uses: actions/checkout@v4
             - run: sudo apt update


### PR DESCRIPTION
The remote actions that build the macOS release now happen on arm64 Macs.  Adjust the artifact name accordingly.