### PR TITLE
Fix release checks after d95b627a

### DIFF
--- a/.github/workflows/package.sh
+++ b/.github/workflows/package.sh
@@ -55,7 +55,7 @@ EOF
 
 # Package one crate at a time and add it to the local registry so that subsequent crates
 # can pick them up.
-for dir in core std repl client terminal sdl st7735s rpi cli; do
+for dir in core std client terminal sdl st7735s rpi repl cli; do
     cd "${dir}"
     cargo index add --index "${registry}/index" --index-url https://example.com
     cd -

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -37,7 +37,7 @@
 1.  Push the new crates out. This is the last step because it's not reversible:
 
     ```
-    for c in core std repl client terminal sdl st7735s rpi cli; do
+    for c in core std client terminal sdl st7735s rpi repl cli; do
         ( cd $c && cargo publish ) || break
     done
     ```


### PR DESCRIPTION
The repl crate depends on the sdl crate now (for testing purposes only) so make sure package.sh accounts for that.