### PR TITLE
Replace npm scripts with a Makefile

### DIFF
--- a/.github/workflows/publish.sh
+++ b/.github/workflows/publish.sh
@@ -27,7 +27,6 @@ set +ux
 nvm install --lts
 set -ux
 
-rustup target add wasm32-unknown-unknown
 wasm_bindgen_version="$(
     grep -A1 '^name = "wasm-bindgen"$' Cargo.lock \
         | grep '^version' \
@@ -43,8 +42,7 @@ nvm use --lts
 set -ux
 
 cd web
-npm ci --verbose
-npm run-script "build:${node_env}" --verbose
-npm run-script test --verbose
+make NODE_ENV="${node_env}" test
+make NODE_ENV="${node_env}" build-release
 touch dist/.nojekyll
 cd -

--- a/Makefile
+++ b/Makefile
@@ -51,9 +51,20 @@ regen-sdl:
 	    RUST_BACKTRACE=1 \
 	    cargo test $(TEST_ARGS) -- --include-ignored
 
-
 .PHONY: test-sdl
 test-sdl:
 	@cd sdl && \
 	    RUST_BACKTRACE=1 \
 	    cargo test $(TEST_ARGS) -- --include-ignored
+
+.PHONY: start-web-debug
+start-web-debug:
+	$(MAKE) -C web start-debug
+
+.PHONY: start-web-release
+start-web-release:
+	$(MAKE) -C web start-release
+
+.PHONY: test-web
+test-web:
+	$(MAKE) -C web test

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,4 @@
 [toolchain]
 channel = "1.96"
 components = ["clippy", "rust-analyzer", "rustfmt"]
+targets = ["wasm32-unknown-unknown"]

--- a/web/Makefile
+++ b/web/Makefile
@@ -1,0 +1,69 @@
+# EndBASIC
+# Copyright 2026 Julio Merino
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+# EndBASIC Service endpoint to connect to.
+#
+# Can be one of `prod`, `staging`, or `local`.  Refer to `package.json` for the
+# authoritative list.
+NODE_ENV = prod
+
+# Launcher for webpack with the correct configuration.
+WEBPACK = env NODE_ENV="$(NODE_ENV)" ./node_modules/.bin/webpack
+
+node_modules/.stamp: package.json package-lock.json
+	@if test "$${CI:-unset}" = unset; then \
+	    echo "npm install"; \
+	    npm install; \
+    else \
+	    echo "npm ci --verbose"; \
+	    npm ci --verbose; \
+	fi
+	touch $@
+
+.PHONY: build-debug
+build-debug: node_modules/.stamp
+	cargo build --target wasm32-unknown-unknown
+	wasm-bindgen --target bundler --out-dir pkg --out-name index \
+	    ../target/wasm32-unknown-unknown/debug/endbasic_web.wasm
+	$(WEBPACK) --mode=development
+
+.PHONY: build-release
+build-release: node_modules/.stamp
+	cargo build --target wasm32-unknown-unknown --release
+	wasm-bindgen --target bundler --out-dir pkg --out-name index \
+	    ../target/wasm32-unknown-unknown/release/endbasic_web.wasm
+	wasm-opt -O3 -o pkg/index_bg.wasm pkg/index_bg.wasm
+	$(WEBPACK) --mode=production
+
+.PHONY: start-debug
+start-debug: build-debug
+	$(WEBPACK) serve --mode=development
+
+.PHONY: start-release
+start-release: build-release
+	$(WEBPACK) serve --mode=production
+
+.PHONY: test
+test: node_modules/.stamp
+	cargo test
+	env \
+	    GECKODRIVER=./node_modules/.bin/geckodriver \
+	    CARGO_TARGET_WASM32_UNKNOWN_UNKNOWN_RUNNER=wasm-bindgen-test-runner \
+	    cargo test --target wasm32-unknown-unknown
+
+.PHONY: clean
+clean:
+	rm -rf dist pkg

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -15,7 +15,6 @@
                 "copy-webpack-plugin": "^14.0.0",
                 "geckodriver": "^6.1.0",
                 "html-webpack-plugin": "^5.6.3",
