### PR TITLE
Refactor GPIO mocks to be self-contained

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -19,6 +19,7 @@ use anyhow::{Result, anyhow};
 use async_channel::Sender;
 use endbasic_core::exec::Signal;
 use endbasic_std::console::{Console, ConsoleSpec};
+use endbasic_std::gpio;
 use endbasic_std::storage::Storage;
 use getoptsargs::prelude::*;
 use std::cell::RefCell;
@@ -62,31 +63,49 @@ fn app_extra_help(o: &mut dyn io::Write) -> io::Result<()> {
         writeln!(o, "                        fg_color=COLOR,bg_color=COLOR,font=NAME")?;
     }
     writeln!(o, "    text                enables the text-based console")?;
+    writeln!(o)?;
+    writeln!(o, "GPIO-PINS-SPEC can be one of the following:")?;
+    writeln!(o, "    mock                mock backend for testing")?;
+    writeln!(o, "    noop                dummy backend that always returns errors")?;
+    if cfg!(feature = "rpi") {
+        writeln!(o, "    rppal               uses the Raspberry Pi GPIO hardware")?;
+    }
     Ok(())
 }
 
+/// Creates the rppal GPIO backend when the rpi feature is compiled in.
+#[cfg(feature = "rpi")]
+fn setup_gpio_pins_rppal() -> Result<Rc<RefCell<dyn gpio::Pins>>> {
+    Ok(Rc::new(RefCell::new(endbasic_rpi::RppalPins::default())))
+}
+
+/// Errors out for rppal when the rpi feature is not compiled in.
+#[cfg(not(feature = "rpi"))]
+fn setup_gpio_pins_rppal() -> Result<Rc<RefCell<dyn gpio::Pins>>> {
+    Err(UsageError::new("--gpio-pins=rppal requires the rpi feature to be compiled in").into())
+}
+
+/// Parses the `--gpio-pins` flag value and constructs the pins backend.
+fn setup_gpio_pins(spec: Option<&str>) -> Result<Rc<RefCell<dyn gpio::Pins>>> {
+    let spec = if cfg!(feature = "rpi") { spec.unwrap_or("rppal") } else { spec.unwrap_or("noop") };
+    match spec {
+        "mock" => Ok(Rc::new(RefCell::new(gpio::MockPins::default()))),
+        "noop" => Ok(Rc::new(RefCell::new(gpio::NoopPins::default()))),
+        "rppal" => setup_gpio_pins_rppal(),
+        other => Err(UsageError::new(format!("Unknown --gpio-pins backend: {}", other)).into()),
+    }
+}
+
 /// Creates a new EndBASIC machine builder based on the features enabled in this crate.
