### PR TITLE
Fix packaging test after addition of st7735s

### DIFF
--- a/.github/workflows/package.sh
+++ b/.github/workflows/package.sh
@@ -55,7 +55,7 @@ EOF
 
 # Package one crate at a time and add it to the local registry so that subsequent crates
 # can pick them up.
-for dir in core std repl client terminal sdl rpi cli; do
+for dir in core std repl client terminal sdl st7735s rpi cli; do
     cd "${dir}"
     cargo index add --index "${registry}/index" --index-url https://example.com
     cd -


### PR DESCRIPTION
Commit 6109c2099ab09c13067555323ff81a6bb873809f added a new st7735s crate but I forgot to add it to the post-merge package check, so it failed.  Fix it now.