-                "rimraf": "^6.0.1",
                 "webpack": "^5.96.1",
                 "webpack-cli": "^5.1.4",
                 "webpack-dev-server": "^5.1.0"
@@ -1379,16 +1378,6 @@
                 "node": ">=12.0.0"
             }
         },
-        "node_modules/balanced-match": {
-            "version": "4.0.4",
-            "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
-            "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": "18 || 20 || >=22"
-            }
-        },
         "node_modules/baseline-browser-mapping": {
             "version": "2.10.21",
             "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.21.tgz",
@@ -1480,19 +1469,6 @@
             "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==",
             "dev": true,
             "license": "ISC"
-        },
-        "node_modules/brace-expansion": {
-            "version": "5.0.5",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-            "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "balanced-match": "^4.0.2"
-            },
-            "engines": {
-                "node": "18 || 20 || >=22"
-            }
         },
         "node_modules/braces": {
             "version": "3.0.3",
@@ -2600,24 +2576,6 @@
                 "node": ">= 0.4"
             }
         },
-        "node_modules/glob": {
-            "version": "13.0.6",
-            "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
-            "integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
-            "dev": true,
-            "license": "BlueOak-1.0.0",
-            "dependencies": {
-                "minimatch": "^10.2.2",
-                "minipass": "^7.1.3",
-                "path-scurry": "^2.0.2"
-            },
-            "engines": {
-                "node": "18 || 20 || >=22"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/isaacs"
-            }
-        },
         "node_modules/glob-parent": {
             "version": "6.0.2",
             "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
@@ -3378,16 +3336,6 @@
                 "tslib": "^2.0.3"
             }
         },
-        "node_modules/lru-cache": {
-            "version": "11.3.5",
-            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.5.tgz",
-            "integrity": "sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw==",
-            "dev": true,
-            "license": "BlueOak-1.0.0",
-            "engines": {
-                "node": "20 || >=22"
-            }
-        },
         "node_modules/math-intrinsics": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
@@ -3544,32 +3492,6 @@
             "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==",
             "dev": true,
             "license": "ISC"
-        },
-        "node_modules/minimatch": {
-            "version": "10.2.5",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
-            "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
-            "dev": true,
-            "license": "BlueOak-1.0.0",
-            "dependencies": {
-                "brace-expansion": "^5.0.5"
-            },
-            "engines": {
-                "node": "18 || 20 || >=22"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/isaacs"
-            }
-        },
-        "node_modules/minipass": {
-            "version": "7.1.3",
-            "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
-            "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
-            "dev": true,
-            "license": "BlueOak-1.0.0",
-            "engines": {
-                "node": ">=16 || 14 >=14.17"
-            }
         },
         "node_modules/modern-tar": {
             "version": "0.7.6",
@@ -3779,13 +3701,6 @@
                 "node": ">=6"
             }
         },
