### PR TITLE
Make the core bytecode interpreter sync

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -17,6 +17,8 @@ STILL UNDER DEVELOPMENT; NOT RELEASED YET.
 *   Cleaned up internal error handling, which changes how errors returned from
     commands and functions are displayed to the user.
 
+*   Improved the performance of the core interpreter by more than 2x.
+
 ## Changes in version 0.11.1
 
 **Released on 2024-09-14.**


### PR DESCRIPTION
The bytecode interpreter has to be async in order to process builtin callables and stop signals.  However, these async operations are infrequent, and the inner execution loop can be made sync.  Just doing this gives us a 25% performance boost.

But we can go further, clean up the way stop signals are handled, and simplify the core execution loop.  With all these changes, I'm observing an almost 3x performance improvement on a trivial async-less benchmark.