### PR TITLE
Make AGPLv3 website compliance easier

### DIFF
--- a/web/README.md
+++ b/web/README.md
@@ -28,3 +28,14 @@ a minimal web interface to it.
 Visit the following address for a live deployment of the EndBASIC interpreter!
 
 > https://repl.endbasic.dev/
+
+## AGPLv3 deployment metadata
+
+When producing a web build, you can customize the compliance and support links
+embedded in the footer:
+
+* `SOURCE_CODE_URL`: URL where users can fetch corresponding source code.
+* `LICENSE_URL`: URL to the license text presented to users.
+* `ISSUES_URL`: URL where users can report issues.
+
+These are optional and default to the upstream EndBASIC URLs.

--- a/web/src/index.html
+++ b/web/src/index.html
@@ -27,6 +27,10 @@
             &nbsp;&middot;&nbsp;
             <span id="terminal-size">0x0 pixels, 0x0 chars</span>
             &nbsp;&middot;&nbsp;
+            <a id="source-code" href="https://github.com/endbasic/endbasic">Source code</a>
+            &nbsp;&middot;&nbsp;
+            <a id="license" href="https://www.gnu.org/licenses/agpl-3.0.html">License</a>
+            &nbsp;&middot;&nbsp;
             <a id="report-issue" href="https://github.com/endbasic/endbasic/issues/new">Report
             an issue</a>
         </footer>

--- a/web/src/index.js
+++ b/web/src/index.js
@@ -28,9 +28,17 @@ var isAndroid = /\bAndroid\b/i.test(UA);
 var buildId = endbasic_web.get_build_id();
 $('#build-id').text(buildId);
 
+function addIssueBodyTemplate(url, template) {
+    if (url.indexOf("?") == -1) {
+        return url + "?body=" + encodeURIComponent(template);
+    }
+    return url + "&body=" + encodeURIComponent(template);
+}
+
 var template = "Build ID: " + buildId;
-$('#report-issue').attr(
-    "href", "https://github.com/endbasic/endbasic/issues/new?body=" + template);
+$('#source-code').attr("href", __SOURCE_CODE_URL__);
+$('#license').attr("href", __LICENSE_URL__);
+$('#report-issue').attr("href", addIssueBodyTemplate(__ISSUES_URL__, template));
 
 let terminal = document.getElementById('terminal');
 

--- a/web/webpack.config.js
+++ b/web/webpack.config.js
@@ -9,14 +9,33 @@ function getServiceUrl() {
     var node_env = process.env.NODE_ENV;
     switch (node_env) {
         case "prod":
-            return "'https://service.endbasic.dev/'";
+            return "https://service.endbasic.dev/";
         case "staging":
-            return "'https://service-staging.endbasic.dev/'";
+            return "https://service-staging.endbasic.dev/";
         case "local":
-            return "'http://localhost:7071/'";
+            return "http://localhost:7071/";
         default:
             throw new Error("Invalid NODE_ENV VALUE: " + node_env);
     }
+}
+
+function getStringEnvVar(name, fallback) {
+    if (process.env[name]) {
+        return process.env[name];
+    }
+    return fallback;
+}
+
+function getSourceCodeUrl() {
+    return getStringEnvVar("SOURCE_CODE_URL", "https://github.com/endbasic/endbasic");
+}
+
+function getLicenseUrl() {
+    return getStringEnvVar("LICENSE_URL", "https://www.gnu.org/licenses/agpl-3.0.html");
+}
+
+function getIssuesUrl() {
+    return getStringEnvVar("ISSUES_URL", "https://github.com/endbasic/endbasic/issues/new");
 }
 
 module.exports = {
@@ -68,7 +87,10 @@ module.exports = {
         }),
 
         new DefinePlugin({
-            __SERVICE_URL__: getServiceUrl()
+            __SERVICE_URL__: JSON.stringify(getServiceUrl()),
+            __SOURCE_CODE_URL__: JSON.stringify(getSourceCodeUrl()),
+            __LICENSE_URL__: JSON.stringify(getLicenseUrl()),
+            __ISSUES_URL__: JSON.stringify(getIssuesUrl())
         })
     ],
 };


### PR DESCRIPTION
Now that the project is AGPLv3 per the core2 rewrite, we should make compliance easier.  To do so, add various customizable links to the project's source code page and put them in the website footer.