### PR TITLE
Add support for the Delete key in line editing

### DIFF
--- a/repl/src/editor.rs
+++ b/repl/src/editor.rs
@@ -364,6 +364,22 @@ impl Editor {
                     self.dirty = true;
                 }
 
+                Key::Delete => {
+                    let line = &mut self.content[self.file_pos.line];
+                    if self.file_pos.col < line.len() {
+                        line.remove(self.file_pos.col);
+                        // TODO(jmmv): Refresh only the affected line.
+                        need_refresh = true;
+                        self.dirty = true;
+                    } else if self.file_pos.line < self.content.len() - 1 {
+                        let next_line = self.content.remove(self.file_pos.line + 1);
+                        let current_line = &mut self.content[self.file_pos.line];
+                        current_line.push_str(&next_line);
+                        need_refresh = true;
+                        self.dirty = true;
+                    }
+                }
+
                 Key::End => {
                     self.file_pos.col = self.content[self.file_pos.line].len();
                     self.insert_col = self.file_pos.col;

--- a/sdl/src/host.rs
+++ b/sdl/src/host.rs
@@ -146,6 +146,7 @@ fn parse_event(event: Event) -> Option<Key> {
             Keycode::P if keymod.intersects(ctrl_mods) => Some(Key::ArrowUp),
 
             Keycode::Backspace => Some(Key::Backspace),
+            Keycode::Delete => Some(Key::Delete),
             Keycode::End => Some(Key::End),
             Keycode::Escape => Some(Key::Escape),
             Keycode::Home => Some(Key::Home),

--- a/std/src/console/cmds.rs
+++ b/std/src/console/cmds.rs
@@ -254,6 +254,7 @@ impl Callable for InKeyFunction {
             Some(Key::Backspace) => "BS".to_owned(),
             Some(Key::CarriageReturn) => "ENTER".to_owned(),
             Some(Key::Char(x)) => format!("{}", x),
+            Some(Key::Delete) => "DEL".to_owned(),
             Some(Key::End) => "END".to_owned(),
             Some(Key::Eof) => "EOF".to_owned(),
             Some(Key::Escape) => "ESC".to_owned(),

--- a/std/src/console/mod.rs
+++ b/std/src/console/mod.rs
@@ -70,6 +70,9 @@ pub enum Key {
     /// A printable character.
     Char(char),
 
+    /// Deletes the next character.
+    Delete,
+
     /// The end key or `Ctrl-E`.
     End,
 

--- a/std/src/console/readline.rs
+++ b/std/src/console/readline.rs
@@ -214,6 +214,21 @@ async fn read_line_interactive(
                 pos += 1;
             }
 
+            Key::Delete => {
+                if pos < line.len() {
+                    console.hide_cursor()?;
+                    if echo {
+                        console.write(&line.end(pos + 1))?;
+                    } else {
+                        console.write(&SECURE_CHAR.repeat(line.len() - pos - 1))?;
+                    }
+                    console.write(" ")?;
+                    console.move_within_line(-((line.len() - pos) as i16))?;
+                    console.show_cursor()?;
+                    line.remove(pos);
+                }
+            }
+
             Key::End => {
                 let offset = line.len() - pos;
                 if offset > 0 {
@@ -287,6 +302,7 @@ async fn read_line_raw(console: &mut dyn Console) -> io::Result<String> {
                 }
             }
             Key::Char(ch) => line.push(ch),
+            Key::Delete => (),
             Key::End | Key::Home => (),
             Key::Escape => (),
             Key::Eof => return Err(io::Error::new(io::ErrorKind::UnexpectedEof, "EOF")),
@@ -745,6 +761,51 @@ mod tests {
     }
 
     #[test]
+    fn test_read_line_interactive_delete_trailing() {
+        ReadLineInteractiveTest::default()
+            .add_key_chars("abc")
+            .add_output_bytes("abc")
+            // -
+            .add_key(Key::Delete)
+            // -
+            .set_line("abc")
+            .accept();
+    }
+
+    #[test]
+    fn test_read_line_interactive_delete_middle() {
+        ReadLineInteractiveTest::default()
+            .add_key_chars("has a tYpo")
+            .add_output_bytes("has a tYpo")
+            // -
+            .add_key(Key::ArrowLeft)
+            .add_output(CapturedOut::MoveWithinLine(-1))
+            // -
+            .add_key(Key::ArrowLeft)
+            .add_output(CapturedOut::MoveWithinLine(-1))
+            // -
+            .add_key(Key::ArrowLeft)
+            .add_output(CapturedOut::MoveWithinLine(-1))
+            // -
+            .add_key(Key::Delete)
+            .add_output(CapturedOut::HideCursor)
+            .add_output(CapturedOut::Write("po".to_string()))
+            .add_output_bytes(" ")
+            .add_output(CapturedOut::MoveWithinLine(-3))
+            .add_output(CapturedOut::ShowCursor)
+            // -
+            .add_key_chars("y")
+            .add_output(CapturedOut::HideCursor)
+            .add_output_bytes("y")
+            .add_output(CapturedOut::Write("po".to_string()))
+            .add_output(CapturedOut::MoveWithinLine(-2))
+            .add_output(CapturedOut::ShowCursor)
+            // -
+            .set_line("has a typo")
+            .accept();
+    }
+
+    #[test]
     fn test_read_line_interactive_test_move_bounds() {
         ReadLineInteractiveTest::default()
             .set_previous("12")
@@ -1119,6 +1180,10 @@ mod tests {
             .add_output_bytes("affected")
             // -
             .set_line("not affected")
+            .accept();
+
+        ReadLineInteractiveTest::default()
+            .add_key(Key::Delete)
             .accept();
     }
 

--- a/std/src/console/readline.rs
+++ b/std/src/console/readline.rs
@@ -1224,6 +1224,32 @@ mod tests {
     }
 
     #[test]
+    fn test_read_line_without_echo_delete() {
+        ReadLineInteractiveTest::default()
+            .set_echo(false)
+            .set_prompt("> ")
+            .set_previous("secret")
+            .add_output(CapturedOut::Write("> ******".to_string()))
+            .add_output(CapturedOut::SyncNow)
+            // -
+            .add_key(Key::Home)
+            .add_output(CapturedOut::MoveWithinLine(-6))
+            // -
+            .add_key(Key::ArrowRight)
+            .add_output(CapturedOut::MoveWithinLine(1))
+            // -
+            .add_key(Key::Delete)
+            .add_output(CapturedOut::HideCursor)
+            .add_output(CapturedOut::Write("****".to_string()))
+            .add_output_bytes(" ")
+            .add_output(CapturedOut::MoveWithinLine(-5))
+            .add_output(CapturedOut::ShowCursor)
+            // -
+            .set_line("scret")
+            .accept();
+    }
+
+    #[test]
     fn test_read_line_secure_trivial_test() {
         let mut console = MockConsole::default();
         console.set_interactive(true);

--- a/terminal/src/lib.rs
+++ b/terminal/src/lib.rs
@@ -120,6 +120,7 @@ impl TerminalConsole {
 
                     match ev.code {
                         KeyCode::Backspace => Key::Backspace,
+                        KeyCode::Delete => Key::Delete,
                         KeyCode::End => Key::End,
                         KeyCode::Esc => Key::Escape,
                         KeyCode::Home => Key::Home,

--- a/web/src/input.rs
+++ b/web/src/input.rs
@@ -53,6 +53,7 @@ fn on_key_event_into_key(dom_event: KeyboardEvent) -> Key {
         38 => Key::ArrowUp,
         39 => Key::ArrowRight,
         40 => Key::ArrowDown,
+        46 => Key::Delete,
         b'A' if dom_event.ctrl_key() => Key::Home,
         b'B' if dom_event.ctrl_key() => Key::ArrowLeft,
         b'C' if dom_event.ctrl_key() => Key::Interrupt,


### PR DESCRIPTION
## Summary

- Implement Delete key handling in the editor and readline, following the existing Backspace pattern
- Add `Key::Delete` variant to the key enum with mappings across all console backends (SDL, terminal, web)
- Delete key removes the character at the cursor position; at end of line, it joins the next line (editor only)

Fixes #221

## Test plan

- [x] 397/397 tests pass (`cargo test`)
- [x] Zero clippy warnings
- [x] 4 new tests cover Delete key in readline (mid-line, end-of-line, empty input, echo disabled)
- [x] SDL, terminal, web, and REPL backends all handle the new key variant