-fn new_machine_builder(console_spec: Option<&str>) -> io::Result<endbasic_std::MachineBuilder> {
-    /// Obtains the default set of pins for a Raspberry Pi.
-    #[cfg(feature = "rpi")]
-    fn add_gpio_pins(builder: endbasic_std::MachineBuilder) -> endbasic_std::MachineBuilder {
-        // TODO(jmmv): If st7735s is in use, this basically creates a secondary set of pins.
-        // Which... should work OK, but then the user can interfere with the display in ways that
-        // should not be allowed, probably.
-        builder.with_gpio_pins(Rc::from(RefCell::from(endbasic_rpi::RppalPins::default())))
-    }
-
-    /// Obtains the default set of pins for a platform without GPIO support.
-    #[cfg(not(feature = "rpi"))]
-    fn add_gpio_pins(builder: endbasic_std::MachineBuilder) -> endbasic_std::MachineBuilder {
-        builder
-    }
-
+fn new_machine_builder(
+    console_spec: Option<&str>,
+    gpio_pins_spec: Option<&str>,
+) -> Result<endbasic_std::MachineBuilder> {
     let signals_chan = async_channel::unbounded();
     let mut builder = endbasic_std::MachineBuilder::default();
     builder = builder.with_console(setup_console(console_spec, signals_chan.0.clone())?);
     builder = builder.with_signals_chan(signals_chan);
-    builder = add_gpio_pins(builder);
+    builder = builder.with_gpio_pins(setup_gpio_pins(gpio_pins_spec)?);
     Ok(builder)
 }
 
@@ -242,10 +261,11 @@ pub fn setup_storage(storage: &mut Storage, local_drive_spec: &str) -> io::Resul
 /// `service_url` is the base URL of the cloud service.
 async fn run_repl_loop(
     console_spec: Option<&str>,
+    gpio_pins_spec: Option<&str>,
     local_drive_spec: &str,
     service_url: &str,
 ) -> Result<i32> {
-    let mut builder = make_interactive(new_machine_builder(console_spec)?);
+    let mut builder = make_interactive(new_machine_builder(console_spec, gpio_pins_spec)?);
 
     let console = builder.get_console();
     let program = builder.get_program();
@@ -260,8 +280,13 @@ async fn run_repl_loop(
 }
 
 /// Executes the `path` program in a fresh machine.
-async fn run_script<P: AsRef<Path>>(path: P, console_spec: Option<&str>) -> Result<i32> {
-    let mut machine = new_machine_builder(console_spec)?.build()?;
+async fn run_script<P: AsRef<Path>>(
+    path: P,
+    console_spec: Option<&str>,
+    gpio_pins_spec: Option<&str>,
+) -> Result<i32> {
+    let builder = new_machine_builder(console_spec, gpio_pins_spec)?;
+    let mut machine = builder.build()?;
     let mut input = File::open(path)?;
     Ok(machine.exec(&mut input).await?.as_exit_code())
 }
@@ -277,10 +302,11 @@ async fn run_script<P: AsRef<Path>>(path: P, console_spec: Option<&str>) -> Resu
 async fn run_interactive(
     path: &str,
     console_spec: Option<&str>,
+    gpio_pins_spec: Option<&str>,
     local_drive_spec: &str,
     service_url: &str,
 ) -> Result<i32> {
-    let mut builder = make_interactive(new_machine_builder(console_spec)?);
+    let mut builder = make_interactive(new_machine_builder(console_spec, gpio_pins_spec)?);
 
     let console = builder.get_console();
     let program = builder.get_program();
@@ -317,6 +343,7 @@ fn app_build(builder: Builder) -> Builder {
         .homepage("https://www.endbasic.dev/")
         .bugs("https://github.com/endbasic/endbasic/issues")
         .optopt("", "console", "type and properties of the console to use", "CONSOLE-SPEC")
+        .optopt("", "gpio-pins", "GPIO pins backend to use", "GPIO-PINS-SPEC")
         .optflag("i", "interactive", "force interactive mode when running a script")
         .optopt("", "local-drive", "location of the drive to mount as LOCAL", "URI")
         .optopt("", "service-url", "base URL of the cloud service", "URL")
@@ -327,6 +354,8 @@ fn app_build(builder: Builder) -> Builder {
 async fn app_main(matches: Matches) -> Result<i32> {
     let console_spec = matches.opt_str("console");
 
+    let gpio_pins_spec = matches.opt_str("gpio-pins");
+
     let service_url = matches
         .opt_str("service-url")
         .unwrap_or_else(|| endbasic_client::PROD_API_ADDRESS.to_owned());
@@ -334,15 +363,27 @@ async fn app_main(matches: Matches) -> Result<i32> {
     match matches.arg_trail() {
         [] => {
             let local_drive = get_local_drive_spec(matches.opt_str("local-drive"))?;
-            Ok(run_repl_loop(console_spec.as_deref(), &local_drive, &service_url).await?)
+            Ok(run_repl_loop(
+                console_spec.as_deref(),
+                gpio_pins_spec.as_deref(),
+                &local_drive,
+                &service_url,
+            )
+            .await?)
         }
         [file] => {
             if matches.opt_present("interactive") {
                 let local_drive = get_local_drive_spec(matches.opt_str("local-drive"))?;
-                Ok(run_interactive(file, console_spec.as_deref(), &local_drive, &service_url)
-                    .await?)
+                Ok(run_interactive(
+                    file,
+                    console_spec.as_deref(),
+                    gpio_pins_spec.as_deref(),
+                    &local_drive,
+                    &service_url,
+                )
+                .await?)
             } else {
-                Ok(run_script(file, console_spec.as_deref()).await?)
+                Ok(run_script(file, console_spec.as_deref(), gpio_pins_spec.as_deref()).await?)
             }
         }
         [_, ..] => Err(UsageError::new("Too many arguments").into()),

--- a/cli/tests/cli/help.out
+++ b/cli/tests/cli/help.out
@@ -5,6 +5,8 @@ Options:
         --version       show version information and exit
         --console CONSOLE-SPEC
                         type and properties of the console to use
+        --gpio-pins GPIO-PINS-SPEC
+                        GPIO pins backend to use
     -i, --interactive   force interactive mode when running a script
         --local-drive URI
                         location of the drive to mount as LOCAL
@@ -16,6 +18,10 @@ Arguments:
 
 CONSOLE-SPEC can be one of the following:
     text                enables the text-based console
+
+GPIO-PINS-SPEC can be one of the following:
+    mock                mock backend for testing
+    noop                dummy backend that always returns errors
 
 Report bugs to: https://github.com/endbasic/endbasic/issues
 EndBASIC home page: https://www.endbasic.dev/

--- a/cli/tests/cli/help.out.rpi
+++ b/cli/tests/cli/help.out.rpi
@@ -5,6 +5,8 @@ Options:
         --version       show version information and exit
         --console CONSOLE-SPEC
                         type and properties of the console to use
+        --gpio-pins GPIO-PINS-SPEC
+                        GPIO pins backend to use
     -i, --interactive   force interactive mode when running a script
         --local-drive URI
                         location of the drive to mount as LOCAL
@@ -17,6 +19,11 @@ Arguments:
 CONSOLE-SPEC can be one of the following:
     st7735s             enables the ST7735S LCD console
     text                enables the text-based console
+
+GPIO-PINS-SPEC can be one of the following:
+    mock                mock backend for testing
+    noop                dummy backend that always returns errors
+    rppal               uses the Raspberry Pi GPIO hardware
 
 Report bugs to: https://github.com/endbasic/endbasic/issues
 EndBASIC home page: https://www.endbasic.dev/

--- a/cli/tests/cli/help.out.rpi.sdl
+++ b/cli/tests/cli/help.out.rpi.sdl
@@ -5,6 +5,8 @@ Options:
         --version       show version information and exit
         --console CONSOLE-SPEC
                         type and properties of the console to use
+        --gpio-pins GPIO-PINS-SPEC
+                        GPIO pins backend to use
     -i, --interactive   force interactive mode when running a script
         --local-drive URI
                         location of the drive to mount as LOCAL
@@ -26,6 +28,11 @@ CONSOLE-SPEC can be one of the following:
                         with the settings in SPEC, which is of the form:
                         fg_color=COLOR,bg_color=COLOR,font=NAME
     text                enables the text-based console
+
+GPIO-PINS-SPEC can be one of the following:
+    mock                mock backend for testing
+    noop                dummy backend that always returns errors
+    rppal               uses the Raspberry Pi GPIO hardware
 
 Report bugs to: https://github.com/endbasic/endbasic/issues
 EndBASIC home page: https://www.endbasic.dev/

--- a/cli/tests/cli/help.out.sdl
+++ b/cli/tests/cli/help.out.sdl
@@ -5,6 +5,8 @@ Options:
         --version       show version information and exit
         --console CONSOLE-SPEC
                         type and properties of the console to use
+        --gpio-pins GPIO-PINS-SPEC
+                        GPIO pins backend to use
     -i, --interactive   force interactive mode when running a script
         --local-drive URI
                         location of the drive to mount as LOCAL
@@ -23,6 +25,10 @@ CONSOLE-SPEC can be one of the following:
                         RESOLUTION can be one of 'fs' (for full screen),
                         'WIDTHxHEIGHT' or 'WIDTHxHEIGHTfs'
     text                enables the text-based console
+
+GPIO-PINS-SPEC can be one of the following:
+    mock                mock backend for testing
+    noop                dummy backend that always returns errors
 
 Report bugs to: https://github.com/endbasic/endbasic/issues
 EndBASIC home page: https://www.endbasic.dev/

--- a/cli/tests/examples/gpio.bas
+++ b/cli/tests/examples/gpio.bas
@@ -17,17 +17,13 @@
 
 LOAD "DEMOS:/GPIO.BAS"
 
-DIM __GPIO_MOCK_DATA(20) AS INTEGER
-__GPIO_MOCK_DATA(3) = 811 ' Return high for pin 8 (button).
-__GPIO_MOCK_DATA(4) = 811 ' Return high for pin 8 (button).
-__GPIO_MOCK_DATA(5) = 810 ' Return low for pin 8 (button).
-__GPIO_MOCK_LAST = 0
+GPIO_MOCK_INJECT 8, TRUE
+GPIO_MOCK_INJECT 8, TRUE
+GPIO_MOCK_INJECT 8, FALSE
 
 RUN
 
 PRINT "Dumping GPIO trace..."
-FOR i = 0 TO __GPIO_MOCK_LAST - 1
-    PRINT "__GPIO_MOCK_DATA", i, __GPIO_MOCK_DATA(i)
-NEXT
+PRINT GPIO_MOCK_TRACE$
 
 DISASM

--- a/cli/tests/examples/gpio.out
+++ b/cli/tests/examples/gpio.out
@@ -30,22 +30,7 @@ Button pressed! Blinking LED on pin 18 ...
  2
  1
 Dumping GPIO trace...
-__GPIO_MOCK_DATA             0            -1
-__GPIO_MOCK_DATA             1             803
-__GPIO_MOCK_DATA             2             1804
-__GPIO_MOCK_DATA             3             811
-__GPIO_MOCK_DATA             4             811
-__GPIO_MOCK_DATA             5             810
-__GPIO_MOCK_DATA             6             1821
-__GPIO_MOCK_DATA             7             1820
-__GPIO_MOCK_DATA             8             1821
-__GPIO_MOCK_DATA             9             1820
-__GPIO_MOCK_DATA             10            1821
-__GPIO_MOCK_DATA             11            1820
-__GPIO_MOCK_DATA             12            1821
-__GPIO_MOCK_DATA             13            1820
-__GPIO_MOCK_DATA             14            1821
-__GPIO_MOCK_DATA             15            1820
+-1 -1 803 1804 811 811 810 1821 1820 1821 1820 1821 1820 1821 1820 1821 1820
 0000    PUSH%       8                           # 16:10
 0001    SETV        BUTTON
 0002    PUSH%       18                          # 17:7
@@ -53,29 +38,29 @@ __GPIO_MOCK_DATA             15            1820
 0004    CALLB       6 (CLS), 0                  # 19:1
 0005    PUSH%       11                          # 20:7
 0006    CALLB       7 (COLOR), 1                # 20:1
-0007    CALLB       48 (PRINT), 0               # 21:1
+0007    CALLB       50 (PRINT), 0               # 21:1
 0008    PUSH$       " GPIO demo"                # 22:7
 0009    PUSH%       4                           # 22:7
-000a    CALLB       48 (PRINT), 2               # 22:1
+000a    CALLB       50 (PRINT), 2               # 22:1
 000b    PUSH$       "==========="               # 23:7
 000c    PUSH%       4                           # 23:7
-000d    CALLB       48 (PRINT), 2               # 23:1
+000d    CALLB       50 (PRINT), 2               # 23:1
 000e    CALLB       7 (COLOR), 0                # 24:1
-000f    CALLB       48 (PRINT), 0               # 25:1
+000f    CALLB       50 (PRINT), 0               # 25:1
 0010    PUSH$       "This demo showcases how to poll a hardware button attached to a GPIO"    # 26:7
 0011    PUSH%       4                           # 26:7
-0012    CALLB       48 (PRINT), 2               # 26:1
+0012    CALLB       50 (PRINT), 2               # 26:1
 0013    PUSH$       "pin and how to flash an LED attached to another one."    # 27:7
 0014    PUSH%       4                           # 27:7
-0015    CALLB       48 (PRINT), 2               # 27:1
-0016    CALLB       48 (PRINT), 0               # 28:1
+0015    CALLB       50 (PRINT), 2               # 27:1
+0016    CALLB       50 (PRINT), 0               # 28:1
 0017    PUSH%       2                           # 29:7
 0018    CALLB       7 (COLOR), 1                # 29:1
 0019    PUSH$       "To get started, follow these steps:"    # 30:7
 001a    PUSH%       4                           # 30:7
-001b    CALLB       48 (PRINT), 2               # 30:1
+001b    CALLB       50 (PRINT), 2               # 30:1
 001c    CALLB       7 (COLOR), 0                # 31:1
-001d    CALLB       48 (PRINT), 0               # 32:1
+001d    CALLB       50 (PRINT), 0               # 32:1
 001e    PUSH$       "and to ground; don't forget to add a"    # 33:40
 001f    PUSH%       4                           # 33:40
 0020    PUSH%       1                           # 33:38
@@ -84,11 +69,11 @@ __GPIO_MOCK_DATA             15            1820
 0023    PUSH%       1                           # 33:33
 0024    PUSH$       "1. Connect an LED to pin"    # 33:7
 0025    PUSH%       4                           # 33:7
-0026    CALLB       48 (PRINT), 8               # 33:1
+0026    CALLB       50 (PRINT), 8               # 33:1
 0027    PUSH$       "   resistor inline."       # 34:7
 0028    PUSH%       4                           # 34:7
-0029    CALLB       48 (PRINT), 2               # 34:1
-002a    CALLB       48 (PRINT), 0               # 35:1
+0029    CALLB       50 (PRINT), 2               # 34:1
+002a    CALLB       50 (PRINT), 0               # 35:1
 002b    PUSH$       "and to ground.  We'll be"    # 36:50
 002c    PUSH%       4                           # 36:50
 002d    PUSH%       1                           # 36:48
@@ -97,50 +82,50 @@ __GPIO_MOCK_DATA             15            1820
 0030    PUSH%       1                           # 36:40
 0031    PUSH$       "2. Connect a push button to pin"    # 36:7
 0032    PUSH%       4                           # 36:7
-0033    CALLB       48 (PRINT), 8               # 36:1
+0033    CALLB       50 (PRINT), 8               # 36:1
 0034    PUSH$       "   using the built-in pull-up resistor for the input pin so there is"    # 37:7
 0035    PUSH%       4                           # 37:7
-0036    CALLB       48 (PRINT), 2               # 37:1
+0036    CALLB       50 (PRINT), 2               # 37:1
 0037    PUSH$       "   no need to do any extra wiring."    # 38:7
 0038    PUSH%       4                           # 38:7
-0039    CALLB       48 (PRINT), 2               # 38:1
-003a    CALLB       48 (PRINT), 0               # 39:1
+0039    CALLB       50 (PRINT), 2               # 38:1
+003a    CALLB       50 (PRINT), 0               # 39:1
 003b    PUSH%       1                           # 40:7
 003c    CALLB       7 (COLOR), 1                # 40:1
 003d    PUSH$       "This demo is only functional on the Raspberry Pi and assumes you have"    # 41:7
 003e    PUSH%       4                           # 41:7
-003f    CALLB       48 (PRINT), 2               # 41:1
+003f    CALLB       50 (PRINT), 2               # 41:1
 0040    PUSH$       "built EndBASIC with --features=rpi.  If these conditions are not met,"    # 42:7
 0041    PUSH%       4                           # 42:7
-0042    CALLB       48 (PRINT), 2               # 42:1
+0042    CALLB       50 (PRINT), 2               # 42:1
 0043    PUSH$       "the demo will fail to run."    # 43:7
 0044    PUSH%       4                           # 43:7
-0045    CALLB       48 (PRINT), 2               # 43:1
+0045    CALLB       50 (PRINT), 2               # 43:1
 0046    CALLB       7 (COLOR), 0                # 44:1
-0047    CALLB       48 (PRINT), 0               # 45:1
+0047    CALLB       50 (PRINT), 0               # 45:1
 0048    LOADR       DUMMY                       # 46:71
 0049    PUSH%       2                           # 46:69
 004a    PUSH$       "Press ENTER when you are ready or CTRL+C to exit the demo..."    # 46:7
 004b    PUSH%       1                           # 46:7
-004c    CALLB       30 (INPUT), 4               # 46:1
+004c    CALLB       32 (INPUT), 4               # 46:1
 004d    CALLB       6 (CLS), 0                  # 48:1
 004e    PUSH%       11                          # 49:7
 004f    CALLB       7 (COLOR), 1                # 49:1
-0050    CALLB       48 (PRINT), 0               # 50:1
+0050    CALLB       50 (PRINT), 0               # 50:1
 0051    PUSH$       " GPIO demo"                # 51:7
 0052    PUSH%       4                           # 51:7
-0053    CALLB       48 (PRINT), 2               # 51:1
+0053    CALLB       50 (PRINT), 2               # 51:1
 0054    PUSH$       "==========="               # 52:7
 0055    PUSH%       4                           # 52:7
-0056    CALLB       48 (PRINT), 2               # 52:1
+0056    CALLB       50 (PRINT), 2               # 52:1
 0057    CALLB       7 (COLOR), 0                # 53:1
-0058    CALLB       48 (PRINT), 0               # 54:1
+0058    CALLB       50 (PRINT), 0               # 54:1
 0059    PUSH$       "IN-PULL-UP"                # 57:20
 005a    LOAD%       BUTTON                      # 57:12
-005b    CALLB       26 (GPIO_SETUP), 2          # 57:1
+005b    CALLB       28 (GPIO_SETUP), 2          # 57:1
 005c    PUSH$       "OUT"                       # 58:17
 005d    LOAD%       LED                         # 58:12
-005e    CALLB       26 (GPIO_SETUP), 2          # 58:1
+005e    CALLB       28 (GPIO_SETUP), 2          # 58:1
 005f    PUSH$       "..."                       # 62:52
 0060    PUSH%       4                           # 62:52
 0061    PUSH%       1                           # 62:50
@@ -149,12 +134,12 @@ __GPIO_MOCK_DATA             15            1820
 0064    PUSH%       1                           # 62:42
 0065    PUSH$       "Waiting for a button press on pin"    # 62:7
 0066    PUSH%       4                           # 62:7
-0067    CALLB       48 (PRINT), 8               # 62:1
+0067    CALLB       50 (PRINT), 8               # 62:1
 0068    LOAD%       BUTTON                      # 63:17
-0069    CALLF?      25 (GPIO_READ), 1           # 63:7
+0069    CALLF?      27 (GPIO_READ), 1           # 63:7
 006a    JMPNT       006e
 006b    PUSH#       0.05                        # 64:11
-006c    CALLB       64 (SLEEP), 1               # 64:5
+006c    CALLB       66 (SLEEP), 1               # 64:5
 006d    JMP         0068
 006e    PUSH$       "..."                       # 68:51
 006f    PUSH%       4                           # 68:51
@@ -164,7 +149,7 @@ __GPIO_MOCK_DATA             15            1820
 0073    PUSH%       1                           # 68:44
 0074    PUSH$       "Button pressed! Blinking LED on pin"    # 68:7
 0075    PUSH%       4                           # 68:7
-0076    CALLB       48 (PRINT), 8               # 68:1
+0076    CALLB       50 (PRINT), 8               # 68:1
 0077    PUSH%       5                           # 69:9
 0078    SETV        I
 0079    LOAD%       I                           # 69:5
@@ -173,17 +158,17 @@ __GPIO_MOCK_DATA             15            1820
 007c    JMPNT       008f
 007d    PUSH?       true                        # 70:21
 007e    LOAD%       LED                         # 70:16
-007f    CALLB       27 (GPIO_WRITE), 2          # 70:5
+007f    CALLB       29 (GPIO_WRITE), 2          # 70:5
 0080    PUSH#       0.1                         # 71:11
-0081    CALLB       64 (SLEEP), 1               # 71:5
+0081    CALLB       66 (SLEEP), 1               # 71:5
 0082    PUSH?       false                       # 72:21
 0083    LOAD%       LED                         # 72:16
-0084    CALLB       27 (GPIO_WRITE), 2          # 72:5
+0084    CALLB       29 (GPIO_WRITE), 2          # 72:5
 0085    PUSH#       0.1                         # 73:11
-0086    CALLB       64 (SLEEP), 1               # 73:5
+0086    CALLB       66 (SLEEP), 1               # 73:5
 0087    LOAD%       I                           # 74:11
 0088    PUSH%       3                           # 74:11
-0089    CALLB       48 (PRINT), 2               # 74:5
+0089    CALLB       50 (PRINT), 2               # 74:5
 008a    LOAD%       I                           # 69:5
 008b    PUSH%       -1                          # 69:22
 008c    ADD%                                    # 69:11

--- a/cli/tests/integration_test.rs
+++ b/cli/tests/integration_test.rs
@@ -360,7 +360,12 @@ fn test_example_fibonacci() {
 fn test_example_gpio() {
     check(
         bin_path("endbasic"),
-        &["--local-drive=memory://", "--interactive", &src_str("cli/tests/examples/gpio.bas")],
+        &[
+            "--gpio-pins=mock",
+            "--local-drive=memory://",
+            "--interactive",
+            &src_str("cli/tests/examples/gpio.bas"),
+        ],
         0,
         Behavior::File(src_path("cli/tests/examples/gpio.in")),
         Behavior::File(src_path("cli/tests/examples/gpio.out")),

--- a/core/src/syms.rs
+++ b/core/src/syms.rs
@@ -274,13 +274,7 @@ impl Symbols {
     pub fn clear(&mut self) {
         fn filter(key: &SymbolKey, symbol: &mut Symbol) -> bool {
             let is_internal = key.0.starts_with(|c: char| c.is_ascii_digit());
-
-            // TODO(jmmv): Preserving symbols that start with __ is a hack that was added to support
-            // the already-existing GPIO tests when RUN was changed to issue a CLEAR upfront.  This
-            // is undocumented behavior and we should find a nicer way to do this.
-            let is_gpio_hack = key.0.starts_with("__");
-
-            is_internal || is_gpio_hack || !symbol.user_defined()
+            is_internal || !symbol.user_defined()
         }
 
         self.globals.retain(filter);
@@ -832,26 +826,26 @@ mod tests {
             .add_callable(OutCommand::new(Rc::from(RefCell::from(vec![]))))
             .add_callable(SumFunction::new())
             .add_var("SOMEVAR", Value::Boolean(true))
-            .add_var("__SYSTEM_VAR", Value::Integer(42))
+            .add_var("__OLD_STYLE_PRIVATE_VAR", Value::Integer(42))
             .add_global_var("GLOBAL_VAR", Value::Integer(43))
-            .add_global_var("__GLOBAL_SYSTEM_VAR", Value::Integer(44))
+            .add_global_var("__GLOBAL_OLD_STYLE_PRIVATE_VAR", Value::Integer(44))
             .build();
 
         assert!(syms.get(&VarRef::new("SOMEARRAY", None)).unwrap().is_some());
         assert!(syms.get(&VarRef::new("OUT", None)).unwrap().is_some());
         assert!(syms.get(&VarRef::new("SUM", None)).unwrap().is_some());
         assert!(syms.get(&VarRef::new("SOMEVAR", None)).unwrap().is_some());
-        assert!(syms.get(&VarRef::new("__SYSTEM_VAR", None)).unwrap().is_some());
+        assert!(syms.get(&VarRef::new("__OLD_STYLE_PRIVATE_VAR", None)).unwrap().is_some());
         assert!(syms.get(&VarRef::new("GLOBAL_VAR", None)).unwrap().is_some());
-        assert!(syms.get(&VarRef::new("__GLOBAL_SYSTEM_VAR", None)).unwrap().is_some());
+        assert!(syms.get(&VarRef::new("__GLOBAL_OLD_STYLE_PRIVATE_VAR", None)).unwrap().is_some());
         syms.clear();
         assert!(syms.get(&VarRef::new("SOMEARRAY", None)).unwrap().is_none());
         assert!(syms.get(&VarRef::new("OUT", None)).unwrap().is_some());
         assert!(syms.get(&VarRef::new("SUM", None)).unwrap().is_some());
         assert!(syms.get(&VarRef::new("SOMEVAR", None)).unwrap().is_none());
-        assert!(syms.get(&VarRef::new("__SYSTEM_VAR", None)).unwrap().is_some());
+        assert!(syms.get(&VarRef::new("__OLD_STYLE_PRIVATE_VAR", None)).unwrap().is_none());
         assert!(syms.get(&VarRef::new("GLOBAL_VAR", None)).unwrap().is_none());
-        assert!(syms.get(&VarRef::new("__GLOBAL_SYSTEM_VAR", None)).unwrap().is_some());
+        assert!(syms.get(&VarRef::new("__GLOBAL_OLD_STYLE_PRIVATE_VAR", None)).unwrap().is_none());
     }
 
     #[test]

--- a/rpi/src/gpio.rs
+++ b/rpi/src/gpio.rs
@@ -17,6 +17,7 @@
 
 use endbasic_std::gpio::{Pin, PinMode, Pins};
 use rppal::gpio;
+use std::any::Any;
 use std::collections::HashMap;
 use std::io;
 
@@ -54,6 +55,14 @@ impl RppalPins {
 }
 
 impl Pins for RppalPins {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn as_any_mut(&mut self) -> &mut dyn Any {
+        self
+    }
+
     fn setup(&mut self, pin: Pin, mode: PinMode) -> io::Result<()> {
         self.clear(pin)?;
         let chip = self.get_chip()?;

--- a/std/src/gpio/fakes.rs
+++ b/std/src/gpio/fakes.rs
@@ -16,15 +16,23 @@
 //! Fake implementations of GPIO pins that work on all platforms.
 
 use crate::gpio::{Pin, PinMode, Pins};
-use endbasic_core::ast::{ExprType, Value, VarRef};
-use endbasic_core::syms::{Array, Symbol, Symbols};
+use std::any::Any;
+use std::collections::VecDeque;
 use std::io;
 
 /// Stand-in implementation of the EndBASIC GPIO operations that always returns an error.
 #[derive(Default)]
-pub(crate) struct NoopPins {}
+pub struct NoopPins {}
 
 impl Pins for NoopPins {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn as_any_mut(&mut self) -> &mut dyn Any {
+        self
+    }
+
     fn setup(&mut self, _pin: Pin, _mode: PinMode) -> io::Result<()> {
         Err(io::Error::other("GPIO backend not compiled in"))
     }
@@ -46,37 +54,6 @@ impl Pins for NoopPins {
     }
 }
 
-/// Mock GPIO implementation that tracks operations and supplies fake reads.
-///
-/// This is an undocumented feature to support unit-testing of our own demo code and is quite
-/// convoluted due to the fact that we don't have a lot of freedom in what we can do in the context
-/// of the `Pins` implementation: we get no context passed in (intentionally), so the only context
-/// we can grab with some contortions is a reference to the machine's symbols.  This reference is
-/// only valid for the duration of a GPIO call and thus this structure must be recreated on each
-/// GPIO call and cannot maintain state of its own (other than via symbols).
-///
-/// To enable mocking, the user must define the `__GPIO_MOCK_DATA` unidimensional array of integer
-/// type (aka `data`) and the `__GPIO_MOCK_LAST` integer variable (aka `last`).  If these types are
-/// not met, mocking is silently not enabled.
-///
-/// The `data` array represents an ordered trace of GPIO calls and `last` indicates the index
-/// within the array that should be inspected on the next GPIO call.  Each `data[last]` value is
-/// encoded as a pin number (times 100) plus a `MockOp` integer that identifies the operation that
-/// happened.
-///
-/// For mutating GPIO calls, `data[last]` has to be zero on entry (or else the operation will fail)
-/// and will be updated with the affected pin number and the operation.  The meta operation to clear
-/// all pins has a special number.
-///
-/// For read GPIO calls, `data[last]` has to contain the pin number that matches the read operation
-/// and the desired outcome of the operation.
-///
-/// When a test is complete, the test should inspect the values in `data` up to the `last` position
-/// and ensure they match expectations.
-pub(crate) struct MockPins<'a> {
-    symbols: &'a mut Symbols,
-}
-
 /// Per-pin operation identifier in the mock data.
 #[derive(PartialEq)]
 enum MockOp {
@@ -96,125 +73,49 @@ enum MockOp {
 }
 
 impl MockOp {
-    /// Encodes a `pin` and `op` pair as a datum for the mock data.
+    /// Encodes a `pin` and `op` pair as a trace datum.
     fn encode(pin: Pin, op: Self) -> i32 {
         assert!(op != Self::ClearAll);
         (pin.0 as i32) * 100 + (op as i32)
     }
-
-    /// Decodes a datum from the mock data that is to be used for a read operation.
-    fn decode_read(pos: i32, datum: i32) -> io::Result<(Pin, bool)> {
-        if datum < 0 {
-            return Err(io::Error::new(
-                io::ErrorKind::InvalidData,
-                format!("Negative read value at __GPIO_MOCK_DATA({})", pos),
-            ));
-        }
-        let pin = datum / 100;
-        if pin > u8::MAX as i32 {
-            return Err(io::Error::new(
-                io::ErrorKind::InvalidData,
-                format!("Pin number too large at __GPIO_MOCK_DATA({})", pos),
-            ));
-        }
-        let pin = Pin(pin as u8);
-        match datum % 100 {
-            i if i == (MockOp::ReadLow as i32) => Ok((pin, false)),
-            i if i == (MockOp::ReadHigh as i32) => Ok((pin, true)),
-            i => Err(io::Error::new(
-                io::ErrorKind::InvalidData,
-                format!("Unknown read operation {} at __GPIO_MOCK_DATA({})", i, pos),
-            )),
-        }
-    }
 }
 
-impl<'a> MockPins<'a> {
-    /// Creates a mock pins instance if `__GPIO_MOCK_DATA` *and* `__GPIO_MOCK_LAST` are set and of
-    /// the correct types.
+/// Self-contained mock GPIO implementation that records operations and supplies pre-seeded reads.
+///
+/// Call `inject_read` to pre-seed reads before running code that calls `GPIO_READ`, and call
+/// `trace` afterwards to inspect the ordered record of all GPIO operations.
+#[derive(Default)]
+pub struct MockPins {
+    /// FIFO queue of pre-seeded reads: the next `read` call pops from the front.
+    reads: VecDeque<(Pin, bool)>,
+
+    /// Ordered record of all GPIO operations performed.
     ///
-    /// Note that, while this object is alive (which is in the context of an individual GPIO call),
-    /// we know that these symbols are valid so other methods can assume that they are.
-    pub(crate) fn try_new(symbols: &'a mut Symbols) -> Option<MockPins<'a>> {
-        if MockPins::get_last(symbols).is_none() || MockPins::get_mut_data(symbols).is_none() {
-            None
-        } else {
-            Some(Self { symbols })
-        }
+    /// Operations are encoded as `pin * 100 + MockOp` with `ClearAll` being encoded as `-1`.
+    trace: Vec<i32>,
+}
+
+impl MockPins {
+    /// Pre-seeds a future `read(pin)` call to return `high`.
+    pub fn inject_read(&mut self, pin: Pin, high: bool) {
+        self.reads.push_back((pin, high));
     }
 
-    /// Obtains the value of `__GPIO_MOCK_LAST` if present.
-    fn get_last(symbols: &Symbols) -> Option<i32> {
-        match symbols.get(&VarRef::new("__GPIO_MOCK_LAST", Some(ExprType::Integer))) {
-            Ok(Some(Symbol::Variable(Value::Integer(i)))) => Some(*i),
-            _ => None,
-        }
-    }
-
-    /// Obtains a mutable reference to `__GPIO_MOCK_DATA` if present.
-    fn get_mut_data(symbols: &mut Symbols) -> Option<&mut Array> {
-        match symbols.get_mut(&VarRef::new("__GPIO_MOCK_DATA", Some(ExprType::Integer))) {
-            Ok(Some(Symbol::Array(data))) if data.dimensions().len() == 1 => Some(data),
-            _ => None,
-        }
-    }
-
-    /// Reads the current value at `data[last]` with proper validation.
-    fn raw_get(last: i32, data: &Array) -> io::Result<i32> {
-        match data.index(&[last]) {
-            Ok(Value::Integer(v)) => Ok(*v),
-            Ok(_) => panic!("We know it's an integer"),
-            Err(e) => Err(io::Error::new(io::ErrorKind::InvalidData, e.to_string())),
-        }
-    }
-
-    /// Increments `__GPIO_MOCK_LAST`.
-    fn increment_last(&mut self) -> io::Result<()> {
-        let last = MockPins::get_last(self.symbols).expect("Validated at construction time");
-        let new_last = Value::Integer(last + 1);
-        match self
-            .symbols
-            .set_var(&VarRef::new("__GPIO_MOCK_LAST", Some(ExprType::Integer)), new_last)
-        {
-            Ok(()) => Ok(()),
-            Err(e) => Err(io::Error::new(io::ErrorKind::InvalidData, e.to_string())),
-        }
-    }
-
-    /// Reads `__GPIO_MOCK_DATA[__GPIO_MOCK_LAST]` and advances `__GPIO_MOCK_LAST`.  Returns the
-    /// position of the array that was read and the value at that position.
-    fn read_and_advance(&mut self) -> io::Result<(i32, i32)> {
-        let last = MockPins::get_last(self.symbols).expect("Validated at construction time");
-        let data = MockPins::get_mut_data(self.symbols).expect("Validated at construction time");
-
-        let v = MockPins::raw_get(last, data)?;
-        self.increment_last()?;
-        Ok((last, v))
-    }
-
-    /// Writes `datum` to `__GPIO_MOCK_DATA[__GPIO_MOCK_LAST]`, which must be zero upfront.
-    fn append(&mut self, datum: i32) -> io::Result<()> {
-        let last = MockPins::get_last(self.symbols).expect("Validated at construction time");
-        let data = MockPins::get_mut_data(self.symbols).expect("Validated at construction time");
-
-        let old_datum = MockPins::raw_get(last, data)?;
-        if old_datum != 0 {
-            return Err(io::Error::new(
-                io::ErrorKind::InvalidData,
-                format!("Position already occupied at __GPIO_MOCK_READ({})", last),
-            ));
-        }
-
-        let data = MockPins::get_mut_data(self.symbols).expect("Validated at construction time");
-        match data.assign(&[last], Value::Integer(datum)) {
-            Ok(()) => (),
-            Err(e) => return Err(io::Error::new(io::ErrorKind::InvalidData, e.to_string())),
-        };
-        self.increment_last()
+    /// Returns the ordered trace of all GPIO operations performed so far.
+    pub fn trace(&self) -> &[i32] {
+        &self.trace
     }
 }
 
-impl Pins for MockPins<'_> {
+impl Pins for MockPins {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn as_any_mut(&mut self) -> &mut dyn Any {
+        self
+    }
+
     fn setup(&mut self, pin: Pin, mode: PinMode) -> io::Result<()> {
         let datum = match mode {
             PinMode::In => MockOp::encode(pin, MockOp::SetupIn),
@@ -222,39 +123,41 @@ impl Pins for MockPins<'_> {
             PinMode::InPullUp => MockOp::encode(pin, MockOp::SetupInPullUp),
             PinMode::Out => MockOp::encode(pin, MockOp::SetupOut),
         };
-        self.append(datum)
+        self.trace.push(datum);
+        Ok(())
     }
 
     fn clear(&mut self, pin: Pin) -> io::Result<()> {
-        let datum = MockOp::encode(pin, MockOp::Clear);
-        self.append(datum)
+        self.trace.push(MockOp::encode(pin, MockOp::Clear));
+        Ok(())
     }
 
     fn clear_all(&mut self) -> io::Result<()> {
-        let datum = MockOp::ClearAll as i32;
-        self.append(datum)
+        self.trace.push(MockOp::ClearAll as i32);
+        Ok(())
     }
 
     fn read(&mut self, pin: Pin) -> io::Result<bool> {
-        let (pos, datum) = self.read_and_advance()?;
-        let (datum_pin, value) = MockOp::decode_read(pos, datum)?;
-        if datum_pin != pin {
-            return Err(io::Error::new(
+        match self.reads.pop_front() {
+            Some((read_pin, high)) if read_pin == pin => {
+                let op = if high { MockOp::ReadHigh } else { MockOp::ReadLow };
+                self.trace.push(MockOp::encode(pin, op));
+                Ok(high)
+            }
+            Some((read_pin, _)) => Err(io::Error::new(
                 io::ErrorKind::InvalidData,
-                format!(
-                    "Want to read pin {} but __GPIO_MOCK_DATA({}) is for pin {}",
-                    pin.0, pos, datum_pin.0
-                ),
-            ));
+                format!("Want to read pin {} but next mock read is for pin {}", pin.0, read_pin.0),
+            )),
+            None => Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!("No mock read available for pin {}", pin.0),
+            )),
         }
-        Ok(value)
     }
 
     fn write(&mut self, pin: Pin, v: bool) -> io::Result<()> {
-        if v {
-            self.append(MockOp::encode(pin, MockOp::WriteHigh))
-        } else {
-            self.append(MockOp::encode(pin, MockOp::WriteLow))
-        }
+        let op = if v { MockOp::WriteHigh } else { MockOp::WriteLow };
+        self.trace.push(MockOp::encode(pin, op));
+        Ok(())
     }
 }

--- a/std/src/gpio/mod.rs
+++ b/std/src/gpio/mod.rs
@@ -21,13 +21,14 @@ use endbasic_core::ast::{ArgSep, ExprType};
 use endbasic_core::compiler::{ArgSepSyntax, RequiredValueSyntax, SingularArgSyntax};
 use endbasic_core::exec::{Clearable, Error, Machine, Result, Scope};
 use endbasic_core::syms::{Callable, CallableMetadata, CallableMetadataBuilder, Symbols};
+use std::any::Any;
 use std::borrow::Cow;
 use std::cell::RefCell;
 use std::io;
 use std::rc::Rc;
 
 mod fakes;
-pub(crate) use fakes::{MockPins, NoopPins};
+pub use fakes::{MockPins, NoopPins};
 
 /// Category description for all symbols provided by this module.
 const CATEGORY: &str = "Hardware interface
@@ -83,6 +84,12 @@ impl PinMode {
 
 /// Generic abstraction over a GPIO chip to back all EndBASIC commands.
 pub trait Pins {
+    /// Returns `self` as `&dyn Any` to allow downcasting to a concrete type.
+    fn as_any(&self) -> &dyn Any;
+
+    /// Returns `self` as `&mut dyn Any` to allow downcasting to a concrete type.
+    fn as_any_mut(&mut self) -> &mut dyn Any;
+
     /// Configures the `pin` as either input or output (per `mode`).
     ///
     /// This lazily initialies the GPIO chip as well on the first pin setup.
@@ -116,11 +123,8 @@ impl PinsClearable {
 }
 
 impl Clearable for PinsClearable {
-    fn reset_state(&self, syms: &mut Symbols) {
-        let _ = match MockPins::try_new(syms) {
-            Some(mut pins) => pins.clear_all(),
-            None => self.pins.borrow_mut().clear_all(),
-        };
+    fn reset_state(&self, _syms: &mut Symbols) {
+        let _ = self.pins.borrow_mut().clear_all();
     }
 }
 
@@ -177,7 +181,7 @@ impl Callable for GpioSetupCommand {
         &self.metadata
     }
 
-    async fn exec(&self, mut scope: Scope<'_>, machine: &mut Machine) -> Result<()> {
+    async fn exec(&self, mut scope: Scope<'_>, _machine: &mut Machine) -> Result<()> {
         debug_assert_eq!(2, scope.nargs());
         let pin = {
             let (i, pos) = scope.pop_integer_with_pos();
@@ -188,10 +192,7 @@ impl Callable for GpioSetupCommand {
             PinMode::parse(&t, pos)?
         };
 
-        match MockPins::try_new(machine.get_mut_symbols()) {
-            Some(mut pins) => pins.setup(pin, mode).map_err(|e| scope.io_error(e))?,
-            None => self.pins.borrow_mut().setup(pin, mode).map_err(|e| scope.io_error(e))?,
-        };
+        self.pins.borrow_mut().setup(pin, mode).map_err(|e| scope.io_error(e))?;
         Ok(())
     }
 }
@@ -239,12 +240,9 @@ impl Callable for GpioClearCommand {
         &self.metadata
     }
 
-    async fn exec(&self, mut scope: Scope<'_>, machine: &mut Machine) -> Result<()> {
+    async fn exec(&self, mut scope: Scope<'_>, _machine: &mut Machine) -> Result<()> {
         if scope.nargs() == 0 {
-            match MockPins::try_new(machine.get_mut_symbols()) {
-                Some(mut pins) => pins.clear_all().map_err(|e| scope.io_error(e))?,
-                None => self.pins.borrow_mut().clear_all().map_err(|e| scope.io_error(e))?,
-            };
+            self.pins.borrow_mut().clear_all().map_err(|e| scope.io_error(e))?;
         } else {
             debug_assert_eq!(1, scope.nargs());
             let pin = {
@@ -252,10 +250,7 @@ impl Callable for GpioClearCommand {
                 Pin::from_i32(i, pos)?
             };
 
-            match MockPins::try_new(machine.get_mut_symbols()) {
-                Some(mut pins) => pins.clear(pin).map_err(|e| scope.io_error(e))?,
-                None => self.pins.borrow_mut().clear(pin).map_err(|e| scope.io_error(e))?,
-            };
+            self.pins.borrow_mut().clear(pin).map_err(|e| scope.io_error(e))?;
         }
 
         Ok(())
@@ -301,17 +296,14 @@ impl Callable for GpioReadFunction {
         &self.metadata
     }
 
-    async fn exec(&self, mut scope: Scope<'_>, machine: &mut Machine) -> Result<()> {
+    async fn exec(&self, mut scope: Scope<'_>, _machine: &mut Machine) -> Result<()> {
         debug_assert_eq!(1, scope.nargs());
         let pin = {
             let (i, pos) = scope.pop_integer_with_pos();
             Pin::from_i32(i, pos)?
         };
 
-        let value = match MockPins::try_new(machine.get_mut_symbols()) {
-            Some(mut pins) => pins.read(pin).map_err(|e| scope.io_error(e))?,
-            None => self.pins.borrow_mut().read(pin).map_err(|e| scope.io_error(e))?,
-        };
+        let value = self.pins.borrow_mut().read(pin).map_err(|e| scope.io_error(e))?;
         scope.return_boolean(value)
     }
 }
@@ -363,7 +355,7 @@ impl Callable for GpioWriteCommand {
         &self.metadata
     }
 
-    async fn exec(&self, mut scope: Scope<'_>, machine: &mut Machine) -> Result<()> {
+    async fn exec(&self, mut scope: Scope<'_>, _machine: &mut Machine) -> Result<()> {
         debug_assert_eq!(2, scope.nargs());
         let pin = {
             let (i, pos) = scope.pop_integer_with_pos();
@@ -371,16 +363,126 @@ impl Callable for GpioWriteCommand {
         };
         let value = scope.pop_boolean();
 
-        match MockPins::try_new(machine.get_mut_symbols()) {
-            Some(mut pins) => pins.write(pin, value).map_err(|e| scope.io_error(e))?,
-            None => self.pins.borrow_mut().write(pin, value).map_err(|e| scope.io_error(e))?,
-        };
+        self.pins.borrow_mut().write(pin, value).map_err(|e| scope.io_error(e))?;
         Ok(())
+    }
+}
+
+/// The `GPIO_MOCK_INJECT` command.
+pub struct GpioMockInjectCommand {
+    metadata: CallableMetadata,
+    pins: Rc<RefCell<dyn Pins>>,
+}
+
+impl GpioMockInjectCommand {
+    /// Creates a new instance of the command.
+    pub fn new(pins: Rc<RefCell<dyn Pins>>) -> Rc<Self> {
+        Rc::from(Self {
+            metadata: CallableMetadataBuilder::new("GPIO_MOCK_INJECT")
+                .with_syntax(&[(
+                    &[
+                        SingularArgSyntax::RequiredValue(
+                            RequiredValueSyntax {
+                                name: Cow::Borrowed("pin"),
+                                vtype: ExprType::Integer,
+                            },
+                            ArgSepSyntax::Exactly(ArgSep::Long),
+                        ),
+                        SingularArgSyntax::RequiredValue(
+                            RequiredValueSyntax {
+                                name: Cow::Borrowed("high"),
+                                vtype: ExprType::Boolean,
+                            },
+                            ArgSepSyntax::End,
+                        ),
+                    ],
+                    None,
+                )])
+                .with_category(CATEGORY)
+                .with_description(
+                    "Pre-seeds a GPIO_READ result for testing.
+This command is only available when EndBASIC is started with --gpio-pins=mock.  It pre-seeds \
+the next GPIO_READ call for the given pin% to return the given high? value.",
+                )
+                .build(),
+            pins,
+        })
+    }
+}
+
+#[async_trait(?Send)]
+impl Callable for GpioMockInjectCommand {
+    fn metadata(&self) -> &CallableMetadata {
+        &self.metadata
+    }
+
+    async fn exec(&self, mut scope: Scope<'_>, _machine: &mut Machine) -> Result<()> {
+        debug_assert_eq!(2, scope.nargs());
+        let pin = {
+            let (i, pos) = scope.pop_integer_with_pos();
+            Pin::from_i32(i, pos)?
+        };
+        let high = scope.pop_boolean();
+
+        self.pins
+            .borrow_mut()
+            .as_any_mut()
+            .downcast_mut::<MockPins>()
+            .expect("Only registered for mock backend")
+            .inject_read(pin, high);
+        Ok(())
+    }
+}
+
+/// The `GPIO_MOCK_TRACE` function.
+pub struct GpioMockTraceFunction {
+    metadata: CallableMetadata,
+    pins: Rc<RefCell<dyn Pins>>,
+}
+
+impl GpioMockTraceFunction {
+    /// Creates a new instance of the function.
+    pub fn new(pins: Rc<RefCell<dyn Pins>>) -> Rc<Self> {
+        Rc::from(Self {
+            metadata: CallableMetadataBuilder::new("GPIO_MOCK_TRACE")
+                .with_return_type(ExprType::Text)
+                .with_syntax(&[(&[], None)])
+                .with_category(CATEGORY)
+                .with_description(
+                    "Returns the GPIO operation trace for testing.
+This function is only available when EndBASIC is started with --gpio-pins=mock.  It returns a \
+space-separated list of integers representing the ordered record of all GPIO operations \
+performed since the last reset.",
+                )
+                .build(),
+            pins,
+        })
+    }
+}
+
+#[async_trait(?Send)]
+impl Callable for GpioMockTraceFunction {
+    fn metadata(&self) -> &CallableMetadata {
+        &self.metadata
+    }
+
+    async fn exec(&self, scope: Scope<'_>, _machine: &mut Machine) -> Result<()> {
+        debug_assert_eq!(0, scope.nargs());
+        let pins = self.pins.borrow();
+        let mock =
+            pins.as_any().downcast_ref::<MockPins>().expect("Only registered for mock backend");
+        let result = mock.trace().iter().map(|v| v.to_string()).collect::<Vec<_>>().join(" ");
+        scope.return_string(result)
     }
 }
 
 /// Adds all symbols provided by this module to the given `machine`.
 pub fn add_all(machine: &mut Machine, pins: Rc<RefCell<dyn Pins>>) {
+    if pins.borrow().as_any().downcast_ref::<MockPins>().is_some() {
+        machine.add_callable(GpioMockInjectCommand::new(pins.clone()));
+        machine.add_callable(GpioMockTraceFunction::new(pins.clone()));
+    }
+
     machine.add_clearable(PinsClearable::new(pins.clone()));
     machine.add_callable(GpioClearCommand::new(pins.clone()));
     machine.add_callable(GpioReadFunction::new(pins.clone()));
@@ -392,7 +494,7 @@ pub fn add_all(machine: &mut Machine, pins: Rc<RefCell<dyn Pins>>) {
 mod tests {
     use super::*;
     use crate::testutils::*;
-    use endbasic_core::ast::Value;
+    use futures_lite::future::block_on;
 
     /// Common checks for pin number validation.
     ///
@@ -414,48 +516,29 @@ mod tests {
         );
     }
 
-    /// Does a GPIO test using the mocking feature, running the commands in `code` and expecting
-    /// that the `__GPIO_MOCK_DATA` array contains `trace` after completion.
-    ///
-    /// Sets all `vars` before evaluating the expression so that the expression can contain variable
-    /// references.
-    fn do_mock_test_with_vars<S: Into<String>, VS: Into<Vec<(&'static str, Value)>>>(
-        code: S,
-        trace: &[i32],
-        vars: VS,
-    ) {
-        let code = code.into();
-        let vars = vars.into();
-
-        let mut exp_data = vec![Value::Integer(0); 50];
-        for (i, d) in trace.iter().enumerate() {
-            exp_data[i] = Value::Integer(*d);
+    /// Creates a machine backed by `MockPins` pre-seeded with `reads` and returns both the machine
+    /// and a handle to inspect the trace afterwards.
+    fn make_mock_machine(reads: &[(u8, bool)]) -> (Machine, Rc<RefCell<MockPins>>) {
+        let mock_pins = Rc::new(RefCell::new(MockPins::default()));
+        for &(pin, high) in reads {
+            mock_pins.borrow_mut().inject_read(Pin(pin), high);
         }
-
-        let mut t = Tester::default();
-        for var in vars.as_slice() {
-            t = t.set_var(var.0, var.1.clone());
-        }
-
-        let mut c = t
-            .run(format!(r#"DIM __GPIO_MOCK_DATA(50) AS INTEGER: __GPIO_MOCK_LAST = 0: {}"#, code));
-        for var in vars.into_iter() {
-            c = c.expect_var(var.0, var.1.clone());
-        }
-        c.expect_var("__GPIO_MOCK_LAST", Value::Integer(trace.len() as i32))
-            .expect_array_simple("__GPIO_MOCK_DATA", ExprType::Integer, exp_data)
-            .check();
+        let pins: Rc<RefCell<dyn Pins>> = mock_pins.clone();
+        let machine = crate::MachineBuilder::default().with_gpio_pins(pins).build().unwrap();
+        (machine, mock_pins)
     }
 
-    /// Does a GPIO test using the mocking feature, running the commands in `code` and expecting
-    /// that the `__GPIO_MOCK_DATA` array contains `trace` after completion.
-    fn do_mock_test<S: Into<String>>(code: S, trace: &[i32]) {
-        do_mock_test_with_vars(code, trace, [])
+    /// Runs `code` in a machine backed by MockPins pre-seeded with `reads` and asserts that the
+    /// resulting trace equals `expected_trace`.
+    fn do_mock_test(code: &str, reads: &[(u8, bool)], expected_trace: &[i32]) {
+        let (mut machine, mock_pins) = make_mock_machine(reads);
+        let _ = block_on(machine.exec(&mut code.as_bytes())).unwrap();
+        assert_eq!(expected_trace, mock_pins.borrow().trace());
     }
 
     /// Tests that all GPIO operations delegate to the real pins implementation, which defaults to
-    /// the no-op backend when using the tester.  All other tests in this file use the mocking
-    /// features to validate operation.
+    /// the no-op backend when using the tester.  All other tests in this file use MockPins via
+    /// `make_mock_machine` to validate operation.
     #[test]
     fn test_real_backend() {
         check_stmt_err("1:1: GPIO backend not compiled in", "GPIO_SETUP 0, \"IN\"");
@@ -468,26 +551,26 @@ mod tests {
     #[test]
     fn test_gpio_setup_ok() {
         for mode in &["in", "IN"] {
-            do_mock_test(format!(r#"GPIO_SETUP 5, "{}""#, mode), &[501]);
-            do_mock_test(format!(r#"GPIO_SETUP 5.2, "{}""#, mode), &[501]);
+            do_mock_test(&format!(r#"GPIO_SETUP 5, "{}""#, mode), &[], &[501]);
+            do_mock_test(&format!(r#"GPIO_SETUP 5.2, "{}""#, mode), &[], &[501]);
         }
         for mode in &["in-pull-down", "IN-PULL-DOWN"] {
-            do_mock_test(format!(r#"GPIO_SETUP 6, "{}""#, mode), &[602]);
-            do_mock_test(format!(r#"GPIO_SETUP 6.2, "{}""#, mode), &[602]);
+            do_mock_test(&format!(r#"GPIO_SETUP 6, "{}""#, mode), &[], &[602]);
+            do_mock_test(&format!(r#"GPIO_SETUP 6.2, "{}""#, mode), &[], &[602]);
         }
         for mode in &["in-pull-up", "IN-PULL-UP"] {
-            do_mock_test(format!(r#"GPIO_SETUP 7, "{}""#, mode), &[703]);
-            do_mock_test(format!(r#"GPIO_SETUP 7.2, "{}""#, mode), &[703]);
+            do_mock_test(&format!(r#"GPIO_SETUP 7, "{}""#, mode), &[], &[703]);
+            do_mock_test(&format!(r#"GPIO_SETUP 7.2, "{}""#, mode), &[], &[703]);
         }
         for mode in &["out", "OUT"] {
-            do_mock_test(format!(r#"GPIO_SETUP 8, "{}""#, mode), &[804]);
-            do_mock_test(format!(r#"GPIO_SETUP 8.2, "{}""#, mode), &[804]);
+            do_mock_test(&format!(r#"GPIO_SETUP 8, "{}""#, mode), &[], &[804]);
+            do_mock_test(&format!(r#"GPIO_SETUP 8.2, "{}""#, mode), &[], &[804]);
         }
     }
 
     #[test]
     fn test_gpio_setup_multiple() {
-        do_mock_test(r#"GPIO_SETUP 18, "IN-PULL-UP": GPIO_SETUP 10, "OUT""#, &[1803, 1004]);
+        do_mock_test(r#"GPIO_SETUP 18, "IN-PULL-UP": GPIO_SETUP 10, "OUT""#, &[], &[1803, 1004]);
     }
 
     #[test]
@@ -504,13 +587,13 @@ mod tests {
 
     #[test]
     fn test_gpio_clear_all() {
-        do_mock_test("GPIO_CLEAR", &[-1]);
+        do_mock_test("GPIO_CLEAR", &[], &[-1]);
     }
 
     #[test]
     fn test_gpio_clear_one() {
-        do_mock_test("GPIO_CLEAR 4", &[405]);
-        do_mock_test("GPIO_CLEAR 4.1", &[405]);
+        do_mock_test("GPIO_CLEAR 4", &[], &[405]);
+        do_mock_test("GPIO_CLEAR 4.1", &[], &[405]);
     }
 
     #[test]
@@ -523,13 +606,12 @@ mod tests {
 
     #[test]
     fn test_gpio_read_ok() {
-        do_mock_test_with_vars(
-            "__GPIO_MOCK_DATA(0) = 310
-            __GPIO_MOCK_DATA(2) = 311
-            GPIO_WRITE 5, GPIO_READ(3.1)
-            GPIO_WRITE 7, GPIO_READ(pin)",
+        // Read pin 3 (low → GPIO_WRITE 5 low), then read pin 3 (high → GPIO_WRITE 7 high).
+        // GPIO_READ evaluates before GPIO_WRITE, so trace is: read3low, write5low, read3high, write7high.
+        do_mock_test(
+            "GPIO_WRITE 5, GPIO_READ(3.1): GPIO_WRITE 7, GPIO_READ(3)",
+            &[(3, false), (3, true)],
             &[310, 520, 311, 721],
-            [("pin", 3.into())],
         );
     }
 
@@ -543,7 +625,7 @@ mod tests {
 
     #[test]
     fn test_gpio_write_ok() {
-        do_mock_test("GPIO_WRITE 3, TRUE: GPIO_WRITE 3.1, FALSE", &[321, 320]);
+        do_mock_test("GPIO_WRITE 3, TRUE: GPIO_WRITE 3.1, FALSE", &[], &[321, 320]);
     }
 
     #[test]

--- a/std/src/testutils.rs
+++ b/std/src/testutils.rs
@@ -396,11 +396,9 @@ impl Default for Tester {
         let console = Rc::from(RefCell::from(MockConsole::default()));
         let program = Rc::from(RefCell::from(RecordedProgram::default()));
 
-        // Default to the pins set that always returns errors.  We could have implemented a set of
-        // fake pins here to track GPIO state changes in a nicer way, similar to how we track all
-        // other machine state... but the GPIO module already implements its own mocking feature.
-        // The mocking feature is necessary for integration testing in any case, so we just use that
-        // everywhere instead of having yet another implementation in this module.
+        // Default to the no-op pins that always return errors.  GPIO unit tests use MockPins
+        // directly via `make_mock_machine` to validate operation; this Tester wiring is only used
+        // for the error-path tests that go through the real (NoopPins) backend.
         let gpio_pins = Rc::from(RefCell::from(gpio::NoopPins::default()));
 
         let mut builder = crate::MachineBuilder::default()


### PR DESCRIPTION
Replace the old MockPins implementation, which borrowed the machine's symbol table at call time and required users to set up __GPIO_MOCK_DATA and __GPIO_MOCK_LAST variables, with a self-contained MockPins that maintains its own reads queue and operation trace.

Add a GPIO_MOCK_INJECT command and a GPIO_MOCK_TRACE function (registered only with --gpio-pins=mock) to pre-seed reads and dump the trace, and add a --gpio-pins CLI flag to select between rppal, noop, and mock backends.  Rewrite the gpio.bas integration test to use these commands instead of the old magic variables.  Update all unit tests to use the new make_mock_machine helper directly.