### PR TITLE
Harden mobile text input

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -86,6 +86,8 @@ for the time being.**
 
 *   Issue #139: Added support for shebangs and property lines in scripts.
 
+*   Minor fixes to text input on Android.
+
 ## Changes in version 0.13.0
 
 **Released on 2026-05-29.**

--- a/web/src/index.html
+++ b/web/src/index.html
@@ -11,7 +11,8 @@
             EndBASIC terminal window.
         </canvas>
 
-        <input id="mobile-input" type="text" autocomplete="off" />
+        <input id="mobile-input" type="text" autocomplete="off" autocapitalize="off"
+            autocorrect="off" spellcheck="false" writingsuggestions="false" />
 
         <div id="controls">
             <button id="button-esc" type="button">Esc</button>

--- a/web/src/input.rs
+++ b/web/src/input.rs
@@ -27,12 +27,11 @@ use wasm_bindgen::prelude::*;
 use web_sys::{InputEvent, KeyboardEvent};
 
 /// Converts an HTML input event into our own `Key` representation.
-fn on_input_event_into_key(dom_event: InputEvent) -> Key {
-    let chars = match dom_event.data() {
-        Some(data) => data.chars().collect::<Vec<char>>(),
+fn on_input_event_into_keys(dom_event: InputEvent) -> Vec<Key> {
+    match dom_event.data() {
+        Some(data) => data.chars().map(Key::Char).collect(),
         None => vec![],
-    };
-    if chars.len() == 1 { Key::Char(chars[0]) } else { Key::Unknown }
+    }
 }
 
 /// Converts an HTML keyboard event into our own `Key` representation.
@@ -91,7 +90,9 @@ impl OnScreenKeyboard {
     /// Pushes a new captured `dom_event` input event into the input.
     pub fn inject_input_event(&self, dom_event: InputEvent) {
         // TODO(jmmv): Add an on-screen button to send CTRL+C events.
-        self.safe_try_send(on_input_event_into_key(dom_event))
+        for key in on_input_event_into_keys(dom_event) {
+            self.safe_try_send(key);
+        }
     }
 
     /// Pushes a new captured `dom_event` keyboard event into the input.


### PR DESCRIPTION
Disable browser writing assistance on the web console's hidden mobile input element and preserve multi-character IME commits instead of dropping them as unknown input.

This should fix some oddities I'm observing on Android, but... still doesn't make things "great".  It's good enough for now though.