-        "node_modules/package-json-from-dist": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
-            "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
-            "dev": true,
-            "license": "BlueOak-1.0.0"
-        },
         "node_modules/param-case": {
             "version": "3.0.4",
             "resolved": "https://registry.npmjs.org/param-case/-/param-case-3.0.4.tgz",
@@ -3844,23 +3759,6 @@
             "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
             "dev": true,
             "license": "MIT"
-        },
-        "node_modules/path-scurry": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
-            "integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
-            "dev": true,
-            "license": "BlueOak-1.0.0",
-            "dependencies": {
-                "lru-cache": "^11.0.0",
-                "minipass": "^7.1.2"
-            },
-            "engines": {
-                "node": "18 || 20 || >=22"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/isaacs"
-            }
         },
         "node_modules/path-to-regexp": {
             "version": "0.1.13",
@@ -4189,26 +4087,6 @@
             "license": "MIT",
             "engines": {
                 "node": ">= 4"
-            }
-        },
-        "node_modules/rimraf": {
-            "version": "6.1.3",
-            "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-6.1.3.tgz",
-            "integrity": "sha512-LKg+Cr2ZF61fkcaK1UdkH2yEBBKnYjTyWzTJT6KNPcSPaiT7HSdhtMXQuN5wkTX0Xu72KQ1l8S42rlmexS2hSA==",
-            "dev": true,
-            "license": "BlueOak-1.0.0",
-            "dependencies": {
-                "glob": "^13.0.3",
-                "package-json-from-dist": "^1.0.1"
-            },
-            "bin": {
-                "rimraf": "dist/esm/bin.mjs"
-            },
-            "engines": {
-                "node": "20 || >=22"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/isaacs"
             }
         },
         "node_modules/run-applescript": {

--- a/web/package.json
+++ b/web/package.json
@@ -3,23 +3,6 @@
     "version": "0.13.99",
     "description": "The EndBASIC programming language - web interface",
     "private": true,
-    "scripts": {
-        "_wasm:build:release": "cargo build --target wasm32-unknown-unknown --release && wasm-bindgen --target bundler --out-dir pkg --out-name index ../target/wasm32-unknown-unknown/release/endbasic_web.wasm && wasm-opt -O3 -o pkg/index_bg.wasm pkg/index_bg.wasm",
-        "_wasm:build:debug": "cargo build --target wasm32-unknown-unknown && wasm-bindgen --target bundler --out-dir pkg --out-name index ../target/wasm32-unknown-unknown/debug/endbasic_web.wasm",
-        "_build:release": "npm run _wasm:build:release && webpack --mode=production",
-        "_build:debug": "npm run _wasm:build:debug && webpack --mode=development",
-        "build:prod": "NODE_ENV=prod npm run _build:release",
-        "build:staging": "NODE_ENV=staging npm run _build:release",
-        "build:local": "NODE_ENV=local npm run _build:debug",
-        "_start:release": "webpack serve --mode=production",
-        "_start:debug": "webpack serve --mode=development",
-        "start:prod": "NODE_ENV=prod npm run _start:release",
-        "start:staging": "NODE_ENV=staging npm run _start:release",
-        "start:local": "NODE_ENV=local npm run _start:debug",
-        "test:wasm": "GECKODRIVER=./node_modules/.bin/geckodriver CARGO_TARGET_WASM32_UNKNOWN_UNKNOWN_RUNNER=wasm-bindgen-test-runner cargo test --target wasm32-unknown-unknown",
-        "test": "cargo test && npm run test:wasm",
-        "clean": "rimraf dist pkg"
-    },
     "repository": {
         "type": "git",
         "url": "git+https://github.com/endbasic/endbasic.git"
@@ -43,7 +26,6 @@
         "copy-webpack-plugin": "^14.0.0",
         "geckodriver": "^6.1.0",
         "html-webpack-plugin": "^5.6.3",
-        "rimraf": "^6.0.1",
         "webpack": "^5.96.1",
         "webpack-cli": "^5.1.4",
         "webpack-dev-server": "^5.1.0"


### PR DESCRIPTION
We already have a top-level Makefile, and I find it quite annoying to have to remember a different workflow for the "web" directory.  Also, the scripts section in package.json has become unwieldy and it's hard to read.

Try to simplify this by moving the build logic to a Makefile and expose the couple of useful targets for day-to-day use at the top-level.

The motivation for this change is that I wanted to add the ability to launch the web interface built in debug mode (to avoid the wasm-opt expensive call) while using the prod backend... but there currently was no way to do it -- and retrofitting the change in the existing coe was ugly.

While doing this, install the wasm target via rust-toolchain.toml instead of special-casing this throughout.  This is a little bit less efficient but keeps things simpler.