### PR TITLE
Add Delete support, fix Ctrl+D inconsistencies, and optimize

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -56,6 +56,9 @@ for the time being.**
 
 *   Issue #221: Added support for the delete key in the editor and readline.
 
+*   Fixed Ctrl-D so that it does not produce an EOF (and thus does not exit
+    the interpreter) when pressed within a non-empty line.
+
 ## Changes in version 0.13.0
 
 **Released on 2026-05-29.**

--- a/NEWS.md
+++ b/NEWS.md
@@ -54,6 +54,8 @@ for the time being.**
 *   Fixed various issues in the web and SDL consoles with blanking new lines
     and the whole screen when a non-default color is set.
 
+*   Issue #221: Added support for the delete key in the editor and readline.
+
 ## Changes in version 0.13.0
 
 **Released on 2026-05-29.**

--- a/repl/src/editor.rs
+++ b/repl/src/editor.rs
@@ -72,6 +72,26 @@ struct FilePos {
     col: usize,
 }
 
+/// Describes how much of the editor view must be repainted.
+///
+/// Order is important!  Later entries in this enum mean that "more" of the viewport must
+/// be refreshed.
+#[derive(Clone, Copy, Eq, Ord, PartialEq, PartialOrd)]
+enum RefreshKind {
+    None,
+    CurrentLine,
+    Full,
+}
+
+impl RefreshKind {
+    /// Upgrades `self` to at least `new_value`.
+    fn upgrade(&mut self, new_value: Self) {
+        if new_value > *self {
+            *self = new_value;
+        }
+    }
+}
+
 /// An interactive console-based text editor.
 ///
 /// The text editor owns the textual contents it is editing.
@@ -192,6 +212,38 @@ impl Editor {
         Ok(())
     }
 
+    /// Refreshes only the line under the cursor, using the previously queried `console_size`.
+    fn refresh_current_line(
+        &self,
+        console: &mut dyn Console,
+        console_size: CharsXY,
+    ) -> io::Result<()> {
+        debug_assert!(self.file_pos.line >= self.viewport_pos.line);
+        debug_assert!(
+            self.file_pos.line < self.viewport_pos.line + usize::from(console_size.y - 1)
+        );
+
+        let row = self.file_pos.line - self.viewport_pos.line;
+        let row = if cfg!(debug_assertions) {
+            u16::try_from(row).expect("Computed y must have fit on screen")
+        } else {
+            row as u16
+        };
+
+        console.set_color(TEXT_COLOR.0, TEXT_COLOR.1)?;
+        console.locate(CharsXY::new(0, row))?;
+        console.clear(ClearType::CurrentLine)?;
+
+        let line = &self.content[self.file_pos.line];
+        if line.len() > self.viewport_pos.col {
+            console.write(&line.range(
+                self.viewport_pos.col,
+                self.viewport_pos.col + usize::from(console_size.x),
+            ))?;
+        }
+        Ok(())
+    }
+
     /// Moves the cursor down by the given number of lines in `nlines` or to the last line if there
     /// are insufficient lines to perform the move.
     fn move_down(&mut self, nlines: usize) {
@@ -226,7 +278,7 @@ impl Editor {
             self.content.push(LineBuffer::default());
         }
 
-        let mut need_refresh = true;
+        let mut refresh = RefreshKind::Full;
         loop {
             // The key handling below only deals with moving the insertion position within the file
             // but does not bother to update the viewport. Adjust it now, if necessary.
@@ -234,22 +286,22 @@ impl Editor {
             let height = usize::from(console_size.y);
             if self.file_pos.line < self.viewport_pos.line {
                 self.viewport_pos.line = self.file_pos.line;
-                need_refresh = true;
+                refresh.upgrade(RefreshKind::Full);
             } else if self.file_pos.line > self.viewport_pos.line + height - 2 {
                 if self.file_pos.line > height - 2 {
                     self.viewport_pos.line = self.file_pos.line - (height - 2);
                 } else {
                     self.viewport_pos.line = 0;
                 }
-                need_refresh = true;
+                refresh.upgrade(RefreshKind::Full);
             }
 
             if self.file_pos.col < self.viewport_pos.col {
                 self.viewport_pos.col = self.file_pos.col;
-                need_refresh = true;
+                refresh.upgrade(RefreshKind::Full);
             } else if self.file_pos.col >= self.viewport_pos.col + width {
                 self.viewport_pos.col = self.file_pos.col - width + 1;
-                need_refresh = true;
+                refresh.upgrade(RefreshKind::Full);
             }
 
             // TODO(jmmv): We must handle the cursor visibility outside of the non-sync block
@@ -257,13 +309,18 @@ impl Editor {
             // when syncing is disabled.  This is suboptimal and should be fixed by decoupling
             // the two properties...
             console.hide_cursor()?;
-            if need_refresh {
-                self.refresh(console, console_size)?;
-                need_refresh = false;
-            } else {
-                self.refresh_status(console, console_size)?;
-                console.set_color(TEXT_COLOR.0, TEXT_COLOR.1)?;
+            match refresh {
+                RefreshKind::Full => self.refresh(console, console_size)?,
+                RefreshKind::CurrentLine => {
+                    self.refresh_status(console, console_size)?;
+                    self.refresh_current_line(console, console_size)?;
+                }
+                RefreshKind::None => {
+                    self.refresh_status(console, console_size)?;
+                    console.set_color(TEXT_COLOR.0, TEXT_COLOR.1)?;
+                }
             }
+            refresh = RefreshKind::None;
             let cursor_pos = {
                 let x = self.file_pos.col - self.viewport_pos.col;
                 let y = self.file_pos.line - self.viewport_pos.line;
@@ -329,8 +386,7 @@ impl Editor {
                                 console.show_cursor()?;
                             }
                         } else {
-                            // TODO(jmmv): Refresh only the affected line.
-                            need_refresh = true;
+                            refresh.upgrade(RefreshKind::CurrentLine);
                         }
                         for _ in 0..nremove {
                             line.remove(self.file_pos.col - 1);
@@ -343,7 +399,7 @@ impl Editor {
                         self.file_pos.col = self.content[self.file_pos.line - 1].len();
                         self.join_next_line_into(self.file_pos.line - 1);
                         self.file_pos.line -= 1;
-                        need_refresh = true;
+                        refresh.upgrade(RefreshKind::Full);
                     }
                     self.insert_col = self.file_pos.col;
                 }
@@ -354,7 +410,7 @@ impl Editor {
                         line.remove(self.file_pos.col);
                         self.dirty = true;
                         if self.file_pos.col < line.len() {
-                            need_refresh = true;
+                            refresh.upgrade(RefreshKind::Full);
                         } else {
                             console.hide_cursor()?;
                             console.clear(ClearType::UntilNewLine)?;
@@ -362,7 +418,7 @@ impl Editor {
                         }
                     } else if self.file_pos.line + 1 < self.content.len() {
                         self.join_next_line_into(self.file_pos.line);
-                        need_refresh = true;
+                        refresh.upgrade(RefreshKind::Full);
                     }
                 }
 
@@ -371,15 +427,14 @@ impl Editor {
 
                     let line = &mut self.content[self.file_pos.line];
                     if self.file_pos.col < line.len() {
-                        // TODO(jmmv): Refresh only the affected line.
-                        need_refresh = true;
+                        refresh.upgrade(RefreshKind::CurrentLine);
                     }
 
                     line.insert(self.file_pos.col, ch);
                     self.file_pos.col += 1;
                     self.insert_col = self.file_pos.col;
 
-                    if cursor_pos.x < console_size.x - 1 && !need_refresh {
+                    if cursor_pos.x < console_size.x - 1 && refresh == RefreshKind::None {
                         console.write(ch.encode_utf8(&mut buf))?;
                     }
 
@@ -413,7 +468,9 @@ impl Editor {
                         self.file_pos.line + 1,
                         LineBuffer::from(indent + &new.into_inner()),
                     );
-                    need_refresh = !appending;
+                    if !appending {
+                        refresh.upgrade(RefreshKind::Full);
+                    }
 
                     self.file_pos.col = indent_len;
                     self.file_pos.line += 1;
@@ -428,8 +485,7 @@ impl Editor {
                 Key::Tab => {
                     let line = &mut self.content[self.file_pos.line];
                     if self.file_pos.col < line.len() {
-                        // TODO(jmmv): Refresh only the affected line.
-                        need_refresh = true;
+                        refresh.upgrade(RefreshKind::CurrentLine);
                     }
 
                     let new_pos = (self.file_pos.col + INDENT_WIDTH) / INDENT_WIDTH * INDENT_WIDTH;
@@ -440,7 +496,7 @@ impl Editor {
                     line.insert_str(self.file_pos.col, &new_text);
                     self.file_pos.col = new_pos;
                     self.insert_col = self.file_pos.col;
-                    if !need_refresh {
+                    if refresh == RefreshKind::None {
                         console.write(&new_text)?;
                     }
                     self.dirty = true;
@@ -582,6 +638,22 @@ mod tests {
             self.output.push(CapturedOut::HideCursor);
             self = self.refresh_status(file_pos);
             self.output.push(CapturedOut::SetColor(TEXT_COLOR.0, TEXT_COLOR.1));
+            self.output.push(CapturedOut::Locate(cursor));
+            self.output.push(CapturedOut::ShowCursor);
+            self.output.push(CapturedOut::SyncNow);
+            self
+        }
+
+        /// Records the console changes needed to refresh only the current line and the status bar.
+        fn refresh_line(mut self, file_pos: FilePos, line: &str, cursor: CharsXY) -> Self {
+            self.output.push(CapturedOut::HideCursor);
+            self = self.refresh_status(file_pos);
+            self.output.push(CapturedOut::SetColor(TEXT_COLOR.0, TEXT_COLOR.1));
+            self.output.push(CapturedOut::Locate(yx(cursor.y, 0)));
+            self.output.push(CapturedOut::Clear(ClearType::CurrentLine));
+            if !line.is_empty() {
+                self.output.push(CapturedOut::Write(line.to_string()));
+            }
             self.output.push(CapturedOut::Locate(cursor));
             self.output.push(CapturedOut::ShowCursor);
             self.output.push(CapturedOut::SyncNow);
@@ -738,16 +810,16 @@ mod tests {
 
         cb.add_input_chars("a");
         ob = ob.set_dirty();
-        ob = ob.refresh(linecol(0, 1), &["aprevious content"], yx(0, 1));
+        ob = ob.refresh_line(linecol(0, 1), "aprevious content", yx(0, 1));
 
         cb.add_input_chars("b");
-        ob = ob.refresh(linecol(0, 2), &["abprevious content"], yx(0, 2));
+        ob = ob.refresh_line(linecol(0, 2), "abprevious content", yx(0, 2));
 
         cb.add_input_chars("c");
-        ob = ob.refresh(linecol(0, 3), &["abcprevious content"], yx(0, 3));
+        ob = ob.refresh_line(linecol(0, 3), "abcprevious content", yx(0, 3));
 
         cb.add_input_chars(" ");
-        ob = ob.refresh(linecol(0, 4), &["abc previous content"], yx(0, 4));
+        ob = ob.refresh_line(linecol(0, 4), "abc previous content", yx(0, 4));
 
         run_editor("previous content", "abc previous content\n", cb, ob);
     }
@@ -772,7 +844,7 @@ mod tests {
         ob = ob.quick_refresh(linecol(0, 2), yx(0, 2));
 
         cb.add_input_chars("d");
-        ob = ob.refresh(linecol(0, 3), &["abdc"], yx(0, 3));
+        ob = ob.refresh_line(linecol(0, 3), "abdc", yx(0, 3));
 
         run_editor("", "abdc\n", cb, ob);
     }
@@ -903,13 +975,13 @@ mod tests {
 
         cb.add_input_chars(".");
         ob = ob.set_dirty();
-        ob = ob.refresh(linecol(0, 1), &[".text"], yx(0, 1));
+        ob = ob.refresh_line(linecol(0, 1), ".text", yx(0, 1));
 
         cb.add_input_keys(&[Key::Home]);
         ob = ob.quick_refresh(linecol(0, 0), yx(0, 0));
 
         cb.add_input_chars(",");
-        ob = ob.refresh(linecol(0, 1), &[",.text"], yx(0, 1));
+        ob = ob.refresh_line(linecol(0, 1), ",.text", yx(0, 1));
 
         run_editor("text", ",.text\n", cb, ob);
     }
@@ -941,7 +1013,7 @@ mod tests {
 
         cb.add_input_chars(".");
         ob = ob.set_dirty();
-        ob = ob.refresh(linecol(0, 3), &["  .text"], yx(0, 3));
+        ob = ob.refresh_line(linecol(0, 3), "  .text", yx(0, 3));
 
         run_editor("  text", "  .text\n", cb, ob);
     }
@@ -1025,10 +1097,10 @@ mod tests {
 
         cb.add_input_keys(&[Key::Tab]);
         ob = ob.set_dirty();
-        ob = ob.refresh(linecol(0, 4), &["    ."], yx(0, 4));
+        ob = ob.refresh_line(linecol(0, 4), "    .", yx(0, 4));
 
         cb.add_input_keys(&[Key::Tab]);
-        ob = ob.refresh(linecol(0, 8), &["        ."], yx(0, 8));
+        ob = ob.refresh_line(linecol(0, 8), "        .", yx(0, 8));
 
         run_editor(".", "        .\n", cb, ob);
     }
@@ -1089,13 +1161,13 @@ mod tests {
 
         cb.add_input_keys(&[Key::Backspace]);
         ob = ob.set_dirty();
-        ob = ob.refresh(linecol(0, 8), &["        aligned"], yx(0, 8));
+        ob = ob.refresh_line(linecol(0, 8), "        aligned", yx(0, 8));
 
         cb.add_input_keys(&[Key::Backspace]);
-        ob = ob.refresh(linecol(0, 4), &["    aligned"], yx(0, 4));
+        ob = ob.refresh_line(linecol(0, 4), "    aligned", yx(0, 4));
 
         cb.add_input_keys(&[Key::Backspace]);
-        ob = ob.refresh(linecol(0, 0), &["aligned"], yx(0, 0));
+        ob = ob.refresh_line(linecol(0, 0), "aligned", yx(0, 0));
 
         cb.add_input_keys(&[Key::Backspace]);
         ob = ob.quick_refresh(linecol(0, 0), yx(0, 0));
@@ -1226,7 +1298,7 @@ mod tests {
 
         cb.add_input_keys(&[Key::Char('X')]);
         ob = ob.set_dirty();
-        ob = ob.refresh(linecol(2, 5), &["longer", "a", "longXer", "b"], yx(2, 5));
+        ob = ob.refresh_line(linecol(2, 5), "longXer", yx(2, 5));
 
         cb.add_input_keys(&[Key::ArrowDown]);
         ob = ob.quick_refresh(linecol(3, 1), yx(3, 1));
@@ -1503,37 +1575,17 @@ mod tests {
             ob = ob.quick_refresh(linecol(1, *file_col), yx(1, *cursor_col));
         }
         cb.add_input_keys(&[Key::Char('D')]);
-        ob = ob.refresh(
-            linecol(1, 40),
-            &["", "456789012345678901234567890123456789DABC", ""],
-            yx(1, 37),
-        );
+        ob = ob.refresh_line(linecol(1, 40), "456789012345678901234567890123456789DABC", yx(1, 37));
         cb.add_input_keys(&[Key::Char('E')]);
-        ob = ob.refresh(
-            linecol(1, 41),
-            &["", "456789012345678901234567890123456789DEAB", ""],
-            yx(1, 38),
-        );
+        ob = ob.refresh_line(linecol(1, 41), "456789012345678901234567890123456789DEAB", yx(1, 38));
 
         // Delete a few characters to restore the overflow part of the insertion line.
         cb.add_input_keys(&[Key::Backspace]);
-        ob = ob.refresh(
-            linecol(1, 40),
-            &["", "456789012345678901234567890123456789DABC", ""],
-            yx(1, 37),
-        );
+        ob = ob.refresh_line(linecol(1, 40), "456789012345678901234567890123456789DABC", yx(1, 37));
         cb.add_input_keys(&[Key::Backspace]);
-        ob = ob.refresh(
-            linecol(1, 39),
-            &["", "456789012345678901234567890123456789ABC", ""],
-            yx(1, 36),
-        );
+        ob = ob.refresh_line(linecol(1, 39), "456789012345678901234567890123456789ABC", yx(1, 36));
         cb.add_input_keys(&[Key::Backspace]);
-        ob = ob.refresh(
-            linecol(1, 38),
-            &["", "45678901234567890123456789012345678ABC", ""],
-            yx(1, 35),
-        );
+        ob = ob.refresh_line(linecol(1, 38), "45678901234567890123456789012345678ABC", yx(1, 35));
 
         // Move back to the beginning of the line to see surrounding lines reappear.
         for col in 0u16..35u16 {

--- a/repl/src/editor.rs
+++ b/repl/src/editor.rs
@@ -281,7 +281,7 @@ impl Editor {
             console.sync_now()?;
 
             match console.read_key().await? {
-                Key::Escape | Key::Eof | Key::Interrupt => break,
+                Key::Escape | Key::Interrupt => break,
 
                 Key::ArrowUp => self.move_up(1),
 
@@ -348,7 +348,7 @@ impl Editor {
                     self.insert_col = self.file_pos.col;
                 }
 
-                Key::Delete => {
+                Key::Delete | Key::EofOrDelete => {
                     if self.file_pos.col < self.content[self.file_pos.line].len() {
                         let line = &mut self.content[self.file_pos.line];
                         line.remove(self.file_pos.col);
@@ -653,10 +653,11 @@ mod tests {
 
         let mut console = MockConsole::default();
         console.set_size_chars(yx(10, 40));
+        console.add_input_keys(&[Key::Escape]);
         block_on(editor.edit(&mut console)).unwrap();
         assert!(!editor.is_dirty());
 
-        console.add_input_keys(&[Key::Char('x')]);
+        console.add_input_keys(&[Key::Char('x'), Key::Escape]);
         block_on(editor.edit(&mut console)).unwrap();
         assert!(editor.is_dirty());
 
@@ -668,7 +669,7 @@ mod tests {
         assert_eq!("different\n", editor.text());
         assert!(!editor.is_dirty());
 
-        console.add_input_keys(&[Key::Char('x')]);
+        console.add_input_keys(&[Key::Char('x'), Key::Escape]);
         block_on(editor.edit(&mut console)).unwrap();
         assert!(editor.is_dirty());
 
@@ -1102,8 +1103,7 @@ mod tests {
         run_editor("          aligned", "aligned\n", cb, ob);
     }
 
-    #[test]
-    fn test_delete_in_middle_of_line() {
+    fn do_delete_in_middle_of_line_test(key: Key) {
         let mut cb = MockConsole::default();
         cb.set_size_chars(yx(10, 40));
         let mut ob = OutputBuilder::new(yx(10, 40));
@@ -1114,11 +1114,21 @@ mod tests {
             ob = ob.quick_refresh(linecol(0, usize::from(i + 1)), yx(0, i + 1));
         }
 
-        cb.add_input_keys(&[Key::Delete]);
+        cb.add_input_keys(&[key]);
         ob = ob.set_dirty();
         ob = ob.refresh(linecol(0, 7), &["has a tpo"], yx(0, 7));
 
         run_editor("has a typo\n", "has a tpo\n", cb, ob);
+    }
+
+    #[test]
+    fn test_delete_in_middle_of_line() {
+        do_delete_in_middle_of_line_test(Key::Delete)
+    }
+
+    #[test]
+    fn test_ctrl_d_in_middle_of_line() {
+        do_delete_in_middle_of_line_test(Key::EofOrDelete)
     }
 
     #[test]
@@ -1143,8 +1153,7 @@ mod tests {
         run_editor("sample\n", "sampl\n", cb, ob);
     }
 
-    #[test]
-    fn test_delete_joins_with_next_line() {
+    fn do_delete_joins_with_next_line_test(key: Key) {
         let mut cb = MockConsole::default();
         cb.set_size_chars(yx(10, 40));
         let mut ob = OutputBuilder::new(yx(10, 40));
@@ -1155,11 +1164,21 @@ mod tests {
             ob = ob.quick_refresh(linecol(0, usize::from(i + 1)), yx(0, i + 1));
         }
 
-        cb.add_input_keys(&[Key::Delete]);
+        cb.add_input_keys(&[key]);
         ob = ob.set_dirty();
         ob = ob.refresh(linecol(0, 5), &["firstsecond"], yx(0, 5));
 
         run_editor("first\nsecond\n", "firstsecond\n", cb, ob);
+    }
+
+    #[test]
+    fn test_delete_joins_with_next_line() {
+        do_delete_joins_with_next_line_test(Key::Delete)
+    }
+
+    #[test]
+    fn test_ctrl_d_joins_with_next_line() {
+        do_delete_joins_with_next_line_test(Key::EofOrDelete)
     }
 
     #[test]

--- a/repl/src/editor.rs
+++ b/repl/src/editor.rs
@@ -111,6 +111,13 @@ impl Default for Editor {
 }
 
 impl Editor {
+    /// Appends the line at `line + 1` to the line at `line`.
+    fn join_next_line_into(&mut self, line: usize) {
+        let next = self.content.remove(line + 1);
+        self.content[line].push_str(&next);
+        self.dirty = true;
+    }
+
     /// Rewrites the status line at the bottom of the `console`, using the previously queried
     /// `console_size`.
     ///
@@ -333,15 +340,30 @@ impl Editor {
                             self.dirty = true;
                         }
                     } else if self.file_pos.line > 0 {
-                        let line = self.content.remove(self.file_pos.line);
-                        let prev = &mut self.content[self.file_pos.line - 1];
-                        self.file_pos.col = prev.len();
-                        prev.push_str(&line);
+                        self.file_pos.col = self.content[self.file_pos.line - 1].len();
+                        self.join_next_line_into(self.file_pos.line - 1);
                         self.file_pos.line -= 1;
                         need_refresh = true;
-                        self.dirty = true;
                     }
                     self.insert_col = self.file_pos.col;
+                }
+
+                Key::Delete => {
+                    if self.file_pos.col < self.content[self.file_pos.line].len() {
+                        let line = &mut self.content[self.file_pos.line];
+                        line.remove(self.file_pos.col);
+                        self.dirty = true;
+                        if self.file_pos.col < line.len() {
+                            need_refresh = true;
+                        } else {
+                            console.hide_cursor()?;
+                            console.clear(ClearType::UntilNewLine)?;
+                            console.show_cursor()?;
+                        }
+                    } else if self.file_pos.line + 1 < self.content.len() {
+                        self.join_next_line_into(self.file_pos.line);
+                        need_refresh = true;
+                    }
                 }
 
                 Key::Char(ch) => {
@@ -1078,6 +1100,84 @@ mod tests {
         ob = ob.quick_refresh(linecol(0, 0), yx(0, 0));
 
         run_editor("          aligned", "aligned\n", cb, ob);
+    }
+
+    #[test]
+    fn test_delete_in_middle_of_line() {
+        let mut cb = MockConsole::default();
+        cb.set_size_chars(yx(10, 40));
+        let mut ob = OutputBuilder::new(yx(10, 40));
+        ob = ob.refresh(linecol(0, 0), &["has a typo"], yx(0, 0));
+
+        for i in 0..7u16 {
+            cb.add_input_keys(&[Key::ArrowRight]);
+            ob = ob.quick_refresh(linecol(0, usize::from(i + 1)), yx(0, i + 1));
+        }
+
+        cb.add_input_keys(&[Key::Delete]);
+        ob = ob.set_dirty();
+        ob = ob.refresh(linecol(0, 7), &["has a tpo"], yx(0, 7));
+
+        run_editor("has a typo\n", "has a tpo\n", cb, ob);
+    }
+
+    #[test]
+    fn test_delete_last_character_of_line() {
+        let mut cb = MockConsole::default();
+        cb.set_size_chars(yx(10, 40));
+        let mut ob = OutputBuilder::new(yx(10, 40));
+        ob = ob.refresh(linecol(0, 0), &["sample"], yx(0, 0));
+
+        for i in 0..5u16 {
+            cb.add_input_keys(&[Key::ArrowRight]);
+            ob = ob.quick_refresh(linecol(0, usize::from(i + 1)), yx(0, i + 1));
+        }
+
+        cb.add_input_keys(&[Key::Delete]);
+        ob = ob.set_dirty();
+        ob = ob.add(CapturedOut::HideCursor);
+        ob = ob.add(CapturedOut::Clear(ClearType::UntilNewLine));
+        ob = ob.add(CapturedOut::ShowCursor);
+        ob = ob.quick_refresh(linecol(0, 5), yx(0, 5));
+
+        run_editor("sample\n", "sampl\n", cb, ob);
+    }
+
+    #[test]
+    fn test_delete_joins_with_next_line() {
+        let mut cb = MockConsole::default();
+        cb.set_size_chars(yx(10, 40));
+        let mut ob = OutputBuilder::new(yx(10, 40));
+        ob = ob.refresh(linecol(0, 0), &["first", "second"], yx(0, 0));
+
+        for i in 0..5u16 {
+            cb.add_input_keys(&[Key::ArrowRight]);
+            ob = ob.quick_refresh(linecol(0, usize::from(i + 1)), yx(0, i + 1));
+        }
+
+        cb.add_input_keys(&[Key::Delete]);
+        ob = ob.set_dirty();
+        ob = ob.refresh(linecol(0, 5), &["firstsecond"], yx(0, 5));
+
+        run_editor("first\nsecond\n", "firstsecond\n", cb, ob);
+    }
+
+    #[test]
+    fn test_delete_at_end_of_file_is_ignored() {
+        let mut cb = MockConsole::default();
+        cb.set_size_chars(yx(10, 40));
+        let mut ob = OutputBuilder::new(yx(10, 40));
+        ob = ob.refresh(linecol(0, 0), &["sample"], yx(0, 0));
+
+        for i in 0..6u16 {
+            cb.add_input_keys(&[Key::ArrowRight]);
+            ob = ob.quick_refresh(linecol(0, usize::from(i + 1)), yx(0, i + 1));
+        }
+
+        cb.add_input_keys(&[Key::Delete]);
+        ob = ob.quick_refresh(linecol(0, 6), yx(0, 6));
+
+        run_editor("sample\n", "sample\n", cb, ob);
     }
 
     #[test]

--- a/repl/src/lib.rs
+++ b/repl/src/lib.rs
@@ -467,7 +467,7 @@ mod tests {
             console.add_input_chars("PRINT");
             block_on(signals_tx.send(Signal::Break)).unwrap();
             console.add_input_chars(" 123");
-            console.add_input_keys(&[Key::NewLine, Key::Eof]);
+            console.add_input_keys(&[Key::NewLine, Key::EofOrDelete]);
         }
         block_on(run_repl_loop(&mut machine, console, program)).unwrap();
         tester.run("").expect_prints([" 123", "End of input by CTRL-D"]).check();
@@ -483,9 +483,9 @@ mod tests {
         {
             let mut console = console.borrow_mut();
             console.add_input_chars("INPUT a\n");
-            console.add_input_keys(&[Key::Eof]);
+            console.add_input_keys(&[Key::EofOrDelete]);
             console.add_input_chars("PRINT 3\n");
-            console.add_input_keys(&[Key::Eof]);
+            console.add_input_keys(&[Key::EofOrDelete]);
         }
         block_on(run_repl_loop(&mut machine, console, program)).unwrap();
         tester.run("").expect_prints(["ERROR: 1:1: EOF", " 3", "End of input by CTRL-D"]).check();

--- a/sdl/src/console.rs
+++ b/sdl/src/console.rs
@@ -702,7 +702,7 @@ mod tests {
         assert_poll_is_none(test.console());
 
         test.push_event(Event::Quit { timestamp: 0 });
-        assert_poll_is_key(test.console(), Key::Eof);
+        assert_poll_is_key(test.console(), Key::EofOrDelete);
         assert_poll_is_none(test.console());
 
         test.push_event(key_down(Keycode::C, Mod::LCTRLMOD));
@@ -741,7 +741,7 @@ mod tests {
         let mut test = SdlTest::new();
 
         test.push_event(Event::Quit { timestamp: 0 });
-        assert_eq!(Key::Eof, block_on(test.console().read_key()).unwrap());
+        assert_eq!(Key::EofOrDelete, block_on(test.console().read_key()).unwrap());
 
         test.push_event(key_down(Keycode::C, Mod::LCTRLMOD));
         assert_eq!(Key::Interrupt, block_on(test.console().read_key()).unwrap());
@@ -751,9 +751,9 @@ mod tests {
         assert_eq!(Signal::Break, test.wait_one_signal());
 
         test.push_event(key_down(Keycode::D, Mod::LCTRLMOD));
-        assert_eq!(Key::Eof, block_on(test.console().read_key()).unwrap());
+        assert_eq!(Key::EofOrDelete, block_on(test.console().read_key()).unwrap());
         test.push_event(key_down(Keycode::D, Mod::RCTRLMOD));
-        assert_eq!(Key::Eof, block_on(test.console().read_key()).unwrap());
+        assert_eq!(Key::EofOrDelete, block_on(test.console().read_key()).unwrap());
 
         test.push_event(key_down(Keycode::D, Mod::empty()));
         test.push_event(key_down(Keycode::Up, Mod::empty()));

--- a/sdl/src/host.rs
+++ b/sdl/src/host.rs
@@ -145,14 +145,14 @@ fn parse_event(event: Event) -> Option<Key> {
             // For now, we recognize it here so that closing the window causes the interpreter to
             // exit... but that only works when the interpreter is waiting for input (which means
             // that this also confuses INKEY).
-            Some(Key::Eof)
+            Some(Key::EofOrDelete)
         }
 
         Event::KeyDown { keycode: Some(keycode), keymod, .. } => match keycode {
             Keycode::A if keymod.intersects(ctrl_mods) => Some(Key::Home),
             Keycode::B if keymod.intersects(ctrl_mods) => Some(Key::ArrowLeft),
             Keycode::C if keymod.intersects(ctrl_mods) => Some(Key::Interrupt),
-            Keycode::D if keymod.intersects(ctrl_mods) => Some(Key::Eof),
+            Keycode::D if keymod.intersects(ctrl_mods) => Some(Key::EofOrDelete),
             Keycode::E if keymod.intersects(ctrl_mods) => Some(Key::End),
             Keycode::F if keymod.intersects(ctrl_mods) => Some(Key::ArrowRight),
             Keycode::J if keymod.intersects(ctrl_mods) => Some(Key::NewLine),
@@ -839,7 +839,10 @@ mod tests {
             Some(Key::Interrupt),
             parse_event(key_down(Keycode::C, Mod::LCTRLMOD | Mod::NUMMOD))
         );
-        assert_eq!(Some(Key::Eof), parse_event(key_down(Keycode::D, Mod::RCTRLMOD | Mod::CAPSMOD)));
+        assert_eq!(
+            Some(Key::EofOrDelete),
+            parse_event(key_down(Keycode::D, Mod::RCTRLMOD | Mod::CAPSMOD))
+        );
         assert_eq!(Some(Key::Delete), parse_event(key_down(Keycode::Delete, Mod::NOMOD)));
     }
 

--- a/sdl/src/host.rs
+++ b/sdl/src/host.rs
@@ -161,6 +161,7 @@ fn parse_event(event: Event) -> Option<Key> {
             Keycode::P if keymod.intersects(ctrl_mods) => Some(Key::ArrowUp),
 
             Keycode::Backspace => Some(Key::Backspace),
+            Keycode::Delete => Some(Key::Delete),
             Keycode::End => Some(Key::End),
             Keycode::Escape => Some(Key::Escape),
             Keycode::Home => Some(Key::Home),
@@ -839,6 +840,7 @@ mod tests {
             parse_event(key_down(Keycode::C, Mod::LCTRLMOD | Mod::NUMMOD))
         );
         assert_eq!(Some(Key::Eof), parse_event(key_down(Keycode::D, Mod::RCTRLMOD | Mod::CAPSMOD)));
+        assert_eq!(Some(Key::Delete), parse_event(key_down(Keycode::Delete, Mod::NOMOD)));
     }
 
     #[test]

--- a/st7735s/src/lib.rs
+++ b/st7735s/src/lib.rs
@@ -116,7 +116,7 @@ impl<K: InputOps> InputOps for ST7735SInput<K> {
         match self.on_button_rx.try_recv() {
             Ok(k) => Ok(Some(k)),
             Err(TryRecvError::Empty) => self.keyboard.poll_key().await,
-            Err(TryRecvError::Closed) => Ok(Some(Key::Eof)),
+            Err(TryRecvError::Closed) => Ok(Some(Key::EofOrDelete)),
         }
     }
 
@@ -125,7 +125,7 @@ impl<K: InputOps> InputOps for ST7735SInput<K> {
             result = self.on_button_rx.recv() => {
                 match result {
                     Ok(k) => Ok(k),
-                    Err(_) => Ok(Key::Eof),
+                    Err(_) => Ok(Key::EofOrDelete),
                 }
             }
             result = self.keyboard.read_key() => result,

--- a/std/src/console/cmds.rs
+++ b/std/src/console/cmds.rs
@@ -254,6 +254,7 @@ impl Callable for InKeyFunction {
             Some(Key::Backspace) => "BS".to_owned(),
             Some(Key::CarriageReturn) => "ENTER".to_owned(),
             Some(Key::Char(x)) => format!("{}", x),
+            Some(Key::Delete) => "DEL".to_owned(),
             Some(Key::End) => "END".to_owned(),
             Some(Key::Eof) => "EOF".to_owned(),
             Some(Key::Escape) => "ESC".to_owned(),

--- a/std/src/console/cmds.rs
+++ b/std/src/console/cmds.rs
@@ -256,7 +256,7 @@ impl Callable for InKeyFunction {
             Some(Key::Char(x)) => format!("{}", x),
             Some(Key::Delete) => "DEL".to_owned(),
             Some(Key::End) => "END".to_owned(),
-            Some(Key::Eof) => "EOF".to_owned(),
+            Some(Key::EofOrDelete) => "EOF".to_owned(),
             Some(Key::Escape) => "ESC".to_owned(),
             Some(Key::Home) => "HOME".to_owned(),
             Some(Key::Interrupt) => "INT".to_owned(),
@@ -931,7 +931,11 @@ mod tests {
 
     #[test]
     fn test_input_propagates_eof_as_error() {
-        Tester::default().add_input_keys(&[Key::Eof]).run("INPUT a").expect_err("1:1: EOF").check();
+        Tester::default()
+            .add_input_keys(&[Key::EofOrDelete])
+            .run("INPUT a")
+            .expect_err("1:1: EOF")
+            .check();
     }
 
     #[test]

--- a/std/src/console/mod.rs
+++ b/std/src/console/mod.rs
@@ -70,6 +70,9 @@ pub enum Key {
     /// A printable character.
     Char(char),
 
+    /// Deletes the current character.
+    Delete,
+
     /// The end key or `Ctrl-E`.
     End,
 

--- a/std/src/console/mod.rs
+++ b/std/src/console/mod.rs
@@ -76,14 +76,16 @@ pub enum Key {
     /// The end key or `Ctrl-E`.
     End,
 
-    /// Indicates a request for termination (e.g. `Ctrl-D`).
-    Eof,
+    /// Indicates `Ctrl-D` in interactive consoles, or an end-of-input condition in raw ones.
+    ///
+    /// Consumers may interpret this as EOF or as delete depending on context.
+    EofOrDelete,
 
     /// The escape key.
     Escape,
 
     /// Indicates a request for interrupt (e.g. `Ctrl-C`).
-    // TODO(jmmv): This (and maybe Eof too) should probably be represented as a more generic
+    // TODO(jmmv): This (and maybe EofOrDelete too) should probably be represented as a more
     // Control(char) value so that we can represent other control sequences and allow the logic in
     // here to determine what to do with each.
     Interrupt,
@@ -461,13 +463,13 @@ pub fn read_key_from_stdin(buffer: &mut VecDeque<Key>) -> io::Result<Key> {
     if buffer.is_empty() {
         let mut line = String::new();
         if io::stdin().read_line(&mut line)? == 0 {
-            return Ok(Key::Eof);
+            return Ok(Key::EofOrDelete);
         }
         *buffer = line_to_keys(line);
     }
     match buffer.pop_front() {
         Some(key) => Ok(key),
-        None => Ok(Key::Eof),
+        None => Ok(Key::EofOrDelete),
     }
 }
 

--- a/std/src/console/readline.rs
+++ b/std/src/console/readline.rs
@@ -22,6 +22,35 @@ use std::io;
 /// Character to print when typing a secure string.
 const SECURE_CHAR: &str = "*";
 
+/// Erases the character at `remove_pos` and redraws the remainder of the line.
+fn erase_at(
+    console: &mut dyn Console,
+    cursor_pos: usize,
+    remove_pos: usize,
+    line: &mut LineBuffer,
+    echo: bool,
+) -> io::Result<()> {
+    debug_assert!(remove_pos < line.len());
+    debug_assert!(remove_pos <= cursor_pos);
+
+    console.hide_cursor()?;
+    let delta = cursor_pos - remove_pos;
+    if delta > 0 {
+        console.move_within_line(-(delta as i16))?;
+    }
+    let tail_len = line.len() - remove_pos - 1;
+    if echo {
+        console.write(&line.end(remove_pos + 1))?;
+    } else {
+        console.write(&SECURE_CHAR.repeat(tail_len))?;
+    }
+    console.write(" ")?;
+    console.move_within_line(-((tail_len + 1) as i16))?;
+    console.show_cursor()?;
+    line.remove(remove_pos);
+    Ok(())
+}
+
 /// Refreshes the current input line to display `line` assuming that the cursor is currently
 /// offset by `pos` characters from the beginning of the input and that the previous line was
 /// `clear_len` characters long.
@@ -155,18 +184,14 @@ async fn read_line_interactive(
 
             Key::Backspace => {
                 if pos > 0 {
-                    console.hide_cursor()?;
-                    console.move_within_line(-1)?;
-                    if echo {
-                        console.write(&line.end(pos))?;
-                    } else {
-                        console.write(&SECURE_CHAR.repeat(line.len() - pos))?;
-                    }
-                    console.write(" ")?;
-                    console.move_within_line(-((line.len() - pos) as i16 + 1))?;
-                    console.show_cursor()?;
-                    line.remove(pos - 1);
+                    erase_at(console, pos, pos - 1, &mut line, echo)?;
                     pos -= 1;
+                }
+            }
+
+            Key::Delete => {
+                if pos < line.len() {
+                    erase_at(console, pos, pos, &mut line, echo)?;
                 }
             }
 
@@ -287,6 +312,7 @@ async fn read_line_raw(console: &mut dyn Console) -> io::Result<String> {
                 }
             }
             Key::Char(ch) => line.push(ch),
+            Key::Delete => (),
             Key::End | Key::Home => (),
             Key::Escape => (),
             Key::Eof => return Err(io::Error::new(io::ErrorKind::UnexpectedEof, "EOF")),
@@ -474,6 +500,7 @@ mod tests {
     fn test_read_line_interactive_empty() {
         ReadLineInteractiveTest::default().accept();
         ReadLineInteractiveTest::default().add_key(Key::Backspace).accept();
+        ReadLineInteractiveTest::default().add_key(Key::Delete).accept();
         ReadLineInteractiveTest::default().add_key(Key::ArrowLeft).accept();
         ReadLineInteractiveTest::default().add_key(Key::ArrowRight).accept();
     }
@@ -741,6 +768,70 @@ mod tests {
             .add_output(CapturedOut::ShowCursor)
             // -
             .set_line("has a typo")
+            .accept();
+    }
+
+    #[test]
+    fn test_read_line_interactive_middle_delete() {
+        ReadLineInteractiveTest::default()
+            .add_key_chars("has a typo")
+            .add_output_bytes("has a typo")
+            // -
+            .add_key(Key::ArrowLeft)
+            .add_output(CapturedOut::MoveWithinLine(-1))
+            // -
+            .add_key(Key::ArrowLeft)
+            .add_output(CapturedOut::MoveWithinLine(-1))
+            // -
+            .add_key(Key::Delete)
+            .add_output(CapturedOut::HideCursor)
+            .add_output(CapturedOut::Write("o".to_string()))
+            .add_output_bytes(" ")
+            .add_output(CapturedOut::MoveWithinLine(-2))
+            .add_output(CapturedOut::ShowCursor)
+            // -
+            .add_key_chars("e")
+            .add_output(CapturedOut::HideCursor)
+            .add_output_bytes("e")
+            .add_output(CapturedOut::Write("o".to_string()))
+            .add_output(CapturedOut::MoveWithinLine(-1))
+            .add_output(CapturedOut::ShowCursor)
+            // -
+            .set_line("has a tyeo")
+            .accept();
+    }
+
+    #[test]
+    fn test_read_line_interactive_utf8_delete_2byte_char() {
+        ReadLineInteractiveTest::default()
+            .add_key_chars("àé")
+            .add_output(CapturedOut::Write("à".to_string()))
+            .add_output(CapturedOut::Write("é".to_string()))
+            // -
+            .add_key(Key::ArrowLeft)
+            .add_output(CapturedOut::MoveWithinLine(-1))
+            // -
+            .add_key(Key::Delete)
+            .add_output(CapturedOut::HideCursor)
+            .add_output_bytes("")
+            .add_output_bytes(" ")
+            .add_output(CapturedOut::MoveWithinLine(-1))
+            .add_output(CapturedOut::ShowCursor)
+            // -
+            .set_line("à")
+            .accept();
+    }
+
+    #[test]
+    fn test_read_line_interactive_delete_at_end_is_ignored() {
+        ReadLineInteractiveTest::default()
+            .set_previous("sample")
+            .add_output(CapturedOut::Write("sample".to_string()))
+            .add_output(CapturedOut::SyncNow)
+            // -
+            .add_key(Key::Delete)
+            // -
+            .set_line("sample")
             .accept();
     }
 
@@ -1155,6 +1246,29 @@ mod tests {
             .add_output(CapturedOut::ShowCursor)
             // -
             .set_line("pass123756")
+            .accept();
+
+        ReadLineInteractiveTest::default()
+            .set_echo(false)
+            .set_prompt("> ")
+            .set_previous("pass1234")
+            .add_output(CapturedOut::Write("> ********".to_string()))
+            .add_output(CapturedOut::SyncNow)
+            // -
+            .add_key(Key::ArrowLeft)
+            .add_output(CapturedOut::MoveWithinLine(-1))
+            // -
+            .add_key(Key::ArrowLeft)
+            .add_output(CapturedOut::MoveWithinLine(-1))
+            // -
+            .add_key(Key::Delete)
+            .add_output(CapturedOut::HideCursor)
+            .add_output(CapturedOut::Write("*".to_string()))
+            .add_output_bytes(" ")
+            .add_output(CapturedOut::MoveWithinLine(-2))
+            .add_output(CapturedOut::ShowCursor)
+            // -
+            .set_line("pass124")
             .accept();
     }
 

--- a/std/src/console/readline.rs
+++ b/std/src/console/readline.rs
@@ -195,6 +195,12 @@ async fn read_line_interactive(
                 }
             }
 
+            Key::EofOrDelete if !line.is_empty() => {
+                if pos < line.len() {
+                    erase_at(console, pos, pos, &mut line, echo)?;
+                }
+            }
+
             Key::CarriageReturn => {
                 // TODO(jmmv): This is here because the integration tests may be checked out with
                 // CRLF line endings on Windows, which means we'd see two characters to end a line
@@ -247,7 +253,7 @@ async fn read_line_interactive(
                 }
             }
 
-            Key::Eof => return Err(io::Error::new(io::ErrorKind::UnexpectedEof, "EOF")),
+            Key::EofOrDelete => return Err(io::Error::new(io::ErrorKind::UnexpectedEof, "EOF")),
 
             Key::Escape => {
                 // Intentionally ignored.
@@ -315,7 +321,7 @@ async fn read_line_raw(console: &mut dyn Console) -> io::Result<String> {
             Key::Delete => (),
             Key::End | Key::Home => (),
             Key::Escape => (),
-            Key::Eof => return Err(io::Error::new(io::ErrorKind::UnexpectedEof, "EOF")),
+            Key::EofOrDelete => return Err(io::Error::new(io::ErrorKind::UnexpectedEof, "EOF")),
             Key::Interrupt => return Err(io::Error::new(io::ErrorKind::Interrupted, "Ctrl+C")),
             Key::NewLine => break,
             Key::PageDown | Key::PageUp => (),
@@ -472,25 +478,33 @@ mod tests {
             let mut console = MockConsole::default();
             console.add_input_keys(&self.keys);
             console.set_size_chars(self.size_chars);
-            let line = match self.history.as_mut() {
-                Some(history) => block_on(read_line_interactive(
-                    &mut console,
-                    self.prompt,
-                    self.previous,
-                    Some(history),
-                    self.echo,
-                ))
-                .unwrap(),
-                None => block_on(read_line_interactive(
-                    &mut console,
-                    self.prompt,
-                    self.previous,
-                    None,
-                    self.echo,
-                ))
-                .unwrap(),
-            };
+            let line = block_on(read_line_interactive(
+                &mut console,
+                self.prompt,
+                self.previous,
+                self.history.as_mut(),
+                self.echo,
+            ))
+            .unwrap();
             assert_eq!(self.exp_line, &line);
+            assert_eq!(self.exp_output.as_slice(), console.captured_out());
+            assert_eq!(self.exp_history, self.history);
+        }
+
+        /// Executes the test and expects the given error kind.
+        fn expect_err(mut self, exp_kind: io::ErrorKind) {
+            let mut console = MockConsole::default();
+            console.add_input_keys(&self.keys);
+            console.set_size_chars(self.size_chars);
+            let err = block_on(read_line_interactive(
+                &mut console,
+                self.prompt,
+                self.previous,
+                self.history.as_mut(),
+                self.echo,
+            ))
+            .expect_err("read_line_interactive should fail");
+            assert_eq!(exp_kind, err.kind());
             assert_eq!(self.exp_output.as_slice(), console.captured_out());
             assert_eq!(self.exp_history, self.history);
         }
@@ -501,6 +515,9 @@ mod tests {
         ReadLineInteractiveTest::default().accept();
         ReadLineInteractiveTest::default().add_key(Key::Backspace).accept();
         ReadLineInteractiveTest::default().add_key(Key::Delete).accept();
+        ReadLineInteractiveTest::default()
+            .add_key(Key::EofOrDelete)
+            .expect_err(io::ErrorKind::UnexpectedEof);
         ReadLineInteractiveTest::default().add_key(Key::ArrowLeft).accept();
         ReadLineInteractiveTest::default().add_key(Key::ArrowRight).accept();
     }
@@ -802,6 +819,36 @@ mod tests {
     }
 
     #[test]
+    fn test_read_line_interactive_middle_ctrl_d_deletes() {
+        ReadLineInteractiveTest::default()
+            .add_key_chars("has a typo")
+            .add_output_bytes("has a typo")
+            // -
+            .add_key(Key::ArrowLeft)
+            .add_output(CapturedOut::MoveWithinLine(-1))
+            // -
+            .add_key(Key::ArrowLeft)
+            .add_output(CapturedOut::MoveWithinLine(-1))
+            // -
+            .add_key(Key::EofOrDelete)
+            .add_output(CapturedOut::HideCursor)
+            .add_output(CapturedOut::Write("o".to_string()))
+            .add_output_bytes(" ")
+            .add_output(CapturedOut::MoveWithinLine(-2))
+            .add_output(CapturedOut::ShowCursor)
+            // -
+            .add_key_chars("e")
+            .add_output(CapturedOut::HideCursor)
+            .add_output_bytes("e")
+            .add_output(CapturedOut::Write("o".to_string()))
+            .add_output(CapturedOut::MoveWithinLine(-1))
+            .add_output(CapturedOut::ShowCursor)
+            // -
+            .set_line("has a tyeo")
+            .accept();
+    }
+
+    #[test]
     fn test_read_line_interactive_utf8_delete_2byte_char() {
         ReadLineInteractiveTest::default()
             .add_key_chars("àé")
@@ -830,6 +877,19 @@ mod tests {
             .add_output(CapturedOut::SyncNow)
             // -
             .add_key(Key::Delete)
+            // -
+            .set_line("sample")
+            .accept();
+    }
+
+    #[test]
+    fn test_read_line_interactive_ctrl_d_at_end_is_ignored() {
+        ReadLineInteractiveTest::default()
+            .set_previous("sample")
+            .add_output(CapturedOut::Write("sample".to_string()))
+            .add_output(CapturedOut::SyncNow)
+            // -
+            .add_key(Key::EofOrDelete)
             // -
             .set_line("sample")
             .accept();

--- a/std/src/testutils.rs
+++ b/std/src/testutils.rs
@@ -301,7 +301,7 @@ impl Console for MockConsole {
                 }
                 Ok(ch)
             }
-            None => Ok(Key::Eof),
+            None => Ok(Key::EofOrDelete),
         }
     }
 

--- a/terminal/src/lib.rs
+++ b/terminal/src/lib.rs
@@ -39,6 +39,7 @@ fn parse_key_event(ev: KeyEvent) -> Option<Key> {
 
     let key = match ev.code {
         KeyCode::Backspace => Key::Backspace,
+        KeyCode::Delete => Key::Delete,
         KeyCode::End => Key::End,
         KeyCode::Esc => Key::Escape,
         KeyCode::Home => Key::Home,
@@ -443,6 +444,14 @@ mod tests {
     use super::*;
     use futures_util::stream;
     use std::thread;
+
+    #[test]
+    fn test_parse_key_event_delete() {
+        assert_eq!(
+            Some(Key::Delete),
+            parse_key_event(KeyEvent::new(KeyCode::Delete, KeyModifiers::NONE))
+        );
+    }
 
     #[test]
     fn test_drive_raw_keys_eof_does_not_terminate_worker() {

--- a/terminal/src/lib.rs
+++ b/terminal/src/lib.rs
@@ -53,7 +53,7 @@ fn parse_key_event(ev: KeyEvent) -> Option<Key> {
         KeyCode::Char('a') if ev.modifiers == KeyModifiers::CONTROL => Key::Home,
         KeyCode::Char('b') if ev.modifiers == KeyModifiers::CONTROL => Key::ArrowLeft,
         KeyCode::Char('c') if ev.modifiers == KeyModifiers::CONTROL => Key::Interrupt,
-        KeyCode::Char('d') if ev.modifiers == KeyModifiers::CONTROL => Key::Eof,
+        KeyCode::Char('d') if ev.modifiers == KeyModifiers::CONTROL => Key::EofOrDelete,
         KeyCode::Char('e') if ev.modifiers == KeyModifiers::CONTROL => Key::End,
         KeyCode::Char('f') if ev.modifiers == KeyModifiers::CONTROL => Key::ArrowRight,
         KeyCode::Char('j') if ev.modifiers == KeyModifiers::CONTROL => Key::NewLine,
@@ -211,7 +211,7 @@ impl TerminalConsole {
                 }
             };
 
-            done = key == Key::Eof;
+            done = key == Key::EofOrDelete;
 
             // This should never fail but can if the receiver outruns the console because we don't
             // await for the handler to terminate (which we cannot do safely because `Drop` is not
@@ -236,14 +236,14 @@ impl InputOps for TerminalConsole {
         match self.on_key_rx.try_recv() {
             Ok(k) => Ok(Some(k)),
             Err(TryRecvError::Empty) => Ok(None),
-            Err(TryRecvError::Closed) => Ok(Some(Key::Eof)),
+            Err(TryRecvError::Closed) => Ok(Some(Key::EofOrDelete)),
         }
     }
 
     async fn read_key(&mut self) -> io::Result<Key> {
         match self.on_key_rx.recv().await {
             Ok(k) => Ok(k),
-            Err(_) => Ok(Key::Eof),
+            Err(_) => Ok(Key::EofOrDelete),
         }
     }
 }
@@ -454,7 +454,7 @@ mod tests {
     }
 
     #[test]
-    fn test_drive_raw_keys_eof_does_not_terminate_worker() {
+    fn test_drive_raw_keys_eof_or_delete_does_not_terminate_worker() {
         let (on_key_tx, on_key_rx) = async_channel::unbounded();
         let (signals_tx, _signals_rx) = async_channel::unbounded();
         let events = stream::iter([Ok(Event::Key(KeyEvent::new(
@@ -468,7 +468,7 @@ mod tests {
             runtime.block_on(TerminalConsole::raw_key_handler(events, on_key_tx, signals_tx));
         });
 
-        assert_eq!(Key::Eof, on_key_rx.recv_blocking().unwrap());
+        assert_eq!(Key::EofOrDelete, on_key_rx.recv_blocking().unwrap());
 
         on_key_rx.close();
         handle.join().unwrap();

--- a/web/src/input.rs
+++ b/web/src/input.rs
@@ -55,7 +55,7 @@ fn on_key_event_into_key(dom_event: KeyboardEvent) -> Key {
         b'A' if dom_event.ctrl_key() => Key::Home,
         b'B' if dom_event.ctrl_key() => Key::ArrowLeft,
         b'C' if dom_event.ctrl_key() => Key::Interrupt,
-        b'D' if dom_event.ctrl_key() => Key::Eof,
+        b'D' if dom_event.ctrl_key() => Key::EofOrDelete,
         b'E' if dom_event.ctrl_key() => Key::End,
         b'F' if dom_event.ctrl_key() => Key::ArrowRight,
         b'J' if dom_event.ctrl_key() => Key::NewLine,

--- a/web/src/input.rs
+++ b/web/src/input.rs
@@ -51,6 +51,7 @@ fn on_key_event_into_key(dom_event: KeyboardEvent) -> Key {
         38 => Key::ArrowUp,
         39 => Key::ArrowRight,
         40 => Key::ArrowDown,
+        46 => Key::Delete,
         b'A' if dom_event.ctrl_key() => Key::Home,
         b'B' if dom_event.ctrl_key() => Key::ArrowLeft,
         b'C' if dom_event.ctrl_key() => Key::Interrupt,


### PR DESCRIPTION
Various misc changes to the line editor and the full-screen editor to support the Delete key, fix surprising Ctrl+D behavior, and apply some long-overdue optimizations to the full-screen editor refresh cycle.