### PR TITLE
Add arm6v (Rpi0/1) build to gh action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,6 +18,22 @@ name: Build release
 on: [push, pull_request]
 
 jobs:
+    linux-armv6-rpi:
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions-rust-lang/setup-rust-toolchain@v1
+              with:
+                  toolchain: stable
+                  target: arm-unknown-linux-gnueabihf
+            - uses: actions/checkout@v4
+            - run: sudo apt update
+            - run: sudo apt install gcc-arm-linux-gnueabihf
+            - run: ./.github/workflows/release.sh linux-armv6-rpi
+            - uses: actions/upload-artifact@v4
+              with:
+                name: endbasic-linux-armv6-rpi
+                path: endbasic-linux-armv6-rpi/*
+                retention-days: 1
     linux-armv7-rpi:
         runs-on: ubuntu-latest
         steps:

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# The EndBASIC programming language
+# The EndBASIC programming language  
 
 ![Test](https://github.com/endbasic/endbasic/actions/workflows/test.yml/badge.svg?branch=master)
 ![Build release](https://github.com/endbasic/endbasic/actions/workflows/build.yml/badge.svg?branch=master)


### PR DESCRIPTION
In relation to https://github.com/endbasic/endbasic/issues/275, this adds armv6 builds to the gh workflow.

Don't merge a0d3a72b109152a489dded72949e71d2873622e5, it was just a push to test/trigger the actions. It looks like it builds fine :  

https://github.com/ABelliqueux/endbasic/actions/runs/14943362855