### PR TITLE
Fix staging deployment

### DIFF
--- a/.github/workflows/publish.sh
+++ b/.github/workflows/publish.sh
@@ -28,7 +28,11 @@ nvm install --lts
 set -ux
 
 rustup target add wasm32-unknown-unknown
-wasm_bindgen_version="$(grep '^wasm-bindgen = ' web/Cargo.toml | cut -d '"' -f 2)"
+wasm_bindgen_version="$(
+    grep -A1 '^name = "wasm-bindgen"$' Cargo.lock \
+        | grep '^version' \
+        | cut -d '"' -f 2
+)"
 cargo binstall --no-confirm "wasm-bindgen-cli@${wasm_bindgen_version}"
 
 export NVM_DIR="${HOME}/.nvm"


### PR DESCRIPTION
Commit 2d5a6672ac2d5c9d13d751d5f6f40cb1d4a2a318 migrated from wasm-pack to using wasm-bindgen directly and, as part of that, I tried to pin its version to whatever the Cargo.toml file says.  That's incorrect though, because we need the precise version in Cargo.lock to avoid different versions between Cargo and wasm-bindgen-cli.  Fix